### PR TITLE
Harden extension unlock gate and add contract authorization guardrails

### DIFF
--- a/apps/extension-wallet/src/router/AuthGuard.tsx
+++ b/apps/extension-wallet/src/router/AuthGuard.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { SecureStorageManager, createStorageAdapter } from '@ancore/core-sdk';
 
 export const AUTH_STORAGE_KEY = 'ancore_extension_auth';
 
@@ -20,12 +21,20 @@ export const DEFAULT_AUTH_STATE: AuthState = {
 interface AuthContextValue {
   authState: AuthState;
   completeOnboarding: (walletName: string) => void;
-  unlockWallet: () => void;
+  unlockWallet: (password: string) => Promise<boolean>;
   lockWallet: () => void;
   resetWallet: () => void;
 }
 
 const AuthContext = React.createContext<AuthContextValue | null>(null);
+let storageManager: SecureStorageManager | null = null;
+
+function getStorageManager(): SecureStorageManager {
+  if (!storageManager) {
+    storageManager = new SecureStorageManager(createStorageAdapter());
+  }
+  return storageManager;
+}
 
 export function readAuthState(): AuthState {
   if (typeof window === 'undefined') {
@@ -53,6 +62,7 @@ function writeAuthState(authState: AuthState): void {
 
 export function ExtensionAuthProvider({ children }: { children: React.ReactNode }) {
   const [authState, setAuthState] = React.useState<AuthState>(readAuthState);
+  const storage = React.useMemo(() => getStorageManager(), []);
 
   React.useEffect(() => {
     writeAuthState(authState);
@@ -80,24 +90,44 @@ export function ExtensionAuthProvider({ children }: { children: React.ReactNode 
           accountAddress: DEFAULT_AUTH_STATE.accountAddress,
         });
       },
-      unlockWallet: () => {
-        setAuthState((current) => ({
-          ...current,
-          hasOnboarded: true,
-          isUnlocked: true,
-        }));
+      unlockWallet: async (password: string) => {
+        try {
+          const didUnlock = await storage.unlock(password);
+          if (!didUnlock) {
+            setAuthState((current) => ({
+              ...current,
+              isUnlocked: false,
+            }));
+            return false;
+          }
+
+          setAuthState((current) => ({
+            ...current,
+            hasOnboarded: true,
+            isUnlocked: true,
+          }));
+          return true;
+        } catch {
+          setAuthState((current) => ({
+            ...current,
+            isUnlocked: false,
+          }));
+          return false;
+        }
       },
       lockWallet: () => {
+        storage.lock();
         setAuthState((current) => ({
           ...current,
           isUnlocked: false,
         }));
       },
       resetWallet: () => {
+        storage.lock();
         setAuthState(DEFAULT_AUTH_STATE);
       },
     }),
-    [authState]
+    [authState, storage]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/extension-wallet/src/router/__tests__/router.test.tsx
+++ b/apps/extension-wallet/src/router/__tests__/router.test.tsx
@@ -1,8 +1,30 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AUTH_STORAGE_KEY, DEFAULT_AUTH_STATE } from '../AuthGuard';
 import { ExtensionRouterTestHarness } from '..';
+
+const mockUnlock = vi.fn<(password: string) => Promise<boolean>>();
+const mockLock = vi.fn();
+
+vi.mock('@ancore/core-sdk', async () => {
+  const actual = await vi.importActual<object>('@ancore/core-sdk');
+  class MockSecureStorageManager {
+    unlock(password: string) {
+      return mockUnlock(password);
+    }
+
+    lock() {
+      mockLock();
+    }
+  }
+
+  return {
+    ...actual,
+    SecureStorageManager: MockSecureStorageManager,
+    createStorageAdapter: () => ({}),
+  };
+});
 
 function renderRouter(pathname: string, authState = DEFAULT_AUTH_STATE) {
   window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(authState));
@@ -13,6 +35,9 @@ describe('extension router', () => {
   beforeEach(() => {
     window.localStorage.clear();
     document.title = 'Ancore Extension';
+    mockUnlock.mockReset();
+    mockLock.mockReset();
+    mockUnlock.mockResolvedValue(true);
   });
 
   it('redirects first-time users to welcome when they hit a protected route', () => {
@@ -89,5 +114,22 @@ describe('extension router', () => {
     await user.click(screen.getByRole('button', { name: /go back/i }));
 
     expect(await screen.findByRole('heading', { name: /settings/i })).toBeInTheDocument();
+  });
+
+  it('keeps users locked and shows an error when unlock credentials are invalid', async () => {
+    const user = userEvent.setup();
+    mockUnlock.mockResolvedValue(false);
+    renderRouter('/unlock', {
+      ...DEFAULT_AUTH_STATE,
+      hasOnboarded: true,
+      isUnlocked: false,
+    });
+
+    await user.type(screen.getByLabelText(/password/i), 'wrong-password');
+    await user.click(screen.getByRole('button', { name: /unlock/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/invalid password/i);
+    expect(screen.getByRole('heading', { name: /unlock wallet/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /home/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/extension-wallet/src/router/index.tsx
+++ b/apps/extension-wallet/src/router/index.tsx
@@ -254,11 +254,17 @@ function UnlockScreen() {
   const location = useLocation();
   const { authState, unlockWallet, resetWallet } = useExtensionAuth();
   const [password, setPassword] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
   const from = (location.state as { from?: string } | null)?.from ?? '/home';
 
-  function handleUnlock(event: React.FormEvent<HTMLFormElement>) {
+  async function handleUnlock(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    unlockWallet();
+    setError(null);
+    const didUnlock = await unlockWallet(password);
+    if (!didUnlock) {
+      setError('Invalid password. Please try again.');
+      return;
+    }
     navigate(from, { replace: true });
   }
 
@@ -283,6 +289,11 @@ function UnlockScreen() {
           <PrimaryButton disabled={!password.trim()} type="submit">
             Unlock
           </PrimaryButton>
+          {error ? (
+            <p className="rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
+              {error}
+            </p>
+          ) : null}
         </form>
       </Card>
       <button

--- a/apps/extension-wallet/src/security/__tests__/lock-manager.test.ts
+++ b/apps/extension-wallet/src/security/__tests__/lock-manager.test.ts
@@ -5,10 +5,11 @@ import { LockManager } from '../lock-manager';
 
 function makeMockStorageManager(shouldFailUnlock = false) {
   return {
-    unlock: vi.fn(async (password: string) => {
+    unlock: vi.fn(async (password: string): Promise<boolean> => {
       if (shouldFailUnlock || password !== 'correct') {
         throw new Error('Invalid password or corrupted data');
       }
+      return true;
     }),
     lock: vi.fn(),
     isUnlocked: false,
@@ -56,6 +57,26 @@ describe('LockManager', () => {
 
     await expect(manager.unlock('wrong')).rejects.toThrow('Invalid password');
     expect(manager.isLocked).toBe(true);
+    manager.destroy();
+  });
+
+  it('fails closed when storage unlock resolves false', async () => {
+    const storage = {
+      unlock: vi.fn(async () => false),
+      lock: vi.fn(),
+      isUnlocked: false,
+      touch: vi.fn(),
+    };
+    const onUnlock = vi.fn();
+    const manager = new LockManager({
+      autoLockMinutes: 5,
+      storageManager: storage as any,
+      onUnlock,
+    });
+
+    await expect(manager.unlock('correct')).rejects.toThrow('Invalid password or corrupted data');
+    expect(manager.isLocked).toBe(true);
+    expect(onUnlock).not.toHaveBeenCalled();
     manager.destroy();
   });
 

--- a/apps/extension-wallet/src/security/lock-manager.ts
+++ b/apps/extension-wallet/src/security/lock-manager.ts
@@ -41,12 +41,14 @@ export class LockManager {
 
   /**
    * Unlock the wallet with the given password.
-   * Throws if the password is incorrect.
+   * Throws if the password is incorrect or unlock result is non-true.
    */
   async unlock(password: string): Promise<void> {
-    // Delegates password verification to SecureStorageManager.
-    // unlock() will throw 'Invalid password or corrupted data' on bad password.
-    await this.storageManager.unlock(password);
+    // Explicitly require a true result to avoid fail-open behavior.
+    const didUnlock = await this.storageManager.unlock(password);
+    if (didUnlock !== true) {
+      throw new Error('Invalid password or corrupted data');
+    }
 
     this.status = 'unlocked';
     this.detector.start();

--- a/contracts/account/README.md
+++ b/contracts/account/README.md
@@ -48,6 +48,19 @@ soroban contract build
 cargo test
 ```
 
+### Guardrail Coverage (Issue #260)
+
+The account contract test suite includes regression guardrails for storage growth and instance TTL bump policy:
+
+- `test_storage_key_growth_with_high_session_key_count` adds 96 session keys and validates each key is independently persisted/retrievable.
+- `test_instance_ttl_bump_threshold_policy_read_vs_write_paths` validates that read-only calls do not force TTL growth, while write paths restore instance TTL when near expiry.
+
+#### Expected Limits and Extreme-Input Behavior
+
+- High session-key counts are expected to grow persistent storage linearly by one key per session key.
+- Unknown session-key maintenance operations are rejected with `SessionKeyNotFound` (error `#5`).
+- Instance TTL bumping is expected only on mutating paths (`initialize`, `execute`, `upgrade`, `migrate`) and remains unchanged on read paths.
+
 ## Deployment
 
 ### Testnet

--- a/contracts/account/src/lib.rs
+++ b/contracts/account/src/lib.rs
@@ -114,6 +114,7 @@ pub enum DataKey {
 const DAY_IN_LEDGERS: u32 = 17280; // 24 hours * 60 min * 60 sec / 5 sec per ledger
 const INSTANCE_BUMP_AMOUNT: u32 = 30 * DAY_IN_LEDGERS; // 30 days
 const INSTANCE_BUMP_THRESHOLD: u32 = 15 * DAY_IN_LEDGERS; // 15 days
+const EXPIRY_MILLISECONDS_THRESHOLD: u64 = 1_000_000_000_000;
 
 /// Permission bit for execute operations
 /// Permission bit for session-key execute authorization.
@@ -247,9 +248,14 @@ impl AncoreAccount {
         let owner = Self::get_owner(env.clone())?;
         owner.require_auth();
 
+        // Explicit expiry unit contract:
+        // - values < EXPIRY_MILLISECONDS_THRESHOLD are treated as seconds
+        // - values >= EXPIRY_MILLISECONDS_THRESHOLD are treated as milliseconds
+        let normalized_expires_at = Self::normalize_expiry_timestamp(expires_at);
+
         let session_key = SessionKey {
             public_key: public_key.clone(),
-            expires_at,
+            expires_at: normalized_expires_at,
             permissions,
         };
 
@@ -257,7 +263,7 @@ impl AncoreAccount {
             .persistent()
             .set(&DataKey::SessionKey(public_key.clone()), &session_key);
 
-        Self::extend_session_key_ttl(&env, &public_key, expires_at);
+        Self::extend_session_key_ttl(&env, &public_key, normalized_expires_at);
 
         // Emit session_key_added event
         env.events()
@@ -357,28 +363,40 @@ impl AncoreAccount {
 
     /// Refresh the TTL of a session key
     pub fn refresh_session_key_ttl(env: Env, public_key: BytesN<32>) -> Result<(), ContractError> {
-        let session_key = Self::get_session_key(env.clone(), public_key.clone())
+        let mut session_key = Self::get_session_key(env.clone(), public_key.clone())
             .ok_or(ContractError::SessionKeyNotFound)?;
 
-        Self::extend_session_key_ttl(&env, &public_key, session_key.expires_at);
+        // Normalize legacy values here so refresh always operates on canonical seconds.
+        let normalized_expires_at = Self::normalize_expiry_timestamp(session_key.expires_at);
+        if session_key.expires_at != normalized_expires_at {
+            session_key.expires_at = normalized_expires_at;
+            env.storage()
+                .persistent()
+                .set(&DataKey::SessionKey(public_key.clone()), &session_key);
+        }
+
+        Self::extend_session_key_ttl(&env, &public_key, normalized_expires_at);
 
         Ok(())
     }
 
-    /// Helper to cleanly extend session key TTL
-    fn extend_session_key_ttl(env: &Env, public_key: &BytesN<32>, expires_at: u64) {
-        let current_timestamp = env.ledger().timestamp();
-
-        // Auto-detect if expires_at is using ms vs s. ms timestamps are > 100_000_000_000
-        let expires_at_secs = if expires_at > 100_000_000_000 {
+    /// Normalize expiry timestamp into canonical seconds.
+    fn normalize_expiry_timestamp(expires_at: u64) -> u64 {
+        if expires_at >= EXPIRY_MILLISECONDS_THRESHOLD {
             expires_at / 1000
         } else {
             expires_at
-        };
+        }
+    }
 
-        let ledgers_to_live = if expires_at_secs > current_timestamp {
+    /// Helper to cleanly extend session key TTL.
+    /// `expires_at` must already be normalized to seconds.
+    fn extend_session_key_ttl(env: &Env, public_key: &BytesN<32>, expires_at: u64) {
+        let current_timestamp = env.ledger().timestamp();
+
+        let ledgers_to_live = if expires_at > current_timestamp {
             // Using 4 seconds-per-ledger + 1 day buffer to guarantee it outlives expiry
-            ((expires_at_secs - current_timestamp) / 4) as u32 + DAY_IN_LEDGERS
+            ((expires_at - current_timestamp) / 4) as u32 + DAY_IN_LEDGERS
         } else {
             DAY_IN_LEDGERS // 1 day default buffer
         };
@@ -800,6 +818,77 @@ mod test {
         let result = client.try_refresh_session_key_ttl(&unknown_session_pk);
 
         assert_eq!(result, Err(Ok(ContractError::SessionKeyNotFound)));
+    }
+
+    #[test]
+    fn test_add_session_key_normalizes_milliseconds_expiry_to_seconds() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, AncoreAccount);
+        let client = AncoreAccountClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.initialize(&owner);
+        env.mock_all_auths();
+
+        let session_pk = BytesN::from_array(&env, &[3u8; 32]);
+        let expires_at_seconds = env.ledger().timestamp() + 10_000;
+        let expires_at_millis = expires_at_seconds * 1000;
+        let permissions = Vec::new(&env);
+
+        client.add_session_key(&session_pk, &expires_at_millis, &permissions);
+        let session_key = client.get_session_key(&session_pk).unwrap();
+
+        assert_eq!(session_key.expires_at, expires_at_seconds);
+    }
+
+    #[test]
+    fn test_add_session_key_keeps_seconds_expiry_unchanged() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, AncoreAccount);
+        let client = AncoreAccountClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.initialize(&owner);
+        env.mock_all_auths();
+
+        let session_pk = BytesN::from_array(&env, &[4u8; 32]);
+        let expires_at_seconds = env.ledger().timestamp() + 5_000;
+        let permissions = Vec::new(&env);
+
+        client.add_session_key(&session_pk, &expires_at_seconds, &permissions);
+        let session_key = client.get_session_key(&session_pk).unwrap();
+
+        assert_eq!(session_key.expires_at, expires_at_seconds);
+    }
+
+    #[test]
+    fn test_refresh_session_key_ttl_normalizes_legacy_milliseconds_expiry() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, AncoreAccount);
+        let client = AncoreAccountClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.initialize(&owner);
+
+        let session_pk = BytesN::from_array(&env, &[5u8; 32]);
+        let expires_at_seconds = env.ledger().timestamp() + 8_000;
+        let legacy_expires_at_millis = expires_at_seconds * 1000;
+        let permissions = Vec::new(&env);
+
+        // Seed legacy milliseconds-based data directly to validate refresh-path normalization.
+        let legacy_session = SessionKey {
+            public_key: session_pk.clone(),
+            expires_at: legacy_expires_at_millis,
+            permissions,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::SessionKey(session_pk.clone()), &legacy_session);
+
+        client.refresh_session_key_ttl(&session_pk);
+        let refreshed = client.get_session_key(&session_pk).unwrap();
+
+        assert_eq!(refreshed.expires_at, expires_at_seconds);
     }
 
     #[test]

--- a/contracts/account/src/lib.rs
+++ b/contracts/account/src/lib.rs
@@ -1155,6 +1155,41 @@ mod test {
     }
 
     #[test]
+    fn test_upgrade_owner_path_succeeds_and_increments_version() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, AncoreAccount);
+        let client = AncoreAccountClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.initialize(&owner);
+        assert_eq!(client.get_version(), 1);
+
+        env.mock_all_auths();
+        let wasm_hash = BytesN::from_array(&env, &[42u8; 32]);
+        let _ = client.try_upgrade(&wasm_hash);
+
+        // Owner-authorized upgrade should increment version.
+        assert_eq!(client.get_version(), 2);
+    }
+
+    #[test]
+    fn test_upgrade_non_owner_is_rejected_and_version_unchanged() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, AncoreAccount);
+        let client = AncoreAccountClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.initialize(&owner);
+        assert_eq!(client.get_version(), 1);
+
+        // No owner auth is provided; require_auth() should reject this upgrade attempt.
+        let wasm_hash = BytesN::from_array(&env, &[7u8; 32]);
+        let result = client.try_upgrade(&wasm_hash);
+        assert!(result.is_err());
+        assert_eq!(client.get_version(), 1);
+    }
+
+    #[test]
     fn test_storage_key_growth_with_high_session_key_count() {
         let env = Env::default();
         let contract_id = env.register_contract(None, AncoreAccount);

--- a/contracts/account/src/lib.rs
+++ b/contracts/account/src/lib.rs
@@ -1153,4 +1153,96 @@ mod test {
         let res_u64: u64 = soroban_sdk::FromVal::from_val(&env, &result);
         assert_eq!(res_u64, 0);
     }
+
+    #[test]
+    fn test_storage_key_growth_with_high_session_key_count() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, AncoreAccount);
+        let client = AncoreAccountClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.initialize(&owner);
+        env.mock_all_auths();
+
+        let high_count: u8 = 96;
+        let expires_at = env.ledger().timestamp() + 86_400;
+        let mut permissions = Vec::new(&env);
+        permissions.push_back(PERMISSION_EXECUTE);
+
+        // Add a high number of session keys and assert each key is independently persisted.
+        for i in 0..high_count {
+            let mut bytes = [0u8; 32];
+            bytes[0] = i;
+            bytes[31] = 255u8.saturating_sub(i);
+            let session_pk = BytesN::from_array(&env, &bytes);
+            client.add_session_key(&session_pk, &expires_at, &permissions);
+        }
+
+        for i in 0..high_count {
+            let mut bytes = [0u8; 32];
+            bytes[0] = i;
+            bytes[31] = 255u8.saturating_sub(i);
+            let session_pk = BytesN::from_array(&env, &bytes);
+            assert!(client.has_session_key(&session_pk));
+            assert!(client.get_session_key(&session_pk).is_some());
+        }
+
+        // Validate rejection behavior on an unknown key after high-growth writes.
+        let unknown_pk = BytesN::from_array(&env, &[7u8; 32]);
+        assert_eq!(
+            client.try_refresh_session_key_ttl(&unknown_pk),
+            Err(Ok(ContractError::SessionKeyNotFound))
+        );
+    }
+
+    #[test]
+    fn test_instance_ttl_bump_threshold_policy_read_vs_write_paths() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, AncoreAccount);
+        let client = AncoreAccountClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        client.initialize(&owner);
+        env.mock_all_auths();
+
+        let before_read_ttl = env.storage().instance().get_ttl();
+        let _ = client.get_owner();
+        let after_read_ttl = env.storage().instance().get_ttl();
+        assert_eq!(
+            after_read_ttl, before_read_ttl,
+            "read paths should not force instance TTL extension"
+        );
+
+        // Move ledger near expiry so write-path extend_ttl threshold definitely applies.
+        env.ledger().set_sequence_number(
+            env.ledger()
+                .sequence()
+                .saturating_add(INSTANCE_BUMP_AMOUNT as u32),
+        );
+
+        let pre_write_ttl = env.storage().instance().get_ttl();
+        let callee_id = env.register_contract(None, AncoreAccount);
+        let function = soroban_sdk::symbol_short!("get_nonce");
+        let args = Vec::new(&env);
+        let _ = client.execute(
+            &CallerIdentity::Owner,
+            &callee_id,
+            &function,
+            &args,
+            &0u64,
+            &None,
+            &None,
+            &None,
+        );
+        let post_write_ttl = env.storage().instance().get_ttl();
+
+        assert!(
+            post_write_ttl >= INSTANCE_BUMP_THRESHOLD,
+            "write paths must restore TTL above threshold"
+        );
+        assert!(
+            post_write_ttl > pre_write_ttl,
+            "write paths should increase TTL when below threshold"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add account-contract guardrail tests for storage growth and instance TTL bump policy under realistic usage
- harden extension unlock flows by validating storage unlock boolean results and failing closed on invalid credentials
- add explicit contract authorization tests for upgrade boundaries, including non-owner rejection and owner success-path preservation

## Security impact
- prevents fail-open unlock transitions in extension auth flow
- ensures invalid credentials never transition into authenticated routes
- enforces owner-only privilege boundary on contract upgrade via regression tests

## Test plan
- [ ] `cd contracts && cargo test -p ancore-account`
- [ ] `pnpm --filter extension-wallet test -- src/security/__tests__/lock-manager.test.ts src/router/__tests__/router.test.tsx`
- [ ] verify invalid unlock credentials keep user on `/unlock` with error state
- [ ] verify non-owner upgrade attempt fails and owner upgrade increments version

Closes #209
Closes #260
Closes #261