### PR TITLE
test(e2e): add Playwright tests for extension wallet flows

### DIFF
--- a/apps/extension-wallet/package.json
+++ b/apps/extension-wallet/package.json
@@ -9,6 +9,7 @@
     "test": "pnpm --dir ../.. --filter @ancore/ui-kit build && vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/",
+    "test:e2e": "playwright test --config=tests/playwright.config.ts",
     "analyze": "node scripts/analyze-bundle.js"
   },
   "dependencies": {
@@ -24,13 +25,14 @@
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0",
     "react-error-boundary": "^6.1.1",
+    "react-router-dom": "^6.28.0",
     "webextension-polyfill": "^0.12.0",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.1.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.5.0",

--- a/apps/extension-wallet/tests/e2e/lock-unlock.spec.ts
+++ b/apps/extension-wallet/tests/e2e/lock-unlock.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, navigateTo } from '../fixtures/extension';
+
+test.describe('Lock / unlock flow', () => {
+  test('locked wallet shows unlock screen', async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-locked');
+    await navigateTo(page, '/');
+    await expect(page).toHaveURL(/\/unlock/);
+    await expect(page.getByText('Unlock wallet')).toBeVisible();
+  });
+
+  test('unlock screen shows wallet name and address', async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-locked');
+    await navigateTo(page, '/unlock');
+    await expect(page.getByText('Test Wallet')).toBeVisible();
+    await expect(page.getByText('GCFX...WALLET')).toBeVisible();
+  });
+
+  test('unlock with any password grants access to home', async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-locked');
+    await navigateTo(page, '/unlock');
+
+    await page.getByPlaceholder('Enter your password').fill('anypassword');
+    await page.getByRole('button', { name: /Unlock/i }).click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/\/home/);
+    await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
+  });
+
+  test('unlock button is disabled when password is empty', async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-locked');
+    await navigateTo(page, '/unlock');
+
+    const unlockBtn = page.getByRole('button', { name: /Unlock/i });
+    await expect(unlockBtn).toBeDisabled();
+  });
+
+  test('locking wallet redirects to unlock screen', async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-unlocked');
+    await navigateTo(page, '/home');
+
+    await page.getByRole('button', { name: /Lock wallet/i }).click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/\/unlock/);
+  });
+
+  test('locked wallet cannot access protected routes directly', async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-locked');
+    await page.goto('/send');
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/unlock/);
+  });
+
+  test('reset wallet returns to fresh state', async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-locked');
+    await navigateTo(page, '/unlock');
+
+    await page.getByRole('button', { name: /Reset demo wallet/i }).click();
+    // After reset the app stays at /unlock; navigate to / to trigger root redirect
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/\/welcome/);
+  });
+});

--- a/apps/extension-wallet/tests/e2e/onboarding.spec.ts
+++ b/apps/extension-wallet/tests/e2e/onboarding.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '../fixtures/extension';
+
+test.describe('Onboarding flow', () => {
+  test.beforeEach(async ({ page, clearWallet }) => {
+    await page.goto('/');
+    await clearWallet();
+  });
+
+  test('fresh wallet redirects to /welcome', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/welcome/);
+    await expect(page.getByText('Meet your Ancore wallet')).toBeVisible();
+  });
+
+  test('welcome screen shows setup options', async ({ page }) => {
+    await page.goto('/welcome');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('I already have a wallet')).toBeVisible();
+    await expect(page.getByText('Create a wallet')).toBeVisible();
+  });
+
+  test('create wallet flow completes onboarding and lands on /home', async ({ page }) => {
+    await page.goto('/welcome');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByText('Create a wallet').click();
+    await expect(page).toHaveURL(/\/create-account/);
+    await expect(page.getByText('Create account')).toBeVisible();
+
+    const nameInput = page.getByPlaceholder('My Ancore Wallet');
+    await nameInput.clear();
+    await nameInput.fill('E2E Test Wallet');
+
+    await page.getByRole('button', { name: /Create wallet/i }).click();
+
+    await expect(page).toHaveURL(/\/home/);
+    await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
+  });
+
+  test('onboarded wallet skips welcome and goes to unlock', async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-locked');
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/unlock/);
+  });
+
+  test('authenticated wallet goes directly to home', async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-unlocked');
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/home/);
+  });
+
+  test('protected route redirects unauthenticated user to welcome', async ({ page }) => {
+    await page.goto('/home');
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/welcome/);
+  });
+});

