### PR TITLE
feat(contract): add InvalidSignature error variant

### DIFF
--- a/contracts/account/src/lib.rs
+++ b/contracts/account/src/lib.rs
@@ -45,6 +45,8 @@ pub enum ContractError {
     InsufficientPermission = 7,
     /// Invalid version provided for migration
     InvalidVersion = 8,
+    /// Signature is missing or invalid
+    InvalidSignature = 9,
 }
 
 /// Event topic naming convention
@@ -205,8 +207,8 @@ impl AncoreAccount {
                 return Err(ContractError::InsufficientPermission);
             }
 
-            let sig = signature.ok_or(ContractError::Unauthorized)?;
-            let payload = signature_payload.ok_or(ContractError::Unauthorized)?;
+            let sig = signature.ok_or(ContractError::InvalidSignature)?;
+            let payload = signature_payload.ok_or(ContractError::InvalidSignature)?;
 
             // Verify signature using ed25519
             env.crypto().ed25519_verify(&session_pk, &payload, &sig);
@@ -1120,8 +1122,47 @@ mod test {
             &None, // signature_payload=None
         );
 
-        // Should fail with unauthorized session-key missing signature
-        assert!(result.is_err());
+        // Should fail with InvalidSignature because no signature was provided
+        assert!(matches!(result, Err(Ok(ContractError::InvalidSignature))));
+    }
+
+    #[test]
+    fn test_execute_session_key_missing_payload_returns_invalid_signature() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, AncoreAccount);
+        let client = AncoreAccountClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.initialize(&owner);
+        env.mock_all_auths();
+
+        let mut csprng = OsRng;
+        let signing_key = SigningKey::generate(&mut csprng);
+        let session_pk = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+
+        let expires_at = env.ledger().timestamp() + 10000;
+        let mut permissions = Vec::new(&env);
+        permissions.push_back(PERMISSION_EXECUTE);
+        client.add_session_key(&session_pk, &expires_at, &permissions);
+
+        let callee_id = env.register_contract(None, AncoreAccount);
+        let function = soroban_sdk::symbol_short!("get_nonce");
+        let args = Vec::new(&env);
+        let (sig, _payload) = sign_payload(&env, &signing_key, &callee_id, &function, &args, 0);
+
+        // Signature present but payload missing → InvalidSignature
+        let result = client.try_execute(
+            &CallerIdentity::SessionKey(session_pk.clone()),
+            &callee_id,
+            &function,
+            &args,
+            &0u64,
+            &Some(session_pk),
+            &Some(sig),
+            &None,
+        );
+
+        assert!(matches!(result, Err(Ok(ContractError::InvalidSignature))));
     }
 
     #[test]

--- a/contracts/account/test_snapshots/test/test_execute_cross_contract_invocation.1.json
+++ b/contracts/account/test_snapshots/test/test_execute_cross_contract_invocation.1.json
@@ -15,7 +15,7 @@
               "function_name": "add_session_key",
               "args": [
                 {
-                  "bytes": "3413fa06eaa2fa6544f36ada757b647fbdc9836ba342075c64f17b0c6f2e7e34"
+                  "bytes": "ba98dc5e098eb0d0608b358c2d15f7e390775249596ac27e7348f2bb9ece3e6c"
                 },
                 {
                   "u64": 10000
@@ -56,7 +56,7 @@
                   "symbol": "SessionKey"
                 },
                 {
-                  "bytes": "3413fa06eaa2fa6544f36ada757b647fbdc9836ba342075c64f17b0c6f2e7e34"
+                  "bytes": "ba98dc5e098eb0d0608b358c2d15f7e390775249596ac27e7348f2bb9ece3e6c"
                 }
               ]
             },
@@ -76,7 +76,7 @@
                       "symbol": "SessionKey"
                     },
                     {
-                      "bytes": "3413fa06eaa2fa6544f36ada757b647fbdc9836ba342075c64f17b0c6f2e7e34"
+                      "bytes": "ba98dc5e098eb0d0608b358c2d15f7e390775249596ac27e7348f2bb9ece3e6c"
                     }
                   ]
                 },
@@ -108,7 +108,7 @@
                         "symbol": "public_key"
                       },
                       "val": {
-                        "bytes": "3413fa06eaa2fa6544f36ada757b647fbdc9836ba342075c64f17b0c6f2e7e34"
+                        "bytes": "ba98dc5e098eb0d0608b358c2d15f7e390775249596ac27e7348f2bb9ece3e6c"
                       }
                     }
                   ]
@@ -366,7 +366,7 @@
             "data": {
               "vec": [
                 {
-                  "bytes": "3413fa06eaa2fa6544f36ada757b647fbdc9836ba342075c64f17b0c6f2e7e34"
+                  "bytes": "ba98dc5e098eb0d0608b358c2d15f7e390775249596ac27e7348f2bb9ece3e6c"
                 },
                 {
                   "u64": 10000
@@ -400,7 +400,7 @@
             "data": {
               "vec": [
                 {
-                  "bytes": "3413fa06eaa2fa6544f36ada757b647fbdc9836ba342075c64f17b0c6f2e7e34"
+                  "bytes": "ba98dc5e098eb0d0608b358c2d15f7e390775249596ac27e7348f2bb9ece3e6c"
                 },
                 {
                   "u64": 10000
@@ -459,7 +459,7 @@
                       "symbol": "SessionKey"
                     },
                     {
-                      "bytes": "3413fa06eaa2fa6544f36ada757b647fbdc9836ba342075c64f17b0c6f2e7e34"
+                      "bytes": "ba98dc5e098eb0d0608b358c2d15f7e390775249596ac27e7348f2bb9ece3e6c"
                     }
                   ]
                 },
@@ -476,10 +476,10 @@
                   "u64": 0
                 },
                 {
-                  "bytes": "3413fa06eaa2fa6544f36ada757b647fbdc9836ba342075c64f17b0c6f2e7e34"
+                  "bytes": "ba98dc5e098eb0d0608b358c2d15f7e390775249596ac27e7348f2bb9ece3e6c"
                 },
                 {
-                  "bytes": "374502b561f277619da6ed821f1c34ef9e929d4e3f6727bb4318b99e8637bb168cec498361ef80dd735a3bd0606331ce5da30e3ef498f21d3d214c8b66a1d50b"
+                  "bytes": "d481248413aa08f78a89bcbb2fbad0986e599c0c99a95521f1f41e11aed8888e6dec126bbf3288c8dcc7ef10e0854df3e35c7df35dbac0df39185fd48197aa00"
                 },
                 {
                   "bytes": "000000120000000100000000000000000000000000000000000000000000000000000000000000030000000f000000096765745f6e6f6e6365000000000000100000000100000000000000050000000000000000"

--- a/contracts/account/test_snapshots/test/test_execute_session_key_expired.1.json
+++ b/contracts/account/test_snapshots/test/test_execute_session_key_expired.1.json
@@ -15,7 +15,7 @@
               "function_name": "add_session_key",
               "args": [
                 {
-                  "bytes": "d71b38e738107a9e0bddc5ec86f87aa0d20fee5b48a2849cfebc949fc4d7ed0e"
+                  "bytes": "38072d78d3e3cdb2d01d7ed692d248c563fd9205e4dc8b5191cfb13711d8df9d"
                 },
                 {
                   "u64": 1000
@@ -59,7 +59,7 @@
                   "symbol": "SessionKey"
                 },
                 {
-                  "bytes": "d71b38e738107a9e0bddc5ec86f87aa0d20fee5b48a2849cfebc949fc4d7ed0e"
+                  "bytes": "38072d78d3e3cdb2d01d7ed692d248c563fd9205e4dc8b5191cfb13711d8df9d"
                 }
               ]
             },
@@ -79,7 +79,7 @@
                       "symbol": "SessionKey"
                     },
                     {
-                      "bytes": "d71b38e738107a9e0bddc5ec86f87aa0d20fee5b48a2849cfebc949fc4d7ed0e"
+                      "bytes": "38072d78d3e3cdb2d01d7ed692d248c563fd9205e4dc8b5191cfb13711d8df9d"
                     }
                   ]
                 },
@@ -114,7 +114,7 @@
                         "symbol": "public_key"
                       },
                       "val": {
-                        "bytes": "d71b38e738107a9e0bddc5ec86f87aa0d20fee5b48a2849cfebc949fc4d7ed0e"
+                        "bytes": "38072d78d3e3cdb2d01d7ed692d248c563fd9205e4dc8b5191cfb13711d8df9d"
                       }
                     }
                   ]
@@ -372,7 +372,7 @@
             "data": {
               "vec": [
                 {
-                  "bytes": "d71b38e738107a9e0bddc5ec86f87aa0d20fee5b48a2849cfebc949fc4d7ed0e"
+                  "bytes": "38072d78d3e3cdb2d01d7ed692d248c563fd9205e4dc8b5191cfb13711d8df9d"
                 },
                 {
                   "u64": 1000
@@ -409,7 +409,7 @@
             "data": {
               "vec": [
                 {
-                  "bytes": "d71b38e738107a9e0bddc5ec86f87aa0d20fee5b48a2849cfebc949fc4d7ed0e"
+                  "bytes": "38072d78d3e3cdb2d01d7ed692d248c563fd9205e4dc8b5191cfb13711d8df9d"
                 },
                 {
                   "u64": 1000
@@ -468,7 +468,7 @@
                       "symbol": "SessionKey"
                     },
                     {
-                      "bytes": "d71b38e738107a9e0bddc5ec86f87aa0d20fee5b48a2849cfebc949fc4d7ed0e"
+                      "bytes": "38072d78d3e3cdb2d01d7ed692d248c563fd9205e4dc8b5191cfb13711d8df9d"
                     }
                   ]
                 },
@@ -485,10 +485,10 @@
                   "u64": 0
                 },
                 {
-                  "bytes": "d71b38e738107a9e0bddc5ec86f87aa0d20fee5b48a2849cfebc949fc4d7ed0e"
+                  "bytes": "38072d78d3e3cdb2d01d7ed692d248c563fd9205e4dc8b5191cfb13711d8df9d"
                 },
                 {
-                  "bytes": "e4ebfa7582f492d56f66c9bf4515e4e301408fa95e508d52d4fd3e9329e55820cd026a4ccb869cfe5b2bb91aae7a28ba05fac3e9fd46557f386ec8afaebf9903"
+                  "bytes": "1b375b4245b18e4890f71bf34b84e0851487384b646fb1cf9d7948e391c867cb2bea9a13828ee36a64ab5479486a5ea534fb5ba0ce51558f5a96ded790da1202"
                 },
                 {
                   "bytes": "000000120000000100000000000000000000000000000000000000000000000000000000000000030000000f000000096765745f6e6f6e6365000000000000100000000100000000000000050000000000000000"
@@ -583,7 +583,7 @@
                           "symbol": "SessionKey"
                         },
                         {
-                          "bytes": "d71b38e738107a9e0bddc5ec86f87aa0d20fee5b48a2849cfebc949fc4d7ed0e"
+                          "bytes": "38072d78d3e3cdb2d01d7ed692d248c563fd9205e4dc8b5191cfb13711d8df9d"
                         }
                       ]
                     },
@@ -600,10 +600,10 @@
                       "u64": 0
                     },
                     {
-                      "bytes": "d71b38e738107a9e0bddc5ec86f87aa0d20fee5b48a2849cfebc949fc4d7ed0e"
+                      "bytes": "38072d78d3e3cdb2d01d7ed692d248c563fd9205e4dc8b5191cfb13711d8df9d"
                     },
                     {
-                      "bytes": "e4ebfa7582f492d56f66c9bf4515e4e301408fa95e508d52d4fd3e9329e55820cd026a4ccb869cfe5b2bb91aae7a28ba05fac3e9fd46557f386ec8afaebf9903"
+                      "bytes": "1b375b4245b18e4890f71bf34b84e0851487384b646fb1cf9d7948e391c867cb2bea9a13828ee36a64ab5479486a5ea534fb5ba0ce51558f5a96ded790da1202"
                     },
                     {
                       "bytes": "000000120000000100000000000000000000000000000000000000000000000000000000000000030000000f000000096765745f6e6f6e6365000000000000100000000100000000000000050000000000000000"

--- a/contracts/account/test_snapshots/test/test_execute_session_key_missing_payload_returns_invalid_signature.1.json
+++ b/contracts/account/test_snapshots/test/test_execute_session_key_missing_payload_returns_invalid_signature.1.json
@@ -15,7 +15,7 @@
               "function_name": "add_session_key",
               "args": [
                 {
-                  "bytes": "330426ced3ddc875570960b03232708da7970b08aaf0ada72c27f9ac7a072cb9"
+                  "bytes": "c600b4701b9dfc6dd05150266056f857dfefc12956b6b1fc987aa5e3ce89d897"
                 },
                 {
                   "u64": 10000
@@ -56,7 +56,7 @@
                   "symbol": "SessionKey"
                 },
                 {
-                  "bytes": "330426ced3ddc875570960b03232708da7970b08aaf0ada72c27f9ac7a072cb9"
+                  "bytes": "c600b4701b9dfc6dd05150266056f857dfefc12956b6b1fc987aa5e3ce89d897"
                 }
               ]
             },
@@ -76,7 +76,7 @@
                       "symbol": "SessionKey"
                     },
                     {
-                      "bytes": "330426ced3ddc875570960b03232708da7970b08aaf0ada72c27f9ac7a072cb9"
+                      "bytes": "c600b4701b9dfc6dd05150266056f857dfefc12956b6b1fc987aa5e3ce89d897"
                     }
                   ]
                 },
@@ -108,7 +108,7 @@
                         "symbol": "public_key"
                       },
                       "val": {
-                        "bytes": "330426ced3ddc875570960b03232708da7970b08aaf0ada72c27f9ac7a072cb9"
+                        "bytes": "c600b4701b9dfc6dd05150266056f857dfefc12956b6b1fc987aa5e3ce89d897"
                       }
                     }
                   ]
@@ -366,7 +366,7 @@
             "data": {
               "vec": [
                 {
-                  "bytes": "330426ced3ddc875570960b03232708da7970b08aaf0ada72c27f9ac7a072cb9"
+                  "bytes": "c600b4701b9dfc6dd05150266056f857dfefc12956b6b1fc987aa5e3ce89d897"
                 },
                 {
                   "u64": 10000
@@ -400,7 +400,7 @@
             "data": {
               "vec": [
                 {
-                  "bytes": "330426ced3ddc875570960b03232708da7970b08aaf0ada72c27f9ac7a072cb9"
+                  "bytes": "c600b4701b9dfc6dd05150266056f857dfefc12956b6b1fc987aa5e3ce89d897"
                 },
                 {
                   "u64": 10000
@@ -459,7 +459,7 @@
                       "symbol": "SessionKey"
                     },
                     {
-                      "bytes": "330426ced3ddc875570960b03232708da7970b08aaf0ada72c27f9ac7a072cb9"
+                      "bytes": "c600b4701b9dfc6dd05150266056f857dfefc12956b6b1fc987aa5e3ce89d897"
                     }
                   ]
                 },
@@ -476,9 +476,11 @@
                   "u64": 0
                 },
                 {
-                  "bytes": "330426ced3ddc875570960b03232708da7970b08aaf0ada72c27f9ac7a072cb9"
+                  "bytes": "c600b4701b9dfc6dd05150266056f857dfefc12956b6b1fc987aa5e3ce89d897"
                 },
-                "void",
+                {
+                  "bytes": "27f3a805dc72d12e3328d087934553e3b979155d4123e00b69382838bb6d8122b8489b9b8958c1b5c984d488ceea70833a81aff2a98dce16f47bada8e296670f"
+                },
                 "void"
               ]
             }
@@ -504,7 +506,7 @@
             ],
             "data": {
               "error": {
-                "contract": 3
+                "contract": 9
               }
             }
           }
@@ -525,7 +527,7 @@
               },
               {
                 "error": {
-                  "contract": 3
+                  "contract": 9
                 }
               }
             ],
@@ -550,7 +552,7 @@
               },
               {
                 "error": {
-                  "contract": 3
+                  "contract": 9
                 }
               }
             ],
@@ -570,7 +572,7 @@
                           "symbol": "SessionKey"
                         },
                         {
-                          "bytes": "330426ced3ddc875570960b03232708da7970b08aaf0ada72c27f9ac7a072cb9"
+                          "bytes": "c600b4701b9dfc6dd05150266056f857dfefc12956b6b1fc987aa5e3ce89d897"
                         }
                       ]
                     },
@@ -587,9 +589,11 @@
                       "u64": 0
                     },
                     {
-                      "bytes": "330426ced3ddc875570960b03232708da7970b08aaf0ada72c27f9ac7a072cb9"
+                      "bytes": "c600b4701b9dfc6dd05150266056f857dfefc12956b6b1fc987aa5e3ce89d897"
                     },
-                    "void",
+                    {
+                      "bytes": "27f3a805dc72d12e3328d087934553e3b979155d4123e00b69382838bb6d8122b8489b9b8958c1b5c984d488ceea70833a81aff2a98dce16f47bada8e296670f"
+                    },
                     "void"
                   ]
                 }

--- a/contracts/account/test_snapshots/test/test_execute_session_key_permissions.1.json
+++ b/contracts/account/test_snapshots/test/test_execute_session_key_permissions.1.json
@@ -15,7 +15,7 @@
               "function_name": "add_session_key",
               "args": [
                 {
-                  "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                  "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                 },
                 {
                   "u64": 10000
@@ -41,7 +41,7 @@
               "function_name": "add_session_key",
               "args": [
                 {
-                  "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                  "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                 },
                 {
                   "u64": 10000
@@ -82,7 +82,7 @@
                   "symbol": "SessionKey"
                 },
                 {
-                  "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                  "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                 }
               ]
             },
@@ -102,7 +102,7 @@
                       "symbol": "SessionKey"
                     },
                     {
-                      "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                      "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                     }
                   ]
                 },
@@ -134,7 +134,7 @@
                         "symbol": "public_key"
                       },
                       "val": {
-                        "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                        "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                       }
                     }
                   ]
@@ -425,7 +425,7 @@
             "data": {
               "vec": [
                 {
-                  "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                  "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                 },
                 {
                   "u64": 10000
@@ -455,7 +455,7 @@
             "data": {
               "vec": [
                 {
-                  "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                  "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                 },
                 {
                   "u64": 10000
@@ -514,7 +514,7 @@
                       "symbol": "SessionKey"
                     },
                     {
-                      "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                      "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                     }
                   ]
                 },
@@ -531,10 +531,10 @@
                   "u64": 0
                 },
                 {
-                  "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                  "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                 },
                 {
-                  "bytes": "431616efb785f8466b3c20ec26d7c9a966e666279612acadf6abb4c681b65621c9b25598a9e7b2499873f0b64d33e22f367f6f20c109c0ca24128b118294e403"
+                  "bytes": "068d736f4e07d50cbf0311cc181abbf641cf5733a1cb274ae019070fe2ace557c49c23a81bad72d67cca7f5688bf8dbb1fc3653c441bcac5fcc2591295738306"
                 },
                 {
                   "bytes": "000000120000000100000000000000000000000000000000000000000000000000000000000000030000000f000000096765745f6e6f6e6365000000000000100000000100000000000000050000000000000000"
@@ -629,7 +629,7 @@
                           "symbol": "SessionKey"
                         },
                         {
-                          "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                          "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                         }
                       ]
                     },
@@ -646,10 +646,10 @@
                       "u64": 0
                     },
                     {
-                      "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                      "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                     },
                     {
-                      "bytes": "431616efb785f8466b3c20ec26d7c9a966e666279612acadf6abb4c681b65621c9b25598a9e7b2499873f0b64d33e22f367f6f20c109c0ca24128b118294e403"
+                      "bytes": "068d736f4e07d50cbf0311cc181abbf641cf5733a1cb274ae019070fe2ace557c49c23a81bad72d67cca7f5688bf8dbb1fc3653c441bcac5fcc2591295738306"
                     },
                     {
                       "bytes": "000000120000000100000000000000000000000000000000000000000000000000000000000000030000000f000000096765745f6e6f6e6365000000000000100000000100000000000000050000000000000000"
@@ -684,7 +684,7 @@
             "data": {
               "vec": [
                 {
-                  "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                  "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                 },
                 {
                   "u64": 10000
@@ -718,7 +718,7 @@
             "data": {
               "vec": [
                 {
-                  "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                  "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                 },
                 {
                   "u64": 10000
@@ -777,7 +777,7 @@
                       "symbol": "SessionKey"
                     },
                     {
-                      "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                      "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                     }
                   ]
                 },
@@ -794,10 +794,10 @@
                   "u64": 0
                 },
                 {
-                  "bytes": "07e6b1fad4dd8b152d3d8128d851047aeb35429a721e1067a9ec93c54ca2fdfb"
+                  "bytes": "12070e9baa852f0653f107a1109f79301bf91ac1a55c170d825b3477c1806919"
                 },
                 {
-                  "bytes": "431616efb785f8466b3c20ec26d7c9a966e666279612acadf6abb4c681b65621c9b25598a9e7b2499873f0b64d33e22f367f6f20c109c0ca24128b118294e403"
+                  "bytes": "068d736f4e07d50cbf0311cc181abbf641cf5733a1cb274ae019070fe2ace557c49c23a81bad72d67cca7f5688bf8dbb1fc3653c441bcac5fcc2591295738306"
                 },
                 {
                   "bytes": "000000120000000100000000000000000000000000000000000000000000000000000000000000030000000f000000096765745f6e6f6e6365000000000000100000000100000000000000050000000000000000"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.39.4
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@testing-library/jest-dom':
         specifier: ^6.1.0
         version: 6.9.1
@@ -342,7 +345,7 @@ importers:
         version: 29.7.0(@types/node@25.5.0)
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(esbuild@0.21.5)(jest-util@30.3.0)(jest@29.7.0(@types/node@25.5.0))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@25.5.0))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.3)
@@ -1804,6 +1807,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -4241,6 +4249,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5655,6 +5668,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -8642,6 +8665,10 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.2.9': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@radix-ui/number@1.0.1':
     dependencies:
@@ -11692,6 +11719,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -13538,6 +13568,14 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   polished@4.3.1:
     dependencies:
       '@babel/runtime': 7.29.2
@@ -14546,27 +14584,6 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(esbuild@0.21.5)(jest-util@30.3.0)(jest@29.7.0(@types/node@25.5.0))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 29.7.0(@types/node@25.5.0)
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.4
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      esbuild: 0.21.5
-      jest-util: 30.3.0
-
   ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(esbuild@0.21.5)(jest-util@30.3.0)(jest@30.3.0(@types/node@20.19.37)(esbuild-register@3.6.0(esbuild@0.21.5)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
@@ -14607,6 +14624,26 @@ snapshots:
       '@jest/types': 30.3.0
       babel-jest: 30.3.0(@babel/core@7.29.0)
       esbuild: 0.21.5
+      jest-util: 30.3.0
+
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@29.7.0(@types/node@25.5.0))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 29.7.0(@types/node@25.5.0)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.4
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
   tslib@1.14.1: {}


### PR DESCRIPTION
## Summary

- Adds `ContractError::InvalidSignature = 9` to the account contract error enum
- Replaces the generic `Unauthorized` error returned when a session key's `signature` or `signature_payload` is `None` with the more precise `InvalidSignature` variant
- Updates `test_execute_session_key_missing_signature_rejected` to assert the specific error variant (`InvalidSignature`) rather than just `is_err()`
- Adds `test_execute_session_key_missing_payload_returns_invalid_signature` covering the missing-payload case explicitly

## Test plan

- [x] All 27 contract tests pass (`cargo test`)
- [x] Full workspace build/test/lint/format passes (pre-push hook verified)
- [x] No regression on existing session key flows

Closes #203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-key authentication error handling to return a more specific InvalidSignature error when signature or signature payload is missing, replacing the generic Unauthorized response.

* **Tests**
  * Expanded test coverage for edge cases including missing signature payload scenarios.
  * Updated existing authentication tests to reflect new error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->