### PR TITLE
Feat/indexer ingest pipeline

### DIFF
--- a/services/indexer/Cargo.toml
+++ b/services/indexer/Cargo.toml
@@ -31,6 +31,9 @@ base64 = "0.22"
 thiserror = "1"
 anyhow = "1"
 
+# Async trait support
+async-trait = "0.1"
+
 # Tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/services/indexer/migrations/002_create_ingest_checkpoints_table.sql
+++ b/services/indexer/migrations/002_create_ingest_checkpoints_table.sql
@@ -1,0 +1,7 @@
+-- Stores the last successfully processed ledger sequence per ingestion stream.
+-- Allows the worker to resume from the correct position after a restart.
+CREATE TABLE IF NOT EXISTS ingest_checkpoints (
+    stream          VARCHAR(64)  PRIMARY KEY,
+    last_ledger_seq BIGINT       NOT NULL,
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);

--- a/services/indexer/src/ingest/checkpoint.rs
+++ b/services/indexer/src/ingest/checkpoint.rs
@@ -1,0 +1,125 @@
+//! Checkpoint cursor persistence.
+//!
+//! The checkpoint records the last successfully processed ledger sequence so
+//! the ingestion worker can resume from the correct position after a restart.
+
+use anyhow::Context;
+use sqlx::PgPool;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// A persisted ingestion checkpoint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Checkpoint {
+    /// Name of the ingestion stream (allows multiple independent workers).
+    pub stream: String,
+    /// Last ledger sequence that was fully processed and committed.
+    pub last_ledger_seq: u32,
+}
+
+// ── Repository ────────────────────────────────────────────────────────────────
+
+/// Load the current checkpoint for `stream`, returning `None` if no checkpoint
+/// exists yet (i.e. first run).
+pub async fn load(db: &PgPool, stream: &str) -> anyhow::Result<Option<Checkpoint>> {
+    let row = sqlx::query!(
+        r#"
+        SELECT last_ledger_seq
+        FROM ingest_checkpoints
+        WHERE stream = $1
+        "#,
+        stream
+    )
+    .fetch_optional(db)
+    .await
+    .context("load checkpoint")?;
+
+    Ok(row.map(|r| Checkpoint {
+        stream: stream.to_owned(),
+        last_ledger_seq: r.last_ledger_seq as u32,
+    }))
+}
+
+/// Persist (upsert) a checkpoint.
+pub async fn save(db: &PgPool, checkpoint: &Checkpoint) -> anyhow::Result<()> {
+    sqlx::query!(
+        r#"
+        INSERT INTO ingest_checkpoints (stream, last_ledger_seq, updated_at)
+        VALUES ($1, $2, NOW())
+        ON CONFLICT (stream)
+        DO UPDATE SET last_ledger_seq = EXCLUDED.last_ledger_seq,
+                      updated_at      = EXCLUDED.updated_at
+        "#,
+        checkpoint.stream,
+        checkpoint.last_ledger_seq as i64,
+    )
+    .execute(db)
+    .await
+    .context("save checkpoint")?;
+
+    Ok(())
+}
+
+// ── In-memory stub (used in unit tests) ──────────────────────────────────────
+
+/// A simple in-memory checkpoint store for unit testing without a real DB.
+#[derive(Debug, Default)]
+pub struct MemoryCheckpointStore {
+    inner: std::collections::HashMap<String, u32>,
+}
+
+impl MemoryCheckpointStore {
+    pub fn load(&self, stream: &str) -> Option<Checkpoint> {
+        self.inner.get(stream).map(|&seq| Checkpoint {
+            stream: stream.to_owned(),
+            last_ledger_seq: seq,
+        })
+    }
+
+    pub fn save(&mut self, checkpoint: &Checkpoint) {
+        self.inner
+            .insert(checkpoint.stream.clone(), checkpoint.last_ledger_seq);
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_store_returns_none_on_first_run() {
+        let store = MemoryCheckpointStore::default();
+        assert!(store.load("main").is_none());
+    }
+
+    #[test]
+    fn memory_store_roundtrip() {
+        let mut store = MemoryCheckpointStore::default();
+        let cp = Checkpoint {
+            stream: "main".into(),
+            last_ledger_seq: 42,
+        };
+        store.save(&cp);
+        let loaded = store.load("main").unwrap();
+        assert_eq!(loaded.last_ledger_seq, 42);
+    }
+
+    #[test]
+    fn memory_store_upserts() {
+        let mut store = MemoryCheckpointStore::default();
+        store.save(&Checkpoint { stream: "main".into(), last_ledger_seq: 10 });
+        store.save(&Checkpoint { stream: "main".into(), last_ledger_seq: 20 });
+        assert_eq!(store.load("main").unwrap().last_ledger_seq, 20);
+    }
+
+    #[test]
+    fn memory_store_independent_streams() {
+        let mut store = MemoryCheckpointStore::default();
+        store.save(&Checkpoint { stream: "a".into(), last_ledger_seq: 1 });
+        store.save(&Checkpoint { stream: "b".into(), last_ledger_seq: 99 });
+        assert_eq!(store.load("a").unwrap().last_ledger_seq, 1);
+        assert_eq!(store.load("b").unwrap().last_ledger_seq, 99);
+    }
+}

--- a/services/indexer/src/ingest/mod.rs
+++ b/services/indexer/src/ingest/mod.rs
@@ -1,0 +1,9 @@
+pub mod checkpoint;
+pub mod sink;
+pub mod source;
+pub mod worker;
+
+pub use checkpoint::{Checkpoint, MemoryCheckpointStore};
+pub use sink::{EventSink, MemorySink};
+pub use source::{EventSource, VecSource};
+pub use worker::{BatchStats, IngestWorker, WorkerConfig};

--- a/services/indexer/src/ingest/sink.rs
+++ b/services/indexer/src/ingest/sink.rs
@@ -1,0 +1,41 @@
+//! Event sink abstraction.
+//!
+//! In production this writes to the `account_activity` Postgres table.
+//! For tests a [`MemorySink`] is provided.
+
+use crate::schema::canonical::CanonicalEvent;
+
+/// Trait for anything that can durably store canonical events.
+#[async_trait::async_trait]
+pub trait EventSink: Send {
+    /// Persist a batch of canonical events atomically.
+    async fn persist(&mut self, events: &[CanonicalEvent]) -> anyhow::Result<()>;
+}
+
+// ── In-memory sink (tests) ────────────────────────────────────────────────────
+
+/// Accumulates persisted events in memory for assertion in tests.
+#[derive(Debug, Default)]
+pub struct MemorySink {
+    pub events: Vec<CanonicalEvent>,
+}
+
+#[async_trait::async_trait]
+impl EventSink for MemorySink {
+    async fn persist(&mut self, events: &[CanonicalEvent]) -> anyhow::Result<()> {
+        self.events.extend_from_slice(events);
+        Ok(())
+    }
+}
+
+// ── Failing sink (tests) ──────────────────────────────────────────────────────
+
+/// A sink that always returns an error — used to test persist-failure paths.
+pub struct FailingSink;
+
+#[async_trait::async_trait]
+impl EventSink for FailingSink {
+    async fn persist(&mut self, _events: &[CanonicalEvent]) -> anyhow::Result<()> {
+        Err(anyhow::anyhow!("simulated sink failure"))
+    }
+}

--- a/services/indexer/src/ingest/source.rs
+++ b/services/indexer/src/ingest/source.rs
@@ -1,0 +1,34 @@
+//! Event source abstraction.
+//!
+//! In production this would be backed by a Stellar Horizon/RPC streaming
+//! client.  For tests a simple [`VecSource`] is provided.
+
+use crate::schema::canonical::RawEvent;
+
+/// Trait for anything that can supply raw events to the ingestion worker.
+#[async_trait::async_trait]
+pub trait EventSource: Send {
+    /// Fetch up to `limit` events with `ledger_seq > after_ledger`.
+    async fn fetch(&mut self, after_ledger: u32, limit: usize) -> anyhow::Result<Vec<RawEvent>>;
+}
+
+// ── In-memory source (tests) ──────────────────────────────────────────────────
+
+/// A one-shot source backed by a pre-loaded `Vec`.
+/// Drains the vector on the first call; subsequent calls return empty.
+pub struct VecSource {
+    events: Vec<RawEvent>,
+}
+
+impl VecSource {
+    pub fn new(events: Vec<RawEvent>) -> Self {
+        Self { events }
+    }
+}
+
+#[async_trait::async_trait]
+impl EventSource for VecSource {
+    async fn fetch(&mut self, _after_ledger: u32, _limit: usize) -> anyhow::Result<Vec<RawEvent>> {
+        Ok(std::mem::take(&mut self.events))
+    }
+}

--- a/services/indexer/src/ingest/worker.rs
+++ b/services/indexer/src/ingest/worker.rs
@@ -1,0 +1,281 @@
+//! Ingestion worker.
+//!
+//! [`IngestWorker`] pulls batches of [`RawEvent`]s from a source, normalises
+//! them into [`CanonicalEvent`]s, persists them, and advances the checkpoint
+//! cursor.  Out-of-order events (ledger_seq ≤ last checkpoint) are silently
+//! skipped to guarantee idempotent restarts.
+
+use anyhow::Context;
+use tracing::{debug, info, warn};
+
+use crate::schema::canonical::{normalise, CanonicalEvent, RawEvent};
+use super::checkpoint::{Checkpoint, MemoryCheckpointStore};
+use super::sink::EventSink;
+use super::source::EventSource;
+
+// ── Worker ────────────────────────────────────────────────────────────────────
+
+/// Configuration for the ingestion worker.
+#[derive(Debug, Clone)]
+pub struct WorkerConfig {
+    /// Logical name of this ingestion stream (used as checkpoint key).
+    pub stream: String,
+    /// Number of events to process per batch.
+    pub batch_size: usize,
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            stream: "main".into(),
+            batch_size: 100,
+        }
+    }
+}
+
+/// Statistics collected during a single [`IngestWorker::run_once`] call.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct BatchStats {
+    pub fetched: usize,
+    pub skipped: usize,
+    pub normalised: usize,
+    pub persisted: usize,
+    pub errors: usize,
+}
+
+/// The ingestion worker.
+///
+/// Designed to be testable without a real database: the checkpoint store,
+/// event source, and event sink are all injected as trait objects.
+pub struct IngestWorker<Src, Snk> {
+    config: WorkerConfig,
+    checkpoint: MemoryCheckpointStore,
+    source: Src,
+    sink: Snk,
+}
+
+impl<Src, Snk> IngestWorker<Src, Snk>
+where
+    Src: EventSource,
+    Snk: EventSink,
+{
+    pub fn new(config: WorkerConfig, source: Src, sink: Snk) -> Self {
+        Self {
+            config,
+            checkpoint: MemoryCheckpointStore::default(),
+            source,
+            sink,
+        }
+    }
+
+    /// Seed the worker with an existing checkpoint (e.g. loaded from DB on startup).
+    pub fn with_checkpoint(mut self, cp: Checkpoint) -> Self {
+        self.checkpoint.save(&cp);
+        self
+    }
+
+    /// Process one batch of events.
+    ///
+    /// Returns [`BatchStats`] describing what happened.
+    pub async fn run_once(&mut self) -> anyhow::Result<BatchStats> {
+        let last_seq = self
+            .checkpoint
+            .load(&self.config.stream)
+            .map(|c| c.last_ledger_seq)
+            .unwrap_or(0);
+
+        let raw_events = self
+            .source
+            .fetch(last_seq, self.config.batch_size)
+            .await
+            .context("fetch events from source")?;
+
+        let mut stats = BatchStats {
+            fetched: raw_events.len(),
+            ..Default::default()
+        };
+
+        if raw_events.is_empty() {
+            debug!(stream = %self.config.stream, "no new events");
+            return Ok(stats);
+        }
+
+        let mut canonical: Vec<CanonicalEvent> = Vec::with_capacity(raw_events.len());
+        let mut max_ledger = last_seq;
+
+        for raw in raw_events {
+            // Skip out-of-order / already-processed events
+            if raw.ledger_seq <= last_seq {
+                warn!(
+                    ledger_seq = raw.ledger_seq,
+                    last_seq,
+                    "skipping out-of-order event"
+                );
+                stats.skipped += 1;
+                continue;
+            }
+
+            match normalise(raw) {
+                Ok(ev) => {
+                    max_ledger = max_ledger.max(ev.ledger_seq);
+                    canonical.push(ev);
+                    stats.normalised += 1;
+                }
+                Err(e) => {
+                    warn!(error = %e, "failed to normalise event, skipping");
+                    stats.errors += 1;
+                }
+            }
+        }
+
+        if !canonical.is_empty() {
+            self.sink
+                .persist(&canonical)
+                .await
+                .context("persist canonical events")?;
+            stats.persisted = canonical.len();
+
+            // Advance checkpoint only after successful persist
+            self.checkpoint.save(&Checkpoint {
+                stream: self.config.stream.clone(),
+                last_ledger_seq: max_ledger,
+            });
+
+            info!(
+                stream = %self.config.stream,
+                persisted = stats.persisted,
+                max_ledger,
+                "batch committed"
+            );
+        }
+
+        Ok(stats)
+    }
+
+    /// Current checkpoint (for inspection / testing).
+    pub fn current_checkpoint(&self) -> Option<Checkpoint> {
+        self.checkpoint.load(&self.config.stream)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ingest::sink::MemorySink;
+    use crate::ingest::source::VecSource;
+    use chrono::Utc;
+
+    fn raw(ledger_seq: u32, topic: &str) -> RawEvent {
+        RawEvent {
+            ledger_seq,
+            ledger_close_time: Utc::now(),
+            tx_hash: format!("{:0>64}", ledger_seq),
+            contract_id: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN".into(),
+            topics: vec![topic.into()],
+            data: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn processes_events_and_advances_checkpoint() {
+        let source = VecSource::new(vec![raw(1, "transfer"), raw(2, "execute")]);
+        let sink = MemorySink::default();
+        let mut worker = IngestWorker::new(WorkerConfig::default(), source, sink);
+
+        let stats = worker.run_once().await.unwrap();
+
+        assert_eq!(stats.fetched, 2);
+        assert_eq!(stats.normalised, 2);
+        assert_eq!(stats.persisted, 2);
+        assert_eq!(stats.skipped, 0);
+        assert_eq!(worker.current_checkpoint().unwrap().last_ledger_seq, 2);
+    }
+
+    #[tokio::test]
+    async fn skips_out_of_order_events() {
+        let source = VecSource::new(vec![raw(5, "transfer"), raw(3, "transfer")]);
+        let sink = MemorySink::default();
+        // Seed checkpoint at ledger 4 — ledger 3 is behind, ledger 5 is ahead
+        let mut worker = IngestWorker::new(WorkerConfig::default(), source, sink)
+            .with_checkpoint(Checkpoint { stream: "main".into(), last_ledger_seq: 4 });
+
+        let stats = worker.run_once().await.unwrap();
+
+        assert_eq!(stats.fetched, 2);
+        assert_eq!(stats.skipped, 1);   // ledger 3 skipped
+        assert_eq!(stats.normalised, 1); // ledger 5 processed
+        assert_eq!(worker.current_checkpoint().unwrap().last_ledger_seq, 5);
+    }
+
+    #[tokio::test]
+    async fn restart_recovery_resumes_from_checkpoint() {
+        // First run: process ledgers 1-3
+        let source1 = VecSource::new(vec![raw(1, "transfer"), raw(2, "transfer"), raw(3, "transfer")]);
+        let sink = MemorySink::default();
+        let mut worker = IngestWorker::new(WorkerConfig::default(), source1, sink);
+        worker.run_once().await.unwrap();
+
+        let cp = worker.current_checkpoint().unwrap();
+        assert_eq!(cp.last_ledger_seq, 3);
+
+        // Simulate restart: new worker seeded with saved checkpoint
+        let source2 = VecSource::new(vec![raw(2, "transfer"), raw(3, "transfer"), raw(4, "transfer")]);
+        let sink2 = MemorySink::default();
+        let mut worker2 = IngestWorker::new(WorkerConfig::default(), source2, sink2)
+            .with_checkpoint(cp);
+
+        let stats = worker2.run_once().await.unwrap();
+
+        // Ledgers 2 and 3 are behind the checkpoint — only 4 should be processed
+        assert_eq!(stats.skipped, 2);
+        assert_eq!(stats.normalised, 1);
+        assert_eq!(worker2.current_checkpoint().unwrap().last_ledger_seq, 4);
+    }
+
+    #[tokio::test]
+    async fn empty_source_returns_zero_stats() {
+        let source = VecSource::new(vec![]);
+        let sink = MemorySink::default();
+        let mut worker = IngestWorker::new(WorkerConfig::default(), source, sink);
+
+        let stats = worker.run_once().await.unwrap();
+
+        assert_eq!(stats.fetched, 0);
+        assert_eq!(stats.persisted, 0);
+        assert!(worker.current_checkpoint().is_none());
+    }
+
+    #[tokio::test]
+    async fn normalisation_error_increments_error_count() {
+        // A raw event with an empty tx_hash will fail normalisation
+        let mut bad = raw(10, "transfer");
+        bad.tx_hash = String::new();
+
+        let source = VecSource::new(vec![bad, raw(11, "transfer")]);
+        let sink = MemorySink::default();
+        let mut worker = IngestWorker::new(WorkerConfig::default(), source, sink);
+
+        let stats = worker.run_once().await.unwrap();
+
+        assert_eq!(stats.errors, 1);
+        assert_eq!(stats.normalised, 1);
+        // Checkpoint advances to the highest successfully processed ledger
+        assert_eq!(worker.current_checkpoint().unwrap().last_ledger_seq, 11);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_not_advanced_when_nothing_persisted() {
+        let source = VecSource::new(vec![raw(1, "transfer")]);
+        let sink = MemorySink::default();
+        // Checkpoint already at 5 — ledger 1 will be skipped
+        let mut worker = IngestWorker::new(WorkerConfig::default(), source, sink)
+            .with_checkpoint(Checkpoint { stream: "main".into(), last_ledger_seq: 5 });
+
+        worker.run_once().await.unwrap();
+
+        // Checkpoint must not regress
+        assert_eq!(worker.current_checkpoint().unwrap().last_ledger_seq, 5);
+    }
+}

--- a/services/indexer/src/lib.rs
+++ b/services/indexer/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod api;
 pub mod error;
+pub mod ingest;
 pub mod repositories;
+pub mod schema;

--- a/services/indexer/src/schema/canonical.rs
+++ b/services/indexer/src/schema/canonical.rs
@@ -1,0 +1,244 @@
+//! Canonical internal event schema.
+//!
+//! Raw contract events from the Stellar network are normalised into
+//! [`CanonicalEvent`] before being persisted or forwarded downstream.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ── Event kind ────────────────────────────────────────────────────────────────
+
+/// High-level classification of a contract event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    /// Native XLM or asset transfer between accounts.
+    Transfer,
+    /// Session key registered on an account contract.
+    SessionKeyAdded,
+    /// Session key revoked from an account contract.
+    SessionKeyRevoked,
+    /// Relayed transaction executed via the account contract.
+    RelayExecuted,
+    /// Any event that does not map to a known kind.
+    Unknown,
+}
+
+impl std::fmt::Display for EventKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            EventKind::Transfer => "transfer",
+            EventKind::SessionKeyAdded => "session_key_added",
+            EventKind::SessionKeyRevoked => "session_key_revoked",
+            EventKind::RelayExecuted => "relay_executed",
+            EventKind::Unknown => "unknown",
+        };
+        write!(f, "{s}")
+    }
+}
+
+// ── Raw event (source) ────────────────────────────────────────────────────────
+
+/// A raw contract event as received from the Stellar horizon/RPC stream.
+/// Fields mirror the Stellar contract event structure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawEvent {
+    /// Ledger sequence number the event was emitted in.
+    pub ledger_seq: u32,
+    /// Ledger close time (UTC).
+    pub ledger_close_time: DateTime<Utc>,
+    /// Transaction hash (hex-encoded, 64 chars).
+    pub tx_hash: String,
+    /// Contract address that emitted the event.
+    pub contract_id: String,
+    /// Event topic list (XDR base64-encoded SCVal entries).
+    pub topics: Vec<String>,
+    /// Event data payload (XDR base64-encoded SCVal).
+    pub data: String,
+}
+
+// ── Canonical event ───────────────────────────────────────────────────────────
+
+/// Normalised, internal representation of a contract event.
+/// This is the schema written to the database and consumed by downstream services.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CanonicalEvent {
+    /// Stable internal identifier (UUIDv4).
+    pub id: Uuid,
+    /// Classified event kind.
+    pub kind: EventKind,
+    /// Primary account address this event is attributed to.
+    pub account_id: String,
+    /// Ledger sequence number.
+    pub ledger_seq: u32,
+    /// Ledger close time (UTC) — used as the canonical event timestamp.
+    pub occurred_at: DateTime<Utc>,
+    /// Transaction hash.
+    pub tx_hash: String,
+    /// Originating contract address.
+    pub contract_id: String,
+    /// Optional transfer amount (string to preserve precision).
+    pub amount: Option<String>,
+    /// Optional asset identifier (e.g. "native" or "USDC:G...").
+    pub asset: Option<String>,
+    /// Optional counterparty address (recipient / revoker / etc.).
+    pub counterparty: Option<String>,
+    /// Full raw event preserved for auditability.
+    pub raw: RawEvent,
+}
+
+impl CanonicalEvent {
+    /// Derive the activity_type string used in the `account_activity` table.
+    pub fn activity_type(&self) -> String {
+        self.kind.to_string()
+    }
+}
+
+// ── Normaliser ────────────────────────────────────────────────────────────────
+
+/// Errors that can occur during event normalisation.
+#[derive(Debug, thiserror::Error)]
+pub enum NormaliseError {
+    #[error("Missing required field: {0}")]
+    MissingField(&'static str),
+    #[error("Malformed field '{field}': {reason}")]
+    MalformedField { field: &'static str, reason: String },
+}
+
+/// Normalise a [`RawEvent`] into a [`CanonicalEvent`].
+///
+/// The function is intentionally lenient: unknown event shapes are mapped to
+/// [`EventKind::Unknown`] rather than returning an error, so the pipeline
+/// never stalls on unrecognised events.
+pub fn normalise(raw: RawEvent) -> Result<CanonicalEvent, NormaliseError> {
+    if raw.tx_hash.is_empty() {
+        return Err(NormaliseError::MissingField("tx_hash"));
+    }
+    if raw.contract_id.is_empty() {
+        return Err(NormaliseError::MissingField("contract_id"));
+    }
+
+    let kind = classify_event(&raw.topics);
+
+    // The primary account is the contract that emitted the event.
+    // Downstream enrichment can override this for transfer events.
+    let account_id = raw.contract_id.clone();
+
+    // Extract optional transfer fields from topics / data heuristically.
+    // Real implementations would decode XDR; here we use positional conventions.
+    let (amount, asset, counterparty) = extract_transfer_fields(&kind, &raw.topics);
+
+    Ok(CanonicalEvent {
+        id: Uuid::new_v4(),
+        kind,
+        account_id,
+        ledger_seq: raw.ledger_seq,
+        occurred_at: raw.ledger_close_time,
+        tx_hash: raw.tx_hash.clone(),
+        contract_id: raw.contract_id.clone(),
+        amount,
+        asset,
+        counterparty,
+        raw,
+    })
+}
+
+/// Classify an event based on its topic list.
+///
+/// Convention (mirrors Soroban contract SDK event emission):
+///   topics[0] = event name / discriminant
+fn classify_event(topics: &[String]) -> EventKind {
+    match topics.first().map(String::as_str) {
+        Some("transfer") => EventKind::Transfer,
+        Some("session_key_added") | Some("add_session_key") => EventKind::SessionKeyAdded,
+        Some("session_key_revoked") | Some("revoke_session_key") => EventKind::SessionKeyRevoked,
+        Some("relay_executed") | Some("execute") => EventKind::RelayExecuted,
+        _ => EventKind::Unknown,
+    }
+}
+
+/// Extract transfer-related fields from topics using positional convention:
+///   topics[1] = asset, topics[2] = counterparty, data = amount
+fn extract_transfer_fields(
+    kind: &EventKind,
+    topics: &[String],
+) -> (Option<String>, Option<String>, Option<String>) {
+    if *kind != EventKind::Transfer {
+        return (None, None, topics.get(1).cloned());
+    }
+    let asset = topics.get(1).cloned();
+    let counterparty = topics.get(2).cloned();
+    let amount = topics.get(3).cloned();
+    (amount, asset, counterparty)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn make_raw(topics: Vec<&str>) -> RawEvent {
+        RawEvent {
+            ledger_seq: 100,
+            ledger_close_time: Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0).unwrap(),
+            tx_hash: "a".repeat(64),
+            contract_id: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN".to_string(),
+            topics: topics.iter().map(|s| s.to_string()).collect(),
+            data: String::new(),
+        }
+    }
+
+    #[test]
+    fn normalise_transfer_event() {
+        let raw = RawEvent {
+            topics: vec![
+                "transfer".into(),
+                "native".into(),
+                "GBXXX".into(),
+                "100.0000000".into(),
+            ],
+            ..make_raw(vec![])
+        };
+        let ev = normalise(raw).unwrap();
+        assert_eq!(ev.kind, EventKind::Transfer);
+        assert_eq!(ev.asset.as_deref(), Some("native"));
+        assert_eq!(ev.counterparty.as_deref(), Some("GBXXX"));
+        assert_eq!(ev.amount.as_deref(), Some("100.0000000"));
+    }
+
+    #[test]
+    fn normalise_session_key_added() {
+        let ev = normalise(make_raw(vec!["session_key_added", "GBSESSIONKEY"])).unwrap();
+        assert_eq!(ev.kind, EventKind::SessionKeyAdded);
+        assert_eq!(ev.activity_type(), "session_key_added");
+    }
+
+    #[test]
+    fn normalise_unknown_event() {
+        let ev = normalise(make_raw(vec!["some_future_event"])).unwrap();
+        assert_eq!(ev.kind, EventKind::Unknown);
+    }
+
+    #[test]
+    fn normalise_rejects_empty_tx_hash() {
+        let mut raw = make_raw(vec!["transfer"]);
+        raw.tx_hash = String::new();
+        assert!(matches!(normalise(raw), Err(NormaliseError::MissingField("tx_hash"))));
+    }
+
+    #[test]
+    fn normalise_rejects_empty_contract_id() {
+        let mut raw = make_raw(vec!["transfer"]);
+        raw.contract_id = String::new();
+        assert!(matches!(normalise(raw), Err(NormaliseError::MissingField("contract_id"))));
+    }
+
+    #[test]
+    fn activity_type_string_matches_kind() {
+        assert_eq!(EventKind::Transfer.to_string(), "transfer");
+        assert_eq!(EventKind::RelayExecuted.to_string(), "relay_executed");
+    }
+}

--- a/services/indexer/src/schema/mod.rs
+++ b/services/indexer/src/schema/mod.rs
@@ -1,0 +1,3 @@
+pub mod canonical;
+
+pub use canonical::*;

--- a/services/relayer/src/queue/JobQueue.ts
+++ b/services/relayer/src/queue/JobQueue.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from 'crypto';
+import type { Job, EnqueueOptions, DequeueResult, JobStatus } from './types';
+import { nextRetryAfter } from './backoff';
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+
+/**
+ * In-memory job queue with idempotency, retry/backoff, and dead-letter support.
+ *
+ * Designed to be swapped for a persistent backend (Redis, Postgres, etc.) by
+ * implementing the same interface.
+ */
+export class JobQueue {
+  /** Primary store: jobId → Job */
+  private readonly jobs = new Map<string, Job>();
+  /** Idempotency index: idempotencyKey → jobId */
+  private readonly idempotencyIndex = new Map<string, string>();
+
+  // ── Enqueue ────────────────────────────────────────────────────────────────
+
+  /**
+   * Enqueue a new job.
+   *
+   * If a job with the same `idempotencyKey` already exists and is not in a
+   * terminal state (`completed` | `dead`), the existing job is returned
+   * unchanged (duplicate suppression).
+   *
+   * @returns The newly created job, or the existing job if suppressed.
+   */
+  enqueue(options: EnqueueOptions): Job {
+    const { idempotencyKey, type, payload, maxAttempts = DEFAULT_MAX_ATTEMPTS } = options;
+
+    const existingId = this.idempotencyIndex.get(idempotencyKey);
+    if (existingId) {
+      const existing = this.jobs.get(existingId);
+      if (existing && !this.isTerminal(existing.status)) {
+        // Duplicate — return existing job without re-enqueuing
+        return existing;
+      }
+    }
+
+    const now = new Date().toISOString();
+    const job: Job = {
+      id: randomUUID(),
+      idempotencyKey,
+      type,
+      payload,
+      status: 'pending',
+      attempts: 0,
+      maxAttempts,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.jobs.set(job.id, job);
+    this.idempotencyIndex.set(idempotencyKey, job.id);
+    return job;
+  }
+
+  // ── Dequeue ────────────────────────────────────────────────────────────────
+
+  /**
+   * Dequeue the next eligible pending job (FIFO by `createdAt`).
+   *
+   * Returns `null` when no eligible job is available.
+   * The caller must call `ack()` on success or `nack(error)` on failure.
+   */
+  dequeue<T = unknown>(): DequeueResult<T> | null {
+    const now = new Date();
+
+    const candidate = [...this.jobs.values()]
+      .filter((j) => {
+        if (j.status !== 'pending') return false;
+        if (j.retryAfter && new Date(j.retryAfter) > now) return false;
+        return true;
+      })
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt))[0];
+
+    if (!candidate) return null;
+
+    this.update(candidate.id, { status: 'processing', updatedAt: new Date().toISOString() });
+    const job = this.jobs.get(candidate.id) as Job<T>;
+
+    return {
+      job,
+      ack: () => this.ack(job.id),
+      nack: (error: Error) => this.nack(job.id, error),
+    };
+  }
+
+  // ── Accessors ──────────────────────────────────────────────────────────────
+
+  getById(id: string): Job | undefined {
+    return this.jobs.get(id);
+  }
+
+  getByIdempotencyKey(key: string): Job | undefined {
+    const id = this.idempotencyIndex.get(key);
+    return id ? this.jobs.get(id) : undefined;
+  }
+
+  /** All jobs currently in the dead-letter state */
+  getDeadLetterJobs(): Job[] {
+    return [...this.jobs.values()].filter((j) => j.status === 'dead');
+  }
+
+  size(): number {
+    return this.jobs.size;
+  }
+
+  // ── Internal ───────────────────────────────────────────────────────────────
+
+  private ack(id: string): void {
+    this.update(id, { status: 'completed', updatedAt: new Date().toISOString() });
+  }
+
+  private nack(id: string, error: Error): void {
+    const job = this.jobs.get(id);
+    if (!job) return;
+
+    const attempts = job.attempts + 1;
+
+    if (attempts >= job.maxAttempts) {
+      this.update(id, {
+        status: 'dead',
+        attempts,
+        lastError: error.message,
+        updatedAt: new Date().toISOString(),
+      });
+    } else {
+      this.update(id, {
+        status: 'pending',
+        attempts,
+        lastError: error.message,
+        retryAfter: nextRetryAfter(attempts),
+        updatedAt: new Date().toISOString(),
+      });
+    }
+  }
+
+  private update(id: string, patch: Partial<Job>): void {
+    const job = this.jobs.get(id);
+    if (!job) return;
+    this.jobs.set(id, { ...job, ...patch });
+  }
+
+  private isTerminal(status: JobStatus): boolean {
+    return status === 'completed' || status === 'dead';
+  }
+}

--- a/services/relayer/src/queue/__tests__/JobQueue.test.ts
+++ b/services/relayer/src/queue/__tests__/JobQueue.test.ts
@@ -1,0 +1,189 @@
+import { JobQueue } from '../JobQueue';
+
+describe('JobQueue', () => {
+  let queue: JobQueue;
+
+  beforeEach(() => {
+    queue = new JobQueue();
+  });
+
+  // ── Enqueue ────────────────────────────────────────────────────────────────
+
+  describe('enqueue', () => {
+    it('creates a pending job with the supplied payload', () => {
+      const job = queue.enqueue({
+        idempotencyKey: 'key-1',
+        type: 'relay_execute',
+        payload: { foo: 'bar' },
+      });
+
+      expect(job.status).toBe('pending');
+      expect(job.attempts).toBe(0);
+      expect(job.payload).toEqual({ foo: 'bar' });
+      expect(job.idempotencyKey).toBe('key-1');
+    });
+
+    it('suppresses duplicate jobs with the same idempotency key', () => {
+      const first = queue.enqueue({ idempotencyKey: 'dup', type: 'relay_execute', payload: {} });
+      const second = queue.enqueue({ idempotencyKey: 'dup', type: 'relay_execute', payload: {} });
+
+      expect(second.id).toBe(first.id);
+      expect(queue.size()).toBe(1);
+    });
+
+    it('allows re-enqueue after a job reaches terminal state (completed)', () => {
+      const first = queue.enqueue({ idempotencyKey: 'done', type: 'relay_execute', payload: {} });
+      const result = queue.dequeue()!;
+      result.ack();
+
+      const second = queue.enqueue({ idempotencyKey: 'done', type: 'relay_execute', payload: {} });
+      expect(second.id).not.toBe(first.id);
+    });
+
+    it('allows re-enqueue after a job reaches terminal state (dead)', () => {
+      queue.enqueue({
+        idempotencyKey: 'dead-key',
+        type: 'relay_execute',
+        payload: {},
+        maxAttempts: 1,
+      });
+
+      const result = queue.dequeue()!;
+      result.nack(new Error('boom'));
+
+      const second = queue.enqueue({
+        idempotencyKey: 'dead-key',
+        type: 'relay_execute',
+        payload: {},
+      });
+      expect(second.status).toBe('pending');
+    });
+  });
+
+  // ── Dequeue ────────────────────────────────────────────────────────────────
+
+  describe('dequeue', () => {
+    it('returns null when the queue is empty', () => {
+      expect(queue.dequeue()).toBeNull();
+    });
+
+    it('transitions job to processing on dequeue', () => {
+      queue.enqueue({ idempotencyKey: 'k1', type: 'relay_execute', payload: {} });
+      const result = queue.dequeue()!;
+      expect(result.job.status).toBe('processing');
+    });
+
+    it('does not return the same job twice before ack/nack', () => {
+      queue.enqueue({ idempotencyKey: 'k1', type: 'relay_execute', payload: {} });
+      queue.dequeue(); // first dequeue — job is now processing
+      const second = queue.dequeue();
+      expect(second).toBeNull();
+    });
+  });
+
+  // ── Ack ────────────────────────────────────────────────────────────────────
+
+  describe('ack', () => {
+    it('marks the job as completed', () => {
+      queue.enqueue({ idempotencyKey: 'k1', type: 'relay_execute', payload: {} });
+      const result = queue.dequeue()!;
+      result.ack();
+
+      const job = queue.getById(result.job.id)!;
+      expect(job.status).toBe('completed');
+    });
+  });
+
+  // ── Nack / retry ──────────────────────────────────────────────────────────
+
+  describe('nack', () => {
+    it('increments attempts and re-queues as pending on failure', () => {
+      queue.enqueue({
+        idempotencyKey: 'k1',
+        type: 'relay_execute',
+        payload: {},
+        maxAttempts: 3,
+      });
+      const result = queue.dequeue()!;
+      result.nack(new Error('transient'));
+
+      const job = queue.getById(result.job.id)!;
+      expect(job.status).toBe('pending');
+      expect(job.attempts).toBe(1);
+      expect(job.lastError).toBe('transient');
+    });
+
+    it('moves job to dead-letter when maxAttempts is reached', () => {
+      queue.enqueue({
+        idempotencyKey: 'k1',
+        type: 'relay_execute',
+        payload: {},
+        maxAttempts: 1,
+      });
+      const result = queue.dequeue()!;
+      result.nack(new Error('fatal'));
+
+      const job = queue.getById(result.job.id)!;
+      expect(job.status).toBe('dead');
+      expect(job.attempts).toBe(1);
+    });
+
+    it('records the last error message on dead-letter', () => {
+      queue.enqueue({
+        idempotencyKey: 'k1',
+        type: 'relay_execute',
+        payload: {},
+        maxAttempts: 1,
+      });
+      const result = queue.dequeue()!;
+      result.nack(new Error('something went wrong'));
+
+      const job = queue.getById(result.job.id)!;
+      expect(job.lastError).toBe('something went wrong');
+    });
+
+    it('exhausts retries across multiple dequeue cycles', () => {
+      queue.enqueue({
+        idempotencyKey: 'k1',
+        type: 'relay_execute',
+        payload: {},
+        maxAttempts: 3,
+      });
+
+      for (let i = 0; i < 2; i++) {
+        // Force retryAfter to be in the past so the job is immediately eligible
+        const job = queue.getByIdempotencyKey('k1')!;
+        // Patch retryAfter via re-enqueue trick: directly manipulate via getById
+        const stored = queue.getById(job.id) as unknown as Record<string, unknown>;
+        stored['retryAfter'] = new Date(0).toISOString();
+
+        const r = queue.dequeue()!;
+        r.nack(new Error(`attempt ${i + 1}`));
+      }
+
+      // Third attempt — should go dead
+      const job = queue.getByIdempotencyKey('k1')!;
+      const stored = queue.getById(job.id) as unknown as Record<string, unknown>;
+      stored['retryAfter'] = new Date(0).toISOString();
+
+      const last = queue.dequeue()!;
+      last.nack(new Error('final'));
+
+      expect(queue.getById(last.job.id)!.status).toBe('dead');
+    });
+  });
+
+  // ── Dead-letter ────────────────────────────────────────────────────────────
+
+  describe('getDeadLetterJobs', () => {
+    it('returns all dead jobs', () => {
+      queue.enqueue({ idempotencyKey: 'a', type: 'relay_execute', payload: {}, maxAttempts: 1 });
+      queue.enqueue({ idempotencyKey: 'b', type: 'relay_execute', payload: {}, maxAttempts: 1 });
+
+      queue.dequeue()!.nack(new Error('x'));
+      queue.dequeue()!.nack(new Error('y'));
+
+      expect(queue.getDeadLetterJobs()).toHaveLength(2);
+    });
+  });
+});

--- a/services/relayer/src/queue/__tests__/backoff.test.ts
+++ b/services/relayer/src/queue/__tests__/backoff.test.ts
@@ -1,0 +1,27 @@
+import { computeBackoffMs, nextRetryAfter } from '../backoff';
+
+describe('computeBackoffMs', () => {
+  it('returns 0 for attempt 0 with base 0', () => {
+    expect(computeBackoffMs(0, 0)).toBe(0);
+  });
+
+  it('never exceeds the cap', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(computeBackoffMs(i, 1_000, 60_000)).toBeLessThanOrEqual(60_000);
+    }
+  });
+
+  it('returns a non-negative value', () => {
+    for (let i = 0; i < 10; i++) {
+      expect(computeBackoffMs(i)).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe('nextRetryAfter', () => {
+  it('returns an ISO string in the future', () => {
+    const now = new Date();
+    const result = nextRetryAfter(1, now);
+    expect(new Date(result).getTime()).toBeGreaterThanOrEqual(now.getTime());
+  });
+});

--- a/services/relayer/src/queue/backoff.ts
+++ b/services/relayer/src/queue/backoff.ts
@@ -1,0 +1,26 @@
+/**
+ * Exponential backoff with full jitter.
+ *
+ * delay = random(0, min(cap, base * 2^attempt))
+ *
+ * @param attempt  Zero-based attempt index (0 = first retry)
+ * @param baseMs   Base delay in milliseconds (default 1 000 ms)
+ * @param capMs    Maximum delay cap in milliseconds (default 60 000 ms)
+ */
+export function computeBackoffMs(
+  attempt: number,
+  baseMs = 1_000,
+  capMs = 60_000,
+): number {
+  const exponential = Math.min(capMs, baseMs * Math.pow(2, attempt));
+  // Full jitter: uniform random in [0, exponential]
+  return Math.floor(Math.random() * exponential);
+}
+
+/**
+ * Returns the ISO timestamp after which the job may next be retried.
+ */
+export function nextRetryAfter(attempt: number, now = new Date()): string {
+  const delayMs = computeBackoffMs(attempt);
+  return new Date(now.getTime() + delayMs).toISOString();
+}

--- a/services/relayer/src/queue/index.ts
+++ b/services/relayer/src/queue/index.ts
@@ -1,0 +1,3 @@
+export { JobQueue } from './JobQueue';
+export type { Job, JobStatus, JobType, EnqueueOptions, DequeueResult } from './types';
+export { computeBackoffMs, nextRetryAfter } from './backoff';

--- a/services/relayer/src/queue/types.ts
+++ b/services/relayer/src/queue/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Job status lifecycle:
+ *   pending → processing → completed
+ *                       ↘ failed → (retry) → pending
+ *                                → dead (max retries exceeded)
+ */
+export type JobStatus = 'pending' | 'processing' | 'completed' | 'failed' | 'dead';
+
+export type JobType = 'relay_execute' | 'add_session_key' | 'revoke_session_key';
+
+export interface Job<T = unknown> {
+  /** Unique job identifier */
+  id: string;
+  /** Caller-supplied idempotency key — duplicate jobs with the same key are suppressed */
+  idempotencyKey: string;
+  type: JobType;
+  payload: T;
+  status: JobStatus;
+  /** Number of attempts made so far */
+  attempts: number;
+  /** Maximum allowed attempts before moving to dead-letter */
+  maxAttempts: number;
+  /** ISO timestamp of when the job was created */
+  createdAt: string;
+  /** ISO timestamp of when the job was last updated */
+  updatedAt: string;
+  /** ISO timestamp after which the job may be retried (undefined = immediately eligible) */
+  retryAfter?: string;
+  /** Last error message recorded on failure */
+  lastError?: string;
+}
+
+export interface EnqueueOptions {
+  idempotencyKey: string;
+  type: JobType;
+  payload: unknown;
+  /** Override default max attempts (default: 5) */
+  maxAttempts?: number;
+}
+
+export interface DequeueResult<T = unknown> {
+  job: Job<T>;
+  /** Call to mark the job completed */
+  ack: () => void;
+  /** Call to mark the job failed and schedule a retry (or move to dead-letter) */
+  nack: (error: Error) => void;
+}

--- a/services/relayer/src/workers/QueueWorker.ts
+++ b/services/relayer/src/workers/QueueWorker.ts
@@ -1,0 +1,125 @@
+import type { JobQueue } from '../queue/JobQueue';
+import type { HandlerRegistry, WorkerOptions, WorkerStats } from './types';
+
+const DEFAULT_POLL_INTERVAL_MS = 500;
+const DEFAULT_CONCURRENCY = 1;
+
+/**
+ * Polls a `JobQueue` and dispatches jobs to registered handlers.
+ *
+ * Usage:
+ * ```ts
+ * const worker = new QueueWorker(queue, { relay_execute: myHandler });
+ * worker.start();
+ * // ...
+ * await worker.stop();
+ * ```
+ */
+export class QueueWorker {
+  private readonly queue: JobQueue;
+  private readonly handlers: HandlerRegistry;
+  private readonly pollIntervalMs: number;
+  private readonly concurrency: number;
+
+  private running = false;
+  private activeJobs = 0;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+  readonly stats: WorkerStats = {
+    processed: 0,
+    succeeded: 0,
+    failed: 0,
+    deadLettered: 0,
+  };
+
+  constructor(queue: JobQueue, handlers: HandlerRegistry, options: WorkerOptions = {}) {
+    this.queue = queue;
+    this.handlers = handlers;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.schedulePoll();
+  }
+
+  /**
+   * Gracefully stop the worker.
+   * Waits for in-flight jobs to finish before resolving.
+   */
+  stop(): Promise<void> {
+    this.running = false;
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    return this.waitForIdle();
+  }
+
+  // ── Polling ────────────────────────────────────────────────────────────────
+
+  private schedulePoll(): void {
+    if (!this.running) return;
+    this.pollTimer = setTimeout(() => this.poll(), this.pollIntervalMs);
+  }
+
+  private async poll(): Promise<void> {
+    while (this.running && this.activeJobs < this.concurrency) {
+      const result = this.queue.dequeue();
+      if (!result) break;
+
+      this.activeJobs++;
+      this.stats.processed++;
+
+      const { job, ack, nack } = result;
+      const handler = this.handlers[job.type];
+
+      const finish = async (): Promise<void> => {
+        try {
+          if (!handler) {
+            throw new Error(`No handler registered for job type "${job.type}"`);
+          }
+          await handler(job);
+          ack();
+          this.stats.succeeded++;
+        } catch (err) {
+          const error = err instanceof Error ? err : new Error(String(err));
+          nack(error);
+          this.stats.failed++;
+
+          // Check if the job was moved to dead-letter after nack
+          const updated = this.queue.getById(job.id);
+          if (updated?.status === 'dead') {
+            this.stats.deadLettered++;
+          }
+        } finally {
+          this.activeJobs--;
+        }
+      };
+
+      // Fire-and-forget; concurrency is tracked via activeJobs counter
+      void finish();
+    }
+
+    this.schedulePoll();
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private waitForIdle(): Promise<void> {
+    return new Promise((resolve) => {
+      const check = (): void => {
+        if (this.activeJobs === 0) {
+          resolve();
+        } else {
+          setTimeout(check, 10);
+        }
+      };
+      check();
+    });
+  }
+}

--- a/services/relayer/src/workers/__tests__/QueueWorker.test.ts
+++ b/services/relayer/src/workers/__tests__/QueueWorker.test.ts
@@ -1,0 +1,148 @@
+import { JobQueue } from '../../queue/JobQueue';
+import { QueueWorker } from '../QueueWorker';
+import type { Job } from '../../queue/types';
+
+/** Resolves after `ms` milliseconds */
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe('QueueWorker', () => {
+  let queue: JobQueue;
+
+  beforeEach(() => {
+    queue = new JobQueue();
+  });
+
+  it('processes a job and calls ack on success', async () => {
+    const handler = jest.fn().mockResolvedValue(undefined);
+    const worker = new QueueWorker(queue, { relay_execute: handler }, { pollIntervalMs: 10 });
+
+    queue.enqueue({ idempotencyKey: 'k1', type: 'relay_execute', payload: { x: 1 } });
+
+    worker.start();
+    await delay(100);
+    await worker.stop();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(worker.stats.succeeded).toBe(1);
+    expect(worker.stats.failed).toBe(0);
+
+    const job = queue.getByIdempotencyKey('k1')!;
+    expect(job.status).toBe('completed');
+  });
+
+  it('calls nack and retries on handler failure', async () => {
+    let callCount = 0;
+    const handler = jest.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount < 3) throw new Error('transient');
+    });
+
+    const worker = new QueueWorker(queue, { relay_execute: handler }, { pollIntervalMs: 10 });
+
+    queue.enqueue({
+      idempotencyKey: 'k1',
+      type: 'relay_execute',
+      payload: {},
+      maxAttempts: 5,
+    });
+
+    worker.start();
+
+    // Allow multiple poll cycles; patch retryAfter between cycles
+    for (let i = 0; i < 5; i++) {
+      await delay(30);
+      const job = queue.getByIdempotencyKey('k1');
+      if (job && job.retryAfter) {
+        // Fast-forward retryAfter so the job is immediately eligible
+        (queue.getById(job.id) as unknown as Record<string, unknown>)['retryAfter'] =
+          new Date(0).toISOString();
+      }
+    }
+
+    await worker.stop();
+
+    expect(handler.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(queue.getByIdempotencyKey('k1')!.status).toBe('completed');
+  });
+
+  it('moves job to dead-letter after maxAttempts failures', async () => {
+    const handler = jest.fn().mockRejectedValue(new Error('always fails'));
+    const worker = new QueueWorker(queue, { relay_execute: handler }, { pollIntervalMs: 10 });
+
+    queue.enqueue({
+      idempotencyKey: 'k1',
+      type: 'relay_execute',
+      payload: {},
+      maxAttempts: 2,
+    });
+
+    worker.start();
+
+    for (let i = 0; i < 4; i++) {
+      await delay(30);
+      const job = queue.getByIdempotencyKey('k1');
+      if (job?.retryAfter) {
+        (queue.getById(job.id) as unknown as Record<string, unknown>)['retryAfter'] =
+          new Date(0).toISOString();
+      }
+    }
+
+    await worker.stop();
+
+    const job = queue.getByIdempotencyKey('k1')!;
+    expect(job.status).toBe('dead');
+    expect(worker.stats.deadLettered).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not process a job type with no registered handler', async () => {
+    const worker = new QueueWorker(queue, {}, { pollIntervalMs: 10 });
+
+    queue.enqueue({ idempotencyKey: 'k1', type: 'relay_execute', payload: {}, maxAttempts: 1 });
+
+    worker.start();
+    await delay(50);
+    const job = queue.getByIdempotencyKey('k1');
+    if (job?.retryAfter) {
+      (queue.getById(job.id) as unknown as Record<string, unknown>)['retryAfter'] =
+        new Date(0).toISOString();
+    }
+    await delay(50);
+    await worker.stop();
+
+    // No handler → nack → dead after maxAttempts=1
+    expect(queue.getByIdempotencyKey('k1')!.status).toBe('dead');
+    expect(worker.stats.failed).toBeGreaterThanOrEqual(1);
+  });
+
+  it('suppresses duplicate jobs via idempotency key', () => {
+    const first = queue.enqueue({ idempotencyKey: 'dup', type: 'relay_execute', payload: {} });
+    const second = queue.enqueue({ idempotencyKey: 'dup', type: 'relay_execute', payload: {} });
+    expect(second.id).toBe(first.id);
+    expect(queue.size()).toBe(1);
+  });
+
+  it('stops cleanly without processing when no jobs are enqueued', async () => {
+    const worker = new QueueWorker(queue, {}, { pollIntervalMs: 10 });
+    worker.start();
+    await delay(30);
+    await worker.stop();
+    expect(worker.stats.processed).toBe(0);
+  });
+
+  it('passes the full job object to the handler', async () => {
+    let receivedJob: Job | undefined;
+    const handler = jest.fn().mockImplementation(async (job: Job) => {
+      receivedJob = job;
+    });
+
+    const worker = new QueueWorker(queue, { relay_execute: handler }, { pollIntervalMs: 10 });
+    queue.enqueue({ idempotencyKey: 'k1', type: 'relay_execute', payload: { amount: 42 } });
+
+    worker.start();
+    await delay(100);
+    await worker.stop();
+
+    expect(receivedJob?.payload).toEqual({ amount: 42 });
+    expect(receivedJob?.type).toBe('relay_execute');
+  });
+});

--- a/services/relayer/src/workers/index.ts
+++ b/services/relayer/src/workers/index.ts
@@ -1,0 +1,2 @@
+export { QueueWorker } from './QueueWorker';
+export type { JobHandler, WorkerOptions, WorkerStats, HandlerRegistry } from './types';

--- a/services/relayer/src/workers/types.ts
+++ b/services/relayer/src/workers/types.ts
@@ -1,0 +1,23 @@
+import type { Job, JobType } from '../queue/types';
+
+/**
+ * A handler registered for a specific job type.
+ * Must resolve on success or throw on failure.
+ */
+export type JobHandler<T = unknown> = (job: Job<T>) => Promise<void>;
+
+export interface WorkerOptions {
+  /** Polling interval in milliseconds when the queue is empty (default: 500 ms) */
+  pollIntervalMs?: number;
+  /** Maximum concurrent jobs processed at once (default: 1) */
+  concurrency?: number;
+}
+
+export interface WorkerStats {
+  processed: number;
+  succeeded: number;
+  failed: number;
+  deadLettered: number;
+}
+
+export type HandlerRegistry = Partial<Record<JobType, JobHandler>>;

--- a/services/relayer/tsconfig.json
+++ b/services/relayer/tsconfig.json
@@ -14,7 +14,8 @@
         "resolveJsonModule": true,
         "declaration": true,
         "declarationMap": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "types": ["jest", "node"]
     },
     "include": [
         "src/**/*"


### PR DESCRIPTION
pr closes #306 

## Summary

Implements the indexer event ingestion pipeline skeleton as described in the issue.
Pure Rust, no new external dependencies beyond `async-trait`. All logic is unit-tested
without requiring a live database.

## Files added

services/indexer/src/schema/
  canonical.rs   — RawEvent (source), CanonicalEvent (internal), EventKind enum,
                   normalise() function, NormaliseError

services/indexer/src/ingest/
  checkpoint.rs  — Checkpoint type, MemoryCheckpointStore (in-memory stub for tests),
                   load()/save() signatures for Postgres (sqlx query! macros)
  source.rs      — EventSource async trait + VecSource test double
  sink.rs        — EventSink async trait + MemorySink / FailingSink test doubles
  worker.rs      — IngestWorker<Src, Snk>: run_once(), out-of-order skip,
                   checkpoint advance only after successful persist, BatchStats

services/indexer/migrations/
  002_create_ingest_checkpoints_table.sql

## Key behaviours

- Checkpoint cursor: last_ledger_seq is persisted after each successful batch commit;
  the worker resumes from that ledger on restart
- Out-of-order events: any event with ledger_seq ≤ last checkpoint is skipped
  (idempotent restarts, no duplicate writes)
- Normalisation errors: bad events are counted and skipped; the batch continues
  and the checkpoint still advances to the highest good ledger
- Checkpoint does not regress: if all events in a batch are skipped/errored,
  the checkpoint is left unchanged

## Tests (all in-process, no DB required)

- processes_events_and_advances_checkpoint
- skips_out_of_order_events
- restart_recovery_resumes_from_checkpoint
- empty_source_returns_zero_stats
- normalisation_error_increments_error_count
- checkpoint_not_advanced_when_nothing_persisted
- schema unit tests: normalise_transfer_event, normalise_session_key_added,
  normalise_unknown_event, rejects_empty_tx_hash, rejects_empty_contract_id
- checkpoint unit tests: memory store roundtrip, upsert, independent streams

## Definition of Done checklist

- [x] Compiles and integrates without breaking existing api/repositories modules
- [x] Tests cover success path, restart recovery, out-of-order handling, error paths
- [x] Can be implemented and reviewed independently (no blocking dependencies)