--- a/apps/extension-wallet/tests/e2e/session-keys.spec.ts
+++ b/apps/extension-wallet/tests/e2e/session-keys.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect, navigateTo } from '../fixtures/extension';
+
+test.describe('Session key management', () => {
+  test.beforeEach(async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-unlocked');
+    await navigateTo(page, '/session-keys');
+  });
+
+  test('session keys screen is reachable from home', async ({ page }) => {
+    await navigateTo(page, '/home');
+    await page.getByText('Session keys').click();
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/session-keys/);
+  });
+
+  test('session keys screen shows active keys list', async ({ page }) => {
+    await expect(page.getByText('Active keys')).toBeVisible();
+    await expect(page.getByText('Trading bot')).toBeVisible();
+    await expect(page.getByText('Automation script')).toBeVisible();
+  });
+
+  test('session keys screen shows key validity info', async ({ page }) => {
+    await expect(page.getByText(/Valid for 12 more hours/)).toBeVisible();
+    await expect(page.getByText(/expires tomorrow/i)).toBeVisible();
+  });
+
+  test('add session key button is present', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /Add session key/i })).toBeVisible();
+  });
+
+  test('unauthenticated user cannot access session keys', async ({ page, clearWallet }) => {
+    await clearWallet();
+    await page.goto('/session-keys');
+    await page.waitForLoadState('networkidle');
+    await expect(page).not.toHaveURL(/\/session-keys/);
+  });
+
+  test('settings are reachable and back link from session keys works', async ({ page }) => {
+    await navigateTo(page, '/settings');
+    await expect(page).toHaveURL(/\/settings/);
+  });
+});

--- a/apps/extension-wallet/tests/e2e/transactions.spec.ts
+++ b/apps/extension-wallet/tests/e2e/transactions.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect, navigateTo } from '../fixtures/extension';
+
+test.describe('Transaction flow', () => {
+  test.beforeEach(async ({ page, seedWallet }) => {
+    await seedWallet('onboarded-unlocked');
+    await navigateTo(page, '/home');
+  });
+
+  test('home screen shows wallet balance and navigation links', async ({ page }) => {
+    await expect(page.getByText('Available balance')).toBeVisible();
+    await expect(page.getByText('1,245.80 XLM')).toBeVisible();
+    await expect(page.getByText('Send funds')).toBeVisible();
+    await expect(page.getByText('Receive funds')).toBeVisible();
+  });
+
+  test('navigates to /send from home', async ({ page }) => {
+    await page.getByText('Send funds').click();
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/send/);
+    await expect(page.getByRole('heading', { name: 'Send' })).toBeVisible();
+  });
+
+  test('send screen renders recipient and amount inputs', async ({ page }) => {
+    await navigateTo(page, '/send');
+    await expect(page.getByPlaceholder('Recipient address')).toBeVisible();
+    await expect(page.getByPlaceholder('Amount')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Review transaction/i })).toBeVisible();
+  });
+
+  test('navigates to /receive from home', async ({ page }) => {
+    await page.getByText('Receive funds').click();
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/receive/);
+    await expect(page.getByRole('heading', { name: 'Receive', exact: true })).toBeVisible();
+  });
+
+  test('receive screen shows address and actions', async ({ page }) => {
+    await navigateTo(page, '/receive');
+    await expect(page.getByText('Receive funds')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Copy address/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Show QR/i })).toBeVisible();
+  });
+
+  test('navigates to /history from home', async ({ page }) => {
+    await page.getByText('View history').click();
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/history/);
+    await expect(page.getByText('Recent activity')).toBeVisible();
+  });
+
+  test('history screen lists recent transactions', async ({ page }) => {
+    await navigateTo(page, '/history');
+    await expect(page.getByText('Received from Treasury')).toBeVisible();
+    await expect(page.getByText('Sent to Merchant')).toBeVisible();
+    await expect(page.getByText('+320 XLM')).toBeVisible();
+  });
+});

--- a/apps/extension-wallet/tests/fixtures/extension.ts
+++ b/apps/extension-wallet/tests/fixtures/extension.ts
@@ -1,0 +1,58 @@
+import { test as base, type Page } from '@playwright/test';
+
+const AUTH_KEY = 'ancore_extension_auth';
+
+export type WalletState = 'fresh' | 'onboarded-locked' | 'onboarded-unlocked';
+
+const AUTH_PRESETS = {
+  fresh: {
+    hasOnboarded: false,
+    isUnlocked: false,
+    walletName: 'Ancore Wallet',
+    accountAddress: 'GCFX...WALLET',
+  },
+  'onboarded-locked': {
+    hasOnboarded: true,
+    isUnlocked: false,
+    walletName: 'Test Wallet',
+    accountAddress: 'GCFX...WALLET',
+  },
+  'onboarded-unlocked': {
+    hasOnboarded: true,
+    isUnlocked: true,
+    walletName: 'Test Wallet',
+    accountAddress: 'GCFX...WALLET',
+  },
+} as const;
+
+export interface ExtensionFixtures {
+  seedWallet: (state: WalletState) => Promise<void>;
+  clearWallet: () => Promise<void>;
+}
+
+export const test = base.extend<ExtensionFixtures>({
+  seedWallet: async ({ page }, use) => {
+    await use(async (state: WalletState) => {
+      await page.goto('/');
+      await page.evaluate(
+        ([key, value]) => {
+          localStorage.setItem(key, JSON.stringify(value));
+        },
+        [AUTH_KEY, AUTH_PRESETS[state]] as [string, object]
+      );
+    });
+  },
+
+  clearWallet: async ({ page }, use) => {
+    await use(async () => {
+      await page.evaluate((key) => localStorage.removeItem(key), AUTH_KEY);
+    });
+  },
+});
+
+export { expect } from '@playwright/test';
+
+export async function navigateTo(page: Page, path: string): Promise<void> {
+  await page.goto(path);
+  await page.waitForLoadState('networkidle');
+}

--- a/apps/extension-wallet/tests/playwright.config.ts
+++ b/apps/extension-wallet/tests/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? 'github' : 'list',
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    // ui-kit must be built before dev server starts; CI runs `pnpm build:deps` first
+    command: 'pnpm --filter @ancore/ui-kit build && pnpm dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    cwd: '..',
+  },
+});


### PR DESCRIPTION
## Summary

- Installs `@playwright/test` in the extension-wallet package
- Adds `tests/playwright.config.ts` — headless Chromium, auto-starts `vite dev` as `webServer`, CI-compatible
- Adds `tests/fixtures/extension.ts` — `seedWallet` fixture that seeds `localStorage` with preset auth states (`fresh`, `onboarded-locked`, `onboarded-unlocked`) for deterministic test setup
- Adds 4 E2E spec files (26 tests total, runs in ~22 s):
  - `onboarding.spec.ts` — fresh redirect, welcome options, create-wallet flow, pre-seeded state routing, protected-route guard
  - `transactions.spec.ts` — balance display, send/receive/history navigation and content
  - `session-keys.spec.ts` — active keys list, validity labels, add-key button, auth guard
  - `lock-unlock.spec.ts` — lock/unlock cycle, disabled button on empty password, protected routes, wallet reset

## Test plan

- [x] `npx playwright test --config=tests/playwright.config.ts` → **26 passed** in 21.7 s
- [x] All tests run headless (CI-compatible)
- [x] Total execution well under 5-minute target
- [x] Full workspace build/test/lint/format passes (pre-push hook verified)

Closes #231