### PR TITLE
docs: add OpenAPI-style interface reference (issue #287)

### DIFF
--- a/docs/api-reference.yaml
+++ b/docs/api-reference.yaml
@@ -1,0 +1,740 @@
+##
+# Ancore Interface Specification
+# Issue #287 — OpenAPI-style contract/client interface documentation
+#
+# This file is the canonical reference for all contract entrypoints and SDK
+# wrapper methods. Teams MUST keep this in sync when changing signatures.
+#
+# Version history:
+#   0.1.0 — initial spec (2026-04-24)
+##
+
+spec_version: "0.1.0"
+updated: "2026-04-24"
+
+# ---------------------------------------------------------------------------
+# Shared type definitions
+# ---------------------------------------------------------------------------
+types:
+  Address:
+    description: Stellar account or contract address (G… or C… format)
+    type: string
+    pattern: "^[GC][A-Z0-9]{55}$"
+
+  PublicKey:
+    description: Ed25519 public key — Stellar G… address
+    type: string
+    pattern: "^G[A-Z0-9]{55}$"
+
+  BytesN32:
+    description: 32-byte value encoded as hex or base64 (contract layer)
+    type: string
+
+  U64:
+    description: Unsigned 64-bit integer (unix timestamp in seconds or nonce)
+    type: integer
+    minimum: 0
+    maximum: 18446744073709551615
+
+  SessionPermission:
+    description: |
+      Permission bit granted to a session key. Maps to Vec<u32> in the contract.
+      Values are additive — pass multiple to grant multiple permissions.
+    type: integer
+    enum:
+      - value: 0
+        name: SEND_PAYMENT
+        description: Authorize payment operations
+      - value: 1
+        name: MANAGE_DATA
+        description: Authorize manage-data operations
+      - value: 2
+        name: INVOKE_CONTRACT
+        description: Authorize arbitrary contract invocations
+    note: >
+      PERMISSION_EXECUTE (contract constant = 1) must be present in the
+      permissions array for execute() to succeed via the session-key path.
+      PERMISSION_EXECUTE is a separate internal constant from SessionPermission —
+      it is NOT the same as SessionPermission.MANAGE_DATA (also value 1).
+      Always include it explicitly when creating session keys that need to call execute().
+
+  SessionKey:
+    description: A delegated signing key with scoped permissions and expiry
+    fields:
+      publicKey:
+        type: PublicKey
+        required: true
+      permissions:
+        type: array
+        items: SessionPermission
+        required: true
+      expiresAt:
+        type: U64
+        description: >
+          Expiry timestamp. The @ancore/types interface uses unix milliseconds (ms).
+          The contract stores and compares in unix seconds — the SDK's extend_session_key_ttl
+          helper auto-detects ms vs seconds (values > 100_000_000_000 are treated as ms).
+          Pass unix seconds to the contract directly; pass unix ms to the TypeScript SDK types.
+        required: true
+      label:
+        type: string
+        description: Optional human-readable label (off-chain only, not stored on-chain)
+        required: false
+
+  TransactionResult:
+    description: Result of a submitted Stellar transaction
+    fields:
+      status:
+        type: string
+        enum: [success, failure, pending]
+        required: true
+      hash:
+        type: string
+        description: Transaction hash (present on success)
+        required: false
+      ledger:
+        type: integer
+        description: Ledger sequence number (present on success)
+        required: false
+      error:
+        type: string
+        description: Error message (present on failure)
+        required: false
+      timestamp:
+        type: integer
+        description: Unix timestamp (ms) when the result was recorded
+        required: true
+
+  InvocationArgs:
+    description: |
+      Encoded contract invocation — method name + XDR ScVal arguments.
+      Returned by SDK builder methods; pass to your transaction builder.
+    fields:
+      method:
+        type: string
+        required: true
+      args:
+        type: array
+        items: xdr.ScVal
+        required: true
+
+# ---------------------------------------------------------------------------
+# Contract entrypoints  (contracts/account/src/lib.rs)
+# ---------------------------------------------------------------------------
+contract_methods:
+
+  initialize:
+    description: |
+      Initialize the account contract with an owner address.
+      Must be called exactly once after deployment.
+    auth: none
+    parameters:
+      - name: owner
+        type: Address
+        required: true
+        description: Stellar address that will own this account
+    returns:
+      success: "void"
+    errors:
+      - code: 1
+        name: AlreadyInitialized
+        condition: Contract storage already contains an owner key
+    state_changes:
+      - Writes Owner → owner address to instance storage
+      - Writes Nonce → 0 to instance storage
+      - Writes Version → 1 to instance storage
+      - Extends instance TTL (30-day bump)
+    events:
+      - topic: initialized
+        data: "(owner: Address)"
+
+  get_owner:
+    description: Return the owner address stored in the contract.
+    auth: none
+    parameters: []
+    returns:
+      success: Address
+    errors:
+      - code: 2
+        name: NotInitialized
+        condition: Contract has not been initialized
+
+  get_nonce:
+    description: Return the current replay-protection nonce.
+    auth: none
+    parameters: []
+    returns:
+      success: U64
+    errors: []
+    note: Returns 0 if nonce key is absent (pre-initialization safe read).
+
+  get_version:
+    description: Return the current contract version number.
+    auth: none
+    parameters: []
+    returns:
+      success: "u32"
+    errors: []
+
+  execute:
+    description: |
+      Execute a cross-contract call with replay protection.
+      Supports two auth paths: owner direct auth or session-key signature.
+    auth: owner OR valid session key with PERMISSION_EXECUTE
+    parameters:
+      - name: _caller
+        type: CallerIdentity
+        required: true
+        description: "Enum: Owner | SessionKey(BytesN<32>)"
+      - name: to
+        type: Address
+        required: true
+        description: Target contract address
+      - name: function
+        type: Symbol
+        required: true
+        description: Function name to invoke on the target contract
+      - name: args
+        type: "Vec<Val>"
+        required: true
+        description: Arguments to pass to the target function
+      - name: expected_nonce
+        type: U64
+        required: true
+        description: Must equal the current nonce; prevents replay attacks
+      - name: session_pub_key
+        type: "Option<BytesN<32>>"
+        required: false
+        description: Session key public key (session-key path only)
+      - name: signature
+        type: "Option<BytesN<64>>"
+        required: false
+        description: Ed25519 signature over signature_payload (session-key path only)
+      - name: signature_payload
+        type: "Option<Bytes>"
+        required: false
+        description: |
+          Canonical payload that was signed. Must equal the contract-computed
+          payload: XDR(to) ++ XDR(function) ++ XDR(args) ++ XDR(nonce).
+    returns:
+      success: Val
+      description: Return value from the invoked contract function
+    errors:
+      - code: 2
+        name: NotInitialized
+        condition: Contract has not been initialized
+      - code: 3
+        name: Unauthorized
+        condition: Owner path — require_auth() failed
+      - code: 4
+        name: InvalidNonce
+        condition: expected_nonce does not match current nonce
+      - code: 5
+        name: SessionKeyNotFound
+        condition: session_pub_key provided but no matching key in storage
+      - code: 6
+        name: SessionKeyExpired
+        condition: "ledger.timestamp() >= session_key.expires_at"
+      - code: 7
+        name: InsufficientPermission
+        condition: Session key does not have PERMISSION_EXECUTE (bit 1) set
+      - code: 9
+        name: InvalidSignature
+        condition: signature or signature_payload missing, or payload mismatch
+    state_changes:
+      - Increments Nonce by 1 (before invocation — checks-effects-interactions)
+      - Extends instance TTL (30-day bump)
+    events:
+      - topic: executed
+        data: "(to: Address, function: Symbol, nonce: u64)"
+    security_notes:
+      - Nonce is incremented before the cross-contract call to prevent reentrancy nonce manipulation
+      - Signature payload binds to exact (to, function, args, nonce) — no partial replay possible
+
+  add_session_key:
+    description: |
+      Register a new session key with scoped permissions and an expiry timestamp.
+      Only the account owner may call this.
+    auth: owner (require_auth) — called AFTER the expires_at == 0 guard
+    parameters:
+      - name: public_key
+        type: "BytesN<32>"
+        required: true
+        description: Ed25519 public key of the session key
+      - name: expires_at
+        type: U64
+        required: true
+        description: Unix timestamp (seconds) when the key expires; must be > 0
+      - name: permissions
+        type: "Vec<u32>"
+        required: true
+        description: Permission bits granted to this key (see SessionPermission)
+    returns:
+      success: "void"
+    errors:
+      - code: 11
+        name: InvalidExpiration
+        condition: expires_at == 0 (checked first, before auth)
+      - code: 2
+        name: NotInitialized
+        condition: Contract has not been initialized (checked during get_owner)
+      - code: 3
+        name: Unauthorized
+        condition: Caller is not the owner
+    state_changes:
+      - Writes SessionKey(public_key) → SessionKey struct to persistent storage
+      - Extends session key TTL proportional to expires_at
+      - Extends instance TTL (30-day bump)
+    events:
+      - topic: session_key_added
+        data: "(public_key: BytesN<32>, expires_at: u64)"
+
+  revoke_session_key:
+    description: |
+      Remove a session key from storage. Immediately invalidates it.
+      Only the account owner may call this.
+    auth: owner (require_auth)
+    parameters:
+      - name: public_key
+        type: "BytesN<32>"
+        required: true
+        description: Ed25519 public key of the session key to revoke
+    returns:
+      success: "void"
+    errors:
+      - code: 2
+        name: NotInitialized
+        condition: Contract has not been initialized
+      - code: 3
+        name: Unauthorized
+        condition: Caller is not the owner
+    state_changes:
+      - Removes SessionKey(public_key) from persistent storage
+      - Extends instance TTL (30-day bump)
+    events:
+      - topic: session_key_revoked
+        data: "(public_key: BytesN<32>)"
+
+  get_session_key:
+    description: Return the SessionKey struct for a given public key, or None.
+    auth: none
+    parameters:
+      - name: public_key
+        type: "BytesN<32>"
+        required: true
+    returns:
+      success: "Option<SessionKey>"
+    errors: []
+
+  has_session_key:
+    description: Return true if a session key exists in storage (regardless of expiry).
+    auth: none
+    parameters:
+      - name: public_key
+        type: "BytesN<32>"
+        required: true
+    returns:
+      success: bool
+    errors: []
+
+  is_session_key_active:
+    description: Return true if a session key exists AND has not expired.
+    auth: none
+    parameters:
+      - name: public_key
+        type: "BytesN<32>"
+        required: true
+    returns:
+      success: bool
+    errors: []
+
+  refresh_session_key_ttl:
+    description: |
+      Extend the Soroban storage TTL of an existing session key so it is not
+      evicted before its logical expiry. Does not change expires_at.
+    auth: none
+    parameters:
+      - name: public_key
+        type: "BytesN<32>"
+        required: true
+    returns:
+      success: "void"
+    errors:
+      - code: 5
+        name: SessionKeyNotFound
+        condition: No session key found for the given public key
+    state_changes:
+      - Extends persistent storage TTL for SessionKey(public_key)
+      - Extends instance TTL (30-day bump)
+    events:
+      - topic: session_key_ttl_refreshed
+        data: "(public_key: BytesN<32>, expires_at: u64)"
+
+  upgrade:
+    description: |
+      Replace the contract WASM with a new hash. Increments the version counter.
+      Only the account owner may call this.
+    auth: owner (require_auth)
+    parameters:
+      - name: new_wasm_hash
+        type: "BytesN<32>"
+        required: true
+        description: Hash of the new WASM blob; must not be all-zero
+    returns:
+      success: "void"
+    errors:
+      - code: 2
+        name: NotInitialized
+        condition: Contract has not been initialized
+      - code: 3
+        name: Unauthorized
+        condition: Caller is not the owner
+      - code: 10
+        name: InvalidWasmHash
+        condition: new_wasm_hash is all-zero bytes
+    state_changes:
+      - Increments Version by 1
+      - Calls env.deployer().update_current_contract_wasm(new_wasm_hash)
+      - Extends instance TTL (30-day bump)
+    events:
+      - topic: upgraded
+        data: "(new_wasm_hash: BytesN<32>)"
+
+  migrate:
+    description: |
+      Update the stored version number for a migration. Version must be
+      strictly increasing. Only the account owner may call this.
+    auth: owner (require_auth)
+    parameters:
+      - name: new_version
+        type: "u32"
+        required: true
+        description: New version number; must be > current version
+    returns:
+      success: "void"
+    errors:
+      - code: 2
+        name: NotInitialized
+        condition: Contract has not been initialized
+      - code: 3
+        name: Unauthorized
+        condition: Caller is not the owner
+      - code: 8
+        name: InvalidVersion
+        condition: new_version <= current_version
+    state_changes:
+      - Writes Version → new_version to instance storage
+      - Extends instance TTL (30-day bump)
+    events:
+      - topic: migrated
+        data: "(old_version: u32, new_version: u32)"
+
+# ---------------------------------------------------------------------------
+# SDK wrapper methods  (packages/core-sdk / packages/account-abstraction)
+# ---------------------------------------------------------------------------
+sdk_methods:
+
+  AncoreClient.addSessionKey:
+    package: "@ancore/core-sdk"
+    description: |
+      Build the InvocationArgs for an add_session_key contract call.
+      Returns encoded args — caller is responsible for building and submitting
+      the transaction.
+      Delegates to the standalone addSessionKey() function from add-session-key.ts.
+    signature: "addSessionKey(params: AddSessionKeyParams): InvocationArgs"
+    parameters:
+      - name: params.publicKey
+        type: string
+        required: true
+        description: Ed25519 public key (G… Stellar address)
+        validation: non-empty string
+      - name: params.permissions
+        type: "SessionPermission[]"
+        required: true
+        description: Array of permission enum values
+        validation: must be an array
+      - name: params.expiresAt
+        type: number
+        required: true
+        description: >
+          Expiry timestamp in unix seconds (passed directly to the contract).
+          Note: @ancore/types SessionKey.expiresAt is unix ms — convert before
+          passing to addSessionKey if reading from a stored SessionKey.
+        validation: finite number
+    returns:
+      success: InvocationArgs
+    errors:
+      - name: BuilderValidationError
+        code: BUILDER_VALIDATION
+        condition: Any required parameter is missing or invalid
+      - name: SessionKeyManagementError
+        code: SESSION_KEY_MANAGEMENT_FAILED
+        condition: AccountContract layer throws an unexpected error
+    async: false
+
+  AncoreClient.revokeSessionKey:
+    package: "@ancore/core-sdk"
+    description: |
+      Build the InvocationArgs for a revoke_session_key contract call.
+      Delegates to the standalone revokeSessionKey() function from revoke-session-key.ts.
+    signature: "revokeSessionKey(params: RevokeSessionKeyParams): InvocationArgs"
+    parameters:
+      - name: params.publicKey
+        type: string
+        required: true
+        description: Ed25519 public key of the key to revoke
+        validation: non-empty string
+    returns:
+      success: InvocationArgs
+    errors:
+      - name: BuilderValidationError
+        code: BUILDER_VALIDATION
+        condition: publicKey is missing or empty
+      - name: SessionKeyManagementError
+        code: SESSION_KEY_REVOKE_FAILED
+        condition: AccountContract layer throws an unexpected error
+    async: false
+
+  executeWithSessionKey:
+    package: "@ancore/core-sdk"
+    exported_from: "execute-with-session-key.ts"
+    description: |
+      Standalone exported function — NOT a method on AncoreClient.
+      Execute a cross-contract call authenticated by a session key.
+      Validates inputs, builds the execute invocation via an AccountContract instance,
+      delegates to the provided executionLayer for signing and submission, and returns
+      the result.
+      The AncoreClient class in ancore-client.ts does NOT expose this method —
+      use it directly from the module export.
+    signature: >
+      executeWithSessionKey<TResult, TArgs>(
+        params: ExecuteWithSessionKeyParams<TArgs>
+      ): Promise<ExecuteWithSessionKeyResult<TResult>>
+    note: >
+      This function is used via an AncoreClient instance that is constructed with
+      { accountContract, executionLayer } — a different shape from the AncoreClient
+      exported by ancore-client.ts. See execute-with-session-key.ts for the full
+      AncoreClient class that wraps this function.
+    parameters:
+      - name: params.target
+        type: string
+        required: true
+        description: Target contract address (G… or C…)
+        validation: valid Stellar Address
+      - name: params.function
+        type: string
+        required: true
+        description: Function name to invoke on the target contract
+        validation: non-empty string
+      - name: params.args
+        type: "xdr.ScVal[]"
+        required: true
+        description: XDR-encoded arguments for the target function
+        validation: must be an array
+      - name: params.expectedNonce
+        type: number
+        required: true
+        description: Current contract nonce (fetch via AccountContract.getNonce)
+        validation: non-negative integer
+      - name: params.signer.publicKey
+        type: string
+        required: true
+        description: Session key public key (G… address)
+        validation: valid Ed25519 public key (StrKey.isValidEd25519PublicKey)
+      - name: params.signer.signAuthEntryXdr
+        type: "(authEntryXdr: string) => Promise<string> | string"
+        required: true
+        description: Callback that signs an auth entry XDR and returns signed XDR
+        validation: must be a function
+    returns:
+      success: "ExecuteWithSessionKeyResult<TResult>"
+      fields:
+        result: "TResult — decoded return value from the contract"
+        transactionHash: "string | undefined — hash of the submitted transaction"
+    errors:
+      - name: SessionKeyExecutionValidationError
+        code: SESSION_KEY_EXECUTION_VALIDATION
+        condition: Any input parameter fails validation
+      - name: SessionKeyExecutionError
+        code: SESSION_KEY_EXECUTION_UNAUTHORIZED
+        condition: Contract returns Unauthorized (session key not authorized)
+      - name: SessionKeyExecutionError
+        code: SESSION_KEY_EXECUTION_INVALID_NONCE
+        condition: Contract returns InvalidNonce
+      - name: SessionKeyExecutionError
+        code: SESSION_KEY_EXECUTION_NOT_INITIALIZED
+        condition: Contract returns NotInitialized
+      - name: SessionKeyExecutionError
+        code: SESSION_KEY_EXECUTION_CONTRACT
+        condition: Any other AccountContractError
+      - name: SessionKeyExecutionError
+        code: SESSION_KEY_EXECUTION_FAILED
+        condition: Unknown or unexpected error
+    async: true
+
+  sendPayment:
+    package: "@ancore/core-sdk"
+    description: |
+      Build, sign, and submit a Stellar payment transaction.
+      Internally uses AccountTransactionBuilder (simulate + assemble) then
+      submits via StellarClient.
+    signature: >
+      sendPayment(
+        params: SendPaymentParams,
+        deps: SendPaymentDeps
+      ): Promise<TransactionResult>
+    parameters:
+      - name: params.to
+        type: string
+        required: true
+        description: Destination Stellar address (G…)
+        validation: non-empty string
+      - name: params.amount
+        type: string
+        required: true
+        description: Amount as a decimal string (e.g. "10.5000000")
+        validation: positive numeric string
+      - name: params.asset
+        type: "{ code: string; issuer: string } | 'native'"
+        required: false
+        default: "'native'"
+        description: Asset to send; omit or pass 'native' for XLM
+      - name: params.signer
+        type: PaymentSigner
+        required: true
+        description: "Implements sign(xdr: string): Promise<string> | string"
+        validation: must have a sign function
+      - name: deps.sourceAccount
+        type: "Account"
+        required: true
+        description: Loaded Stellar Account object (provides sequence number)
+      - name: deps.builderOptions
+        type: AccountTransactionBuilderOptions
+        required: true
+        description: Network passphrase, RPC server, fee, etc.
+      - name: deps.stellarClient
+        type: StellarClient
+        required: true
+        description: "@ancore/stellar StellarClient for network submission"
+    returns:
+      success: TransactionResult
+    errors:
+      - name: BuilderValidationError
+        code: BUILDER_VALIDATION
+        condition: Invalid params (missing to, non-positive amount, missing signer)
+      - name: SimulationFailedError
+        code: SIMULATION_FAILED
+        condition: Soroban simulation returns an error
+      - name: SimulationExpiredError
+        code: SIMULATION_EXPIRED
+        condition: Simulation result requires ledger restoration
+      - name: TransactionSubmissionError
+        code: SUBMISSION_FAILED
+        condition: Signing fails or network submission fails
+    async: true
+
+  AccountContract.getOwner:
+    package: "@ancore/account-abstraction"
+    description: Simulate get_owner and return the decoded owner address.
+    signature: "getOwner(options: AccountContractReadOptions): Promise<string>"
+    parameters:
+      - name: options.server
+        type: SorobanRpcServer
+        required: true
+      - name: options.sourceAccount
+        type: string
+        required: true
+      - name: options.networkPassphrase
+        type: string
+        required: false
+    returns:
+      success: string
+    errors:
+      - name: AccountContractError
+        condition: Simulation fails or contract not initialized
+    async: true
+
+  AccountContract.getNonce:
+    package: "@ancore/account-abstraction"
+    description: Simulate get_nonce and return the current nonce as a number.
+    signature: "getNonce(options: AccountContractReadOptions): Promise<number>"
+    parameters:
+      - name: options.server
+        type: SorobanRpcServer
+        required: true
+      - name: options.sourceAccount
+        type: string
+        required: true
+      - name: options.networkPassphrase
+        type: string
+        required: false
+    returns:
+      success: number
+    errors:
+      - name: AccountContractError
+        condition: Simulation fails or contract not initialized
+    async: true
+
+  AccountContract.getSessionKey:
+    package: "@ancore/account-abstraction"
+    description: Simulate get_session_key and return the decoded SessionKey or null.
+    signature: >
+      getSessionKey(
+        publicKey: string | Uint8Array,
+        options: AccountContractReadOptions
+      ): Promise<SessionKey | null>
+    parameters:
+      - name: publicKey
+        type: "string | Uint8Array"
+        required: true
+      - name: options
+        type: AccountContractReadOptions
+        required: true
+    returns:
+      success: "SessionKey | null"
+    errors:
+      - name: AccountContractError
+        condition: Simulation fails
+    async: true
+
+# ---------------------------------------------------------------------------
+# Contract error code reference
+# ---------------------------------------------------------------------------
+error_codes:
+  1:  { name: AlreadyInitialized,    sdk_class: AlreadyInitializedError }
+  2:  { name: NotInitialized,        sdk_class: NotInitializedError }
+  3:  { name: Unauthorized,          sdk_class: UnauthorizedError }
+  4:  { name: InvalidNonce,          sdk_class: InvalidNonceError }
+  5:  { name: SessionKeyNotFound,    sdk_class: SessionKeyNotFoundError }
+  6:  { name: SessionKeyExpired,     sdk_class: SessionKeyExpiredError }
+  7:  { name: InsufficientPermission, sdk_class: InsufficientPermissionError }
+  8:  { name: InvalidVersion,        sdk_class: ContractInvocationError }
+  9:  { name: InvalidSignature,      sdk_class: ContractInvocationError }
+  10: { name: InvalidWasmHash,       sdk_class: ContractInvocationError }
+  11: { name: InvalidExpiration,     sdk_class: ContractInvocationError }
+
+# ---------------------------------------------------------------------------
+# Contract events reference
+# ---------------------------------------------------------------------------
+events:
+  initialized:
+    data: "(owner: Address)"
+    emitted_by: [initialize]
+  executed:
+    data: "(to: Address, function: Symbol, nonce: u64)"
+    emitted_by: [execute]
+  session_key_added:
+    data: "(public_key: BytesN<32>, expires_at: u64)"
+    emitted_by: [add_session_key]
+  session_key_revoked:
+    data: "(public_key: BytesN<32>)"
+    emitted_by: [revoke_session_key]
+  session_key_ttl_refreshed:
+    data: "(public_key: BytesN<32>, expires_at: u64)"
+    emitted_by: [refresh_session_key_ttl]
+  upgraded:
+    data: "(new_wasm_hash: BytesN<32>)"
+    emitted_by: [upgrade]
+  migrated:
+    data: "(old_version: u32, new_version: u32)"
+    emitted_by: [migrate]

--- a/docs/contract-methods.md
+++ b/docs/contract-methods.md
@@ -1,0 +1,388 @@
+# Contract Methods
+
+> Canonical reference for all `contracts/account` entrypoints.  
+> Machine-readable spec: [`api-reference.yaml`](./api-reference.yaml)  
+> Last updated: 2026-04-24 · Issue #287
+
+---
+
+## Overview
+
+The Ancore account contract (`contracts/account/src/lib.rs`) is a Soroban smart
+contract that implements account abstraction on Stellar. Every user account is a
+deployed instance of this contract.
+
+**Storage model**
+
+| Key | Storage type | Description |
+|-----|-------------|-------------|
+| `Owner` | Instance | Owner `Address` |
+| `Nonce` | Instance | Replay-protection counter (`u64`) |
+| `Version` | Instance | Contract version (`u32`) |
+| `SessionKey(BytesN<32>)` | Persistent | Per-key `SessionKey` struct |
+
+**Instance TTL** is bumped to 30 days on every write. Persistent session-key
+entries are bumped proportionally to their `expires_at` value.
+
+---
+
+## Error codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| 1 | `AlreadyInitialized` | `initialize()` called on an already-initialized contract |
+| 2 | `NotInitialized` | Any call before `initialize()` |
+| 3 | `Unauthorized` | `require_auth()` failed (caller is not the owner) |
+| 4 | `InvalidNonce` | `expected_nonce` does not match the stored nonce |
+| 5 | `SessionKeyNotFound` | No session key found for the given public key |
+| 6 | `SessionKeyExpired` | `ledger.timestamp() >= session_key.expires_at` |
+| 7 | `InsufficientPermission` | Session key lacks `PERMISSION_EXECUTE` (bit 1) |
+| 8 | `InvalidVersion` | `new_version <= current_version` in `migrate()` |
+| 9 | `InvalidSignature` | Signature or payload missing, or payload mismatch |
+| 10 | `InvalidWasmHash` | All-zero WASM hash passed to `upgrade()` |
+| 11 | `InvalidExpiration` | `expires_at == 0` in `add_session_key()` |
+
+---
+
+## Session permissions
+
+Permission bits are stored as `Vec<u32>` on each session key.
+
+| Value | Constant | Description |
+|-------|----------|-------------|
+| `0` | `SEND_PAYMENT` | Authorize payment operations |
+| `1` | `MANAGE_DATA` | Authorize manage-data operations |
+| `2` | `INVOKE_CONTRACT` | Authorize arbitrary contract invocations |
+
+> **Important:** `execute()` requires the session key to contain the internal
+> `PERMISSION_EXECUTE` constant (`1`). This is a separate contract constant —
+> **not** the same as `SessionPermission.MANAGE_DATA` (which also has value `1`
+> in the TypeScript enum). The contract checks `session.permissions.contains(1)`.
+> Always include `1` in the permissions array for session keys that need to call
+> `execute()`, regardless of what other permissions are set.
+
+---
+
+## Entrypoints
+
+### `initialize`
+
+Initialize the account with an owner. Call once after deployment.
+
+```rust
+pub fn initialize(env: Env, owner: Address) -> Result<(), ContractError>
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `owner` | `Address` | ✓ | Stellar address that will own this account |
+
+**Returns** `void`
+
+**Errors** `AlreadyInitialized (1)`
+
+**State changes**
+- Writes `Owner`, `Nonce = 0`, `Version = 1` to instance storage
+- Extends instance TTL
+
+**Event** `initialized` → data: `(owner: Address)`
+
+---
+
+### `get_owner`
+
+Return the owner address.
+
+```rust
+pub fn get_owner(env: Env) -> Result<Address, ContractError>
+```
+
+**Returns** `Address`  
+**Errors** `NotInitialized (2)`
+
+---
+
+### `get_nonce`
+
+Return the current replay-protection nonce.
+
+```rust
+pub fn get_nonce(env: Env) -> Result<u64, ContractError>
+```
+
+**Returns** `u64` (0 if nonce key is absent)  
+**Errors** none
+
+---
+
+### `get_version`
+
+Return the current contract version.
+
+```rust
+pub fn get_version(env: Env) -> u32
+```
+
+**Returns** `u32` (0 if version key is absent)
+
+---
+
+### `execute`
+
+Execute a cross-contract call with replay protection. Supports two auth paths:
+
+- **Owner path** — `session_pub_key` is `None`; `owner.require_auth()` is called.
+- **Session-key path** — `session_pub_key` is `Some(key)`; the provided Ed25519
+  signature is verified against the canonical payload.
+
+```rust
+pub fn execute(
+    env: Env,
+    _caller: CallerIdentity,
+    to: Address,
+    function: Symbol,
+    args: Vec<Val>,
+    expected_nonce: u64,
+    session_pub_key: Option<BytesN<32>>,
+    signature: Option<BytesN<64>>,
+    signature_payload: Option<Bytes>,
+) -> Result<Val, ContractError>
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `_caller` | `CallerIdentity` | ✓ | `Owner` or `SessionKey(BytesN<32>)` |
+| `to` | `Address` | ✓ | Target contract address |
+| `function` | `Symbol` | ✓ | Function name on the target contract |
+| `args` | `Vec<Val>` | ✓ | Arguments for the target function |
+| `expected_nonce` | `u64` | ✓ | Must equal current nonce |
+| `session_pub_key` | `Option<BytesN<32>>` | — | Session key (session-key path) |
+| `signature` | `Option<BytesN<64>>` | — | Ed25519 signature (session-key path) |
+| `signature_payload` | `Option<Bytes>` | — | Signed payload (session-key path) |
+
+**Signature payload format** (session-key path)
+
+```
+XDR(to) ++ XDR(function) ++ XDR(args) ++ XDR(nonce)
+```
+
+The contract recomputes this payload and rejects any mismatch, preventing
+partial replay attacks.
+
+**Returns** `Val` — return value from the invoked function
+
+**Errors**
+
+| Code | Name | Condition |
+|------|------|-----------|
+| 2 | `NotInitialized` | Contract not initialized |
+| 3 | `Unauthorized` | Owner auth failed |
+| 4 | `InvalidNonce` | Nonce mismatch |
+| 5 | `SessionKeyNotFound` | Unknown session key |
+| 6 | `SessionKeyExpired` | Key past `expires_at` |
+| 7 | `InsufficientPermission` | Key lacks `PERMISSION_EXECUTE` |
+| 9 | `InvalidSignature` | Missing or mismatched signature/payload |
+
+**State changes**
+- Increments `Nonce` by 1 **before** the cross-contract call
+- Extends instance TTL
+
+**Event** `executed` → data: `(to: Address, function: Symbol, nonce: u64)`
+
+---
+
+### `add_session_key`
+
+Register a session key. Owner authorization required.
+
+```rust
+pub fn add_session_key(
+    env: Env,
+    public_key: BytesN<32>,
+    expires_at: u64,
+    permissions: Vec<u32>,
+) -> Result<(), ContractError>
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `public_key` | `BytesN<32>` | ✓ | Ed25519 public key |
+| `expires_at` | `u64` | ✓ | Unix timestamp (seconds); must be > 0 |
+| `permissions` | `Vec<u32>` | ✓ | Permission bits |
+
+**Returns** `void`
+
+**Errors**
+
+| Code | Name | Condition |
+|------|------|-----------|
+| 11 | `InvalidExpiration` | `expires_at == 0` — checked **before** `require_auth()` |
+| 2 | `NotInitialized` | Contract not initialized (checked during `get_owner`) |
+| 3 | `Unauthorized` | Caller is not the owner |
+
+> `InvalidExpiration` fires before auth. A caller without owner auth still gets
+> `InvalidExpiration` when `expires_at == 0`.
+
+**State changes**
+- Writes `SessionKey(public_key)` to persistent storage
+- Extends session key TTL proportional to `expires_at`
+- Extends instance TTL (30-day bump)
+
+**Event** `session_key_added` → data: `(public_key: BytesN<32>, expires_at: u64)`
+
+---
+
+### `revoke_session_key`
+
+Remove a session key immediately. Owner authorization required.
+
+```rust
+pub fn revoke_session_key(env: Env, public_key: BytesN<32>) -> Result<(), ContractError>
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `public_key` | `BytesN<32>` | ✓ | Key to revoke |
+
+**Returns** `void`
+
+**Errors** `NotInitialized (2)`, `Unauthorized (3)`
+
+**State changes**
+- Removes `SessionKey(public_key)` from persistent storage
+- Extends instance TTL
+
+**Event** `session_key_revoked` → data: `(public_key: BytesN<32>)`
+
+---
+
+### `get_session_key`
+
+Return the `SessionKey` struct for a given public key, or `None`.
+
+```rust
+pub fn get_session_key(env: Env, public_key: BytesN<32>) -> Option<SessionKey>
+```
+
+**Returns** `Option<SessionKey>`
+
+---
+
+### `has_session_key`
+
+Return `true` if a session key exists in storage (regardless of expiry).
+
+```rust
+pub fn has_session_key(env: Env, public_key: BytesN<32>) -> bool
+```
+
+**Returns** `bool`
+
+---
+
+### `is_session_key_active`
+
+Return `true` if a session key exists **and** has not expired.
+
+```rust
+pub fn is_session_key_active(env: Env, public_key: BytesN<32>) -> bool
+```
+
+**Returns** `bool`
+
+---
+
+### `refresh_session_key_ttl`
+
+Extend the Soroban storage TTL of an existing session key so it is not evicted
+before its logical `expires_at`. Does **not** change `expires_at`.
+
+```rust
+pub fn refresh_session_key_ttl(env: Env, public_key: BytesN<32>) -> Result<(), ContractError>
+```
+
+**Returns** `void`
+
+**Errors** `SessionKeyNotFound (5)`
+
+**State changes**
+- Extends persistent TTL for `SessionKey(public_key)`
+- Extends instance TTL
+
+**Event** `session_key_ttl_refreshed` → data: `(public_key: BytesN<32>, expires_at: u64)`
+
+---
+
+### `upgrade`
+
+Replace the contract WASM. Owner authorization required.
+
+```rust
+pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), ContractError>
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `new_wasm_hash` | `BytesN<32>` | ✓ | Hash of the new WASM; must not be all-zero |
+
+**Returns** `void`
+
+**Errors** `NotInitialized (2)`, `Unauthorized (3)`, `InvalidWasmHash (10)`
+
+**State changes**
+- Increments `Version` by 1
+- Calls `env.deployer().update_current_contract_wasm()`
+- Extends instance TTL
+
+**Event** `upgraded` → data: `(new_wasm_hash: BytesN<32>)`
+
+---
+
+### `migrate`
+
+Update the stored version number. Version must be strictly increasing. Owner
+authorization required.
+
+```rust
+pub fn migrate(env: Env, new_version: u32) -> Result<(), ContractError>
+```
+
+**Parameters**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `new_version` | `u32` | ✓ | Must be > current version |
+
+**Returns** `void`
+
+**Errors** `NotInitialized (2)`, `Unauthorized (3)`, `InvalidVersion (8)`
+
+**State changes**
+- Writes `Version → new_version`
+- Extends instance TTL
+
+**Event** `migrated` → data: `(old_version: u32, new_version: u32)`
+
+---
+
+## Events reference
+
+| Topic | Data | Emitted by |
+|-------|------|-----------|
+| `initialized` | `(owner: Address)` | `initialize` |
+| `executed` | `(to: Address, function: Symbol, nonce: u64)` | `execute` |
+| `session_key_added` | `(public_key: BytesN<32>, expires_at: u64)` | `add_session_key` |
+| `session_key_revoked` | `(public_key: BytesN<32>)` | `revoke_session_key` |
+| `session_key_ttl_refreshed` | `(public_key: BytesN<32>, expires_at: u64)` | `refresh_session_key_ttl` |
+| `upgraded` | `(new_wasm_hash: BytesN<32>)` | `upgrade` |
+| `migrated` | `(old_version: u32, new_version: u32)` | `migrate` |

--- a/docs/examples/send-payment.md
+++ b/docs/examples/send-payment.md
@@ -1,0 +1,253 @@
+# Example: Send Payment Flow
+
+> End-to-end example for sending a Stellar payment via the Ancore SDK.  
+> References: [`sdk-wrappers.md`](../sdk-wrappers.md) · [`contract-methods.md`](../contract-methods.md)  
+> Last updated: 2026-04-24 · Issue #287
+
+---
+
+## Overview
+
+`sendPayment` builds a Stellar `payment` operation, simulates it via Soroban
+RPC, assembles the transaction, signs it, and submits it to the network.
+
+**Flow**
+
+```
+1. Validate params
+2. Build Operation.payment (native XLM or custom asset)
+3. AccountTransactionBuilder.build() — simulate + assemble
+4. signer.sign(tx.toXDR())          — sign the assembled transaction
+5. stellarClient.submitTransaction() — submit to network
+6. Return TransactionResult
+```
+
+---
+
+## Prerequisites
+
+```bash
+pnpm add @ancore/core-sdk @ancore/stellar @stellar/stellar-sdk
+```
+
+---
+
+## Basic example — send XLM
+
+```typescript
+import { sendPayment } from '@ancore/core-sdk';
+import { StellarClient } from '@ancore/stellar';
+import { Server } from '@stellar/stellar-sdk/rpc';
+import { Account } from '@stellar/stellar-sdk';
+
+const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+const RPC_URL            = 'https://soroban-testnet.stellar.org';
+const SOURCE_ADDRESS     = 'G...SOURCE';
+
+// 1. Load source account (provides sequence number)
+const server         = new Server(RPC_URL);
+const accountData    = await server.getAccount(SOURCE_ADDRESS);
+const sourceAccount  = new Account(accountData.id, accountData.sequence);
+
+// 2. Set up StellarClient
+const stellarClient = new StellarClient({ rpcUrl: RPC_URL });
+
+// 3. Signer — adapt to your key management solution
+const signer = {
+  sign: async (transactionXdr: string): Promise<string> => {
+    return myKeyManager.signTransaction(transactionXdr);
+  },
+};
+
+// 4. Send
+const result = await sendPayment(
+  {
+    to:     'G...DESTINATION',
+    amount: '10.0000000',
+    // asset defaults to native XLM
+    signer,
+  },
+  {
+    sourceAccount,
+    builderOptions: {
+      networkPassphrase: NETWORK_PASSPHRASE,
+      server,
+      fee: '100',
+    },
+    stellarClient,
+  }
+);
+
+console.log('Status:', result.status);   // 'success'
+console.log('Hash:',   result.hash);
+console.log('Ledger:', result.ledger);
+```
+
+---
+
+## Send a non-native asset (e.g. USDC)
+
+```typescript
+const result = await sendPayment(
+  {
+    to:     'G...DESTINATION',
+    amount: '25.0000000',
+    asset:  {
+      code:   'USDC',
+      issuer: 'G...USDC_ISSUER',
+    },
+    signer,
+  },
+  { sourceAccount, builderOptions, stellarClient }
+);
+```
+
+---
+
+## Error handling
+
+```typescript
+import {
+  BuilderValidationError,
+  SimulationFailedError,
+  SimulationExpiredError,
+  TransactionSubmissionError,
+  AncoreSdkError,
+} from '@ancore/core-sdk';
+
+async function safeSendPayment(params, deps) {
+  try {
+    return await sendPayment(params, deps);
+  } catch (error) {
+    if (error instanceof BuilderValidationError) {
+      // Fix the call site — bad inputs
+      console.error('Invalid payment params:', error.message);
+      throw error;
+    }
+
+    if (error instanceof SimulationFailedError) {
+      // Contract would revert — check params and account state
+      console.error('Simulation failed:', error.diagnosticMessage);
+      throw error;
+    }
+
+    if (error instanceof SimulationExpiredError) {
+      // Ledger entry needs restoration — retry after restoring storage
+      console.error('Simulation expired — restore ledger entry and retry.');
+      throw error;
+    }
+
+    if (error instanceof TransactionSubmissionError) {
+      // Network or signing failure
+      console.error('Submission failed:', error.message);
+      if (error.resultXdr) {
+        console.error('Result XDR:', error.resultXdr);
+      }
+      throw error;
+    }
+
+    throw error;
+  }
+}
+```
+
+---
+
+## Platform notes
+
+### Extension wallet (`apps/extension-wallet`)
+
+The extension wallet signs transactions via the background service:
+
+```typescript
+const signer = {
+  sign: async (transactionXdr: string) => {
+    return chrome.runtime.sendMessage({
+      type: 'SIGN_TRANSACTION',
+      transactionXdr,
+    });
+  },
+};
+```
+
+### Mobile wallet (`apps/mobile-wallet`)
+
+Use the secure keychain to sign:
+
+```typescript
+import { signTransaction } from '@/security/keychain';
+
+const signer = {
+  sign: (xdr: string) => signTransaction(xdr, accountPublicKey),
+};
+```
+
+### Web dashboard (`apps/web-dashboard`)
+
+For in-browser signing with a loaded keypair:
+
+```typescript
+import { Keypair, TransactionBuilder } from '@stellar/stellar-sdk';
+
+const keypair = Keypair.fromSecret('S...');
+
+const signer = {
+  sign: (transactionXdr: string) => {
+    const tx = TransactionBuilder.fromXDR(transactionXdr, NETWORK_PASSPHRASE);
+    tx.sign(keypair);
+    return tx.toXDR();
+  },
+};
+```
+
+---
+
+## Full example (TypeScript)
+
+```typescript
+import { sendPayment, BuilderValidationError, TransactionSubmissionError } from '@ancore/core-sdk';
+import { StellarClient } from '@ancore/stellar';
+import { Server } from '@stellar/stellar-sdk/rpc';
+import { Account } from '@stellar/stellar-sdk';
+
+const NETWORK = 'Test SDF Network ; September 2015';
+const RPC_URL = 'https://soroban-testnet.stellar.org';
+
+async function run() {
+  const server        = new Server(RPC_URL);
+  const accountData   = await server.getAccount('G...SOURCE');
+  const sourceAccount = new Account(accountData.id, accountData.sequence);
+  const stellarClient = new StellarClient({ rpcUrl: RPC_URL });
+
+  const signer = {
+    sign: async (xdr: string) => myKeyManager.signTransaction(xdr),
+  };
+
+  try {
+    const result = await sendPayment(
+      { to: 'G...DEST', amount: '5.0000000', signer },
+      {
+        sourceAccount,
+        builderOptions: { networkPassphrase: NETWORK, server, fee: '100' },
+        stellarClient,
+      }
+    );
+    console.log('Payment sent:', result.hash);
+  } catch (err) {
+    if (err instanceof BuilderValidationError) {
+      console.error('Bad params:', err.message);
+    } else if (err instanceof TransactionSubmissionError) {
+      console.error('Submission failed:', err.message, err.resultXdr);
+    } else {
+      throw err;
+    }
+  }
+}
+```
+
+---
+
+## Related
+
+- [SDK: `sendPayment`](../sdk-wrappers.md#sendpayment)
+- [Session-key execute example](./session-key-execute.md)

--- a/docs/examples/session-key-execute.md
+++ b/docs/examples/session-key-execute.md
@@ -1,0 +1,265 @@
+# Example: Session-Key Execute Flow
+
+> End-to-end example for executing a contract call authenticated by a session key.  
+> References: [`sdk-wrappers.md`](../sdk-wrappers.md) · [`contract-methods.md`](../contract-methods.md)  
+> Last updated: 2026-04-24 · Issue #287
+
+---
+
+## Overview
+
+The session-key execute flow lets a scoped key (e.g. held by a dApp or mobile
+app) authorize contract calls on behalf of the account owner — without exposing
+the owner's private key.
+
+**Flow**
+
+```
+1. Owner adds session key on-chain  (add_session_key)
+2. App fetches current nonce        (get_nonce)
+3. App builds execute invocation    (executeWithSessionKey)
+4. Session key signs auth entry     (signer.signAuthEntryXdr)
+5. Transaction submitted            (execution layer)
+6. Contract verifies signature, increments nonce, invokes target
+```
+
+---
+
+## Prerequisites
+
+```bash
+pnpm add @ancore/core-sdk @ancore/account-abstraction @ancore/types
+```
+
+---
+
+## Step 1 — Add a session key (owner)
+
+The account owner registers the session key once. This is typically done in the
+wallet UI.
+
+```typescript
+import { AncoreClient, SessionPermission } from '@ancore/core-sdk';
+import { AccountContract } from '@ancore/account-abstraction';
+
+const CONTRACT_ID = 'C...'; // your deployed account contract
+
+const client = new AncoreClient({ accountContractId: CONTRACT_ID });
+
+// Build the invocation (synchronous — no network call yet)
+const invocation = client.addSessionKey({
+  publicKey:   'GABC...SESSION_KEY_PUBLIC_KEY',
+  permissions: [SessionPermission.SEND_PAYMENT, SessionPermission.INVOKE_CONTRACT],
+  expiresAt:   Math.floor(Date.now() / 1000) + 86400, // unix seconds — 24 hours from now
+  // Note: AddSessionKeyParams.expiresAt is unix seconds (contract layer).
+  // @ancore/types SessionKey.expiresAt is unix ms — they are different units.
+});
+
+// Submit via your transaction builder (owner must sign)
+// await ownerTransactionBuilder.buildAndSubmit(invocation);
+```
+
+---
+
+## Step 2 — Fetch the current nonce
+
+Always fetch the nonce immediately before building the execute call to avoid
+`InvalidNonce` errors.
+
+```typescript
+import { AccountContract } from '@ancore/account-abstraction';
+import { Server } from '@stellar/stellar-sdk/rpc';
+
+const CONTRACT_ID = 'C...';
+const SOURCE_ACCOUNT = 'G...'; // any funded account for simulation
+const NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+
+const server = new Server('https://soroban-testnet.stellar.org');
+const contract = new AccountContract(CONTRACT_ID);
+
+const nonce = await contract.getNonce({
+  server,
+  sourceAccount: SOURCE_ACCOUNT,
+  networkPassphrase: NETWORK_PASSPHRASE,
+});
+```
+
+---
+
+## Step 3 — Execute with session key
+
+```typescript
+import { executeWithSessionKey, SessionKeyExecutionError } from '@ancore/core-sdk';
+import { xdr } from '@stellar/stellar-sdk';
+
+// Signer implementation — adapt to your key management solution
+const signer = {
+  publicKey: 'GABC...SESSION_KEY_PUBLIC_KEY',
+  signAuthEntryXdr: async (authEntryXdr: string): Promise<string> => {
+    // Sign the auth entry XDR with the session key's private key.
+    // Implementation depends on your platform (see platform notes below).
+    return myKeyManager.signAuthEntry(authEntryXdr);
+  },
+};
+
+try {
+  const result = await executeWithSessionKey({
+    target:        'C...TARGET_CONTRACT',
+    function:      'transfer',
+    args:          [
+      xdr.ScVal.scvAddress(/* destination address */),
+      xdr.ScVal.scvI128(/* amount */),
+    ],
+    expectedNonce: nonce,
+    signer,
+  });
+
+  console.log('Transaction hash:', result.transactionHash);
+  console.log('Result:', result.result);
+} catch (error) {
+  handleSessionKeyError(error);
+}
+```
+
+---
+
+## Error handling
+
+```typescript
+import {
+  SessionKeyExecutionError,
+  SessionKeyExecutionValidationError,
+  AncoreSdkError,
+} from '@ancore/core-sdk';
+import {
+  SessionKeyExpiredError,
+  SessionKeyNotFoundError,
+  InvalidNonceError,
+} from '@ancore/account-abstraction';
+
+function handleSessionKeyError(error: unknown): never {
+  if (error instanceof SessionKeyExecutionValidationError) {
+    // Bad inputs — fix the call site
+    throw new Error(`Invalid parameters: ${error.message}`);
+  }
+
+  if (error instanceof SessionKeyExecutionError) {
+    switch (error.code) {
+      case 'SESSION_KEY_EXECUTION_UNAUTHORIZED':
+        // Session key not authorized — check permissions or re-add key
+        throw new Error('Session key is not authorized for this operation.');
+
+      case 'SESSION_KEY_EXECUTION_INVALID_NONCE':
+        // Nonce race — re-fetch nonce and retry once
+        throw new Error('Nonce mismatch — retry after re-fetching the nonce.');
+
+      case 'SESSION_KEY_EXECUTION_NOT_INITIALIZED':
+        throw new Error('Contract not initialized.');
+
+      default:
+        throw new Error(`Session key execution failed [${error.code}]: ${error.message}`);
+    }
+  }
+
+  throw error;
+}
+```
+
+---
+
+## Platform notes
+
+### Extension wallet (`apps/extension-wallet`)
+
+The extension wallet holds session keys in encrypted storage. Use the
+background service's signing API:
+
+```typescript
+// In content script / popup
+const signedXdr = await chrome.runtime.sendMessage({
+  type: 'SIGN_AUTH_ENTRY',
+  authEntryXdr,
+  publicKey: signer.publicKey,
+});
+```
+
+### Mobile wallet (`apps/mobile-wallet`)
+
+Use the secure enclave or keychain to sign auth entries:
+
+```typescript
+import { signAuthEntry } from '@/security/keychain';
+
+const signer = {
+  publicKey: storedPublicKey,
+  signAuthEntryXdr: (xdr) => signAuthEntry(xdr, storedPublicKey),
+};
+```
+
+### Web dashboard (`apps/web-dashboard`)
+
+For in-browser signing, use the `@ancore/crypto` signing utilities:
+
+```typescript
+import { signBytes } from '@ancore/crypto';
+
+const signer = {
+  publicKey: sessionKeyPublicKey,
+  signAuthEntryXdr: async (authEntryXdr) => {
+    const entryBytes = Buffer.from(authEntryXdr, 'base64');
+    return signBytes(entryBytes, sessionKeyPrivateKey);
+  },
+};
+```
+
+---
+
+## Full example (TypeScript)
+
+```typescript
+import { AncoreClient, executeWithSessionKey, SessionPermission } from '@ancore/core-sdk';
+import { AccountContract } from '@ancore/account-abstraction';
+import { Server } from '@stellar/stellar-sdk/rpc';
+import { xdr } from '@stellar/stellar-sdk';
+
+const CONTRACT_ID      = 'C...';
+const TARGET_CONTRACT  = 'C...';
+const SOURCE_ACCOUNT   = 'G...';
+const SESSION_KEY_PUB  = 'G...';
+const NETWORK          = 'Test SDF Network ; September 2015';
+
+async function runSessionKeyExecute() {
+  const server   = new Server('https://soroban-testnet.stellar.org');
+  const contract = new AccountContract(CONTRACT_ID);
+
+  // 1. Fetch nonce
+  const nonce = await contract.getNonce({
+    server,
+    sourceAccount: SOURCE_ACCOUNT,
+    networkPassphrase: NETWORK,
+  });
+
+  // 2. Execute
+  const result = await executeWithSessionKey({
+    target:        TARGET_CONTRACT,
+    function:      'transfer',
+    args:          [xdr.ScVal.scvAddress(/* ... */), xdr.ScVal.scvI128(/* ... */)],
+    expectedNonce: nonce,
+    signer: {
+      publicKey:        SESSION_KEY_PUB,
+      signAuthEntryXdr: (xdr) => myKeyManager.sign(xdr),
+    },
+  });
+
+  return result;
+}
+```
+
+---
+
+## Related
+
+- [Contract method: `execute`](../contract-methods.md#execute)
+- [Contract method: `add_session_key`](../contract-methods.md#add_session_key)
+- [SDK: `executeWithSessionKey`](../sdk-wrappers.md#executewithsessionkey)
+- [Send payment example](./send-payment.md)

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1,0 +1,245 @@
+# Integration Guide
+
+> Team guidelines for integrating with Ancore contract methods and SDK wrappers.  
+> Issue #287 — prevents integration drift across extension, mobile, and dashboard teams.  
+> Last updated: 2026-04-24
+
+---
+
+## Purpose
+
+This guide establishes a shared process so that the extension, mobile, and
+dashboard teams use the same interface contracts, error handling patterns, and
+update workflow. It is the companion to the reference docs:
+
+| Document | What it covers |
+|----------|---------------|
+| [`api-reference.yaml`](./api-reference.yaml) | Machine-readable spec (source of truth) |
+| [`contract-methods.md`](./contract-methods.md) | Contract entrypoints, params, errors, events |
+| [`sdk-wrappers.md`](./sdk-wrappers.md) | SDK wrapper methods and error hierarchy |
+| [`examples/session-key-execute.md`](./examples/session-key-execute.md) | Session-key execute flow |
+| [`examples/send-payment.md`](./examples/send-payment.md) | Payment flow |
+
+---
+
+## Package responsibilities
+
+| Package | Owner | Stability | Purpose |
+|---------|-------|-----------|---------|
+| `@ancore/core-sdk` | Core team | Public SemVer | High-level SDK for app developers |
+| `@ancore/account-abstraction` | Core team | Public SemVer | Low-level contract wrapper |
+| `@ancore/types` | Core team | Public SemVer | Shared TypeScript types |
+| `contracts/account` | Core team | High security | Soroban account contract |
+
+App teams (`apps/extension-wallet`, `apps/mobile-wallet`, `apps/web-dashboard`)
+consume `@ancore/core-sdk` and `@ancore/types`. They do **not** import directly
+from `@ancore/account-abstraction` unless building advanced tooling.
+
+---
+
+## Integration checklist
+
+Before shipping any feature that touches contract methods or SDK wrappers:
+
+- [ ] Verify the method signature against `api-reference.yaml`
+- [ ] Handle all documented error codes (see error handling section below)
+- [ ] Fetch the nonce immediately before any `execute` call
+- [ ] Never hardcode nonces — always read from the contract
+- [ ] Test against Testnet before Mainnet
+- [ ] If a signature change is needed, open an RFC (see [RFC.md](../RFC.md))
+
+---
+
+## Error handling contract
+
+All teams must handle errors using the typed error classes. Never catch a bare
+`Error` and swallow it silently.
+
+### Minimum required handling
+
+```typescript
+import {
+  AncoreSdkError,
+  BuilderValidationError,
+  SessionKeyExecutionError,
+  SessionKeyExecutionValidationError,
+  SimulationFailedError,
+  TransactionSubmissionError,
+} from '@ancore/core-sdk';
+
+function handleSdkError(error: unknown): never {
+  if (error instanceof BuilderValidationError) {
+    // Programming error — fix the call site
+    throw error;
+  }
+
+  if (error instanceof SessionKeyExecutionValidationError) {
+    // Bad inputs — fix the call site
+    throw error;
+  }
+
+  if (error instanceof SessionKeyExecutionError) {
+    // Map to user-facing message by error.code
+    switch (error.code) {
+      case 'SESSION_KEY_EXECUTION_UNAUTHORIZED':
+        showUserError('Session key not authorized. Please re-authenticate.');
+        break;
+      case 'SESSION_KEY_EXECUTION_INVALID_NONCE':
+        // Retry once after re-fetching nonce
+        retryWithFreshNonce();
+        break;
+      default:
+        showUserError('Transaction failed. Please try again.');
+    }
+    throw error;
+  }
+
+  if (error instanceof SimulationFailedError) {
+    showUserError('Transaction would fail on-chain. Check your inputs.');
+    throw error;
+  }
+
+  if (error instanceof TransactionSubmissionError) {
+    showUserError('Network error. Please check your connection and retry.');
+    throw error;
+  }
+
+  throw error;
+}
+```
+
+### Nonce retry pattern
+
+`InvalidNonce` can occur when two operations race. Retry once with a fresh nonce:
+
+```typescript
+async function executeWithRetry(params, contract, readOptions) {
+  try {
+    const nonce = await contract.getNonce(readOptions);
+    return await executeWithSessionKey({ ...params, expectedNonce: nonce });
+  } catch (error) {
+    if (
+      error instanceof SessionKeyExecutionError &&
+      error.code === 'SESSION_KEY_EXECUTION_INVALID_NONCE'
+    ) {
+      // Retry once
+      const freshNonce = await contract.getNonce(readOptions);
+      return await executeWithSessionKey({ ...params, expectedNonce: freshNonce });
+    }
+    throw error;
+  }
+}
+```
+
+---
+
+## Session key lifecycle
+
+```
+Owner adds key  →  App uses key  →  Key expires or owner revokes
+```
+
+**Adding a key**
+
+```typescript
+const invocation = client.addSessionKey({
+  publicKey:   sessionKeyPublicKey,
+  permissions: [SessionPermission.SEND_PAYMENT],
+  expiresAt:   Math.floor(Date.now() / 1000) + 86400, // unix seconds — 24 h from now
+});
+// Build and submit with owner signature
+```
+
+**Checking if a key is still active** (before using it)
+
+```typescript
+// is_session_key_active and refresh_session_key_ttl are contract entrypoints
+// with no TypeScript wrapper in AccountContract. Invoke them via a raw simulation:
+const activeInvocation = contract.call('is_session_key_active', publicKeyScVal);
+// Or check expiry client-side from a stored SessionKey:
+const sessionKey = await contract.getSessionKey(publicKey, readOptions);
+const isActive = sessionKey !== null && sessionKey.expiresAt > Date.now(); // expiresAt is ms in TS types
+```
+
+**Refreshing storage TTL** (before Soroban evicts the entry)
+
+```typescript
+// refresh_session_key_ttl has no TypeScript wrapper in AccountContract.
+// Invoke it via the contract's call() method:
+const op = contract.call('refresh_session_key_ttl', publicKeyScVal);
+// Build and submit this operation (no owner auth required).
+```
+
+**Revoking a key**
+
+```typescript
+const invocation = client.revokeSessionKey({ publicKey: sessionKeyPublicKey });
+// Build and submit with owner signature
+```
+
+---
+
+## Keeping documentation in sync
+
+When you change a contract entrypoint or SDK method signature:
+
+1. Update `docs/api-reference.yaml` — this is the source of truth
+2. Update the relevant section in `contract-methods.md` or `sdk-wrappers.md`
+3. Update any affected examples in `docs/examples/`
+4. If it is a breaking change, open an RFC and bump the major version
+
+**Breaking change definition**
+
+- Removing or renaming a parameter
+- Changing a parameter type
+- Adding a required parameter
+- Changing a return type
+- Removing an error code
+
+Adding optional parameters or new error codes is non-breaking.
+
+---
+
+## Team-specific notes
+
+### Extension wallet (`apps/extension-wallet`)
+
+- Session keys are stored in encrypted extension storage via `SecureStorageManager`
+- Sign auth entries through the background service message bus (see
+  [`examples/session-key-execute.md`](./examples/session-key-execute.md#extension-wallet-appsextension-wallet))
+- Use `chrome.runtime.sendMessage` for cross-context signing
+
+### Mobile wallet (`apps/mobile-wallet`)
+
+- Session keys are stored in the device keychain / secure enclave
+- Sign transactions using the platform keychain API
+- Handle `SimulationExpiredError` by prompting the user to retry — do not
+  silently swallow it
+
+### Web dashboard (`apps/web-dashboard`)
+
+- The dashboard may hold session keys in memory for the duration of a session
+- Clear keys on logout / tab close
+- Use `@ancore/crypto` signing utilities for in-browser key operations
+
+---
+
+## Testnet vs Mainnet
+
+| Setting | Testnet | Mainnet |
+|---------|---------|---------|
+| Network passphrase | `Test SDF Network ; September 2015` | `Public Global Stellar Network ; September 2015` |
+| RPC URL | `https://soroban-testnet.stellar.org` | `https://soroban.stellar.org` |
+| Horizon URL | `https://horizon-testnet.stellar.org` | `https://horizon.stellar.org` |
+
+Always test on Testnet first. Contract IDs differ between networks — never
+hardcode a contract ID; read it from environment configuration.
+
+---
+
+## Related
+
+- [Architecture overview](./architecture/OVERVIEW.md)
+- [Security model](./security/THREAT_MODEL.md)
+- [Contributing guide](../CONTRIBUTING.md)
+- [RFC process](../RFC.md)

--- a/docs/sdk-wrappers.md
+++ b/docs/sdk-wrappers.md
@@ -1,0 +1,398 @@
+# SDK Wrappers
+
+> Canonical reference for `@ancore/core-sdk` and `@ancore/account-abstraction` public APIs.  
+> Machine-readable spec: [`api-reference.yaml`](./api-reference.yaml)  
+> Last updated: 2026-04-24 · Issue #287
+
+---
+
+## Packages
+
+| Package | Stability | Description |
+|---------|-----------|-------------|
+| `@ancore/core-sdk` | Public (SemVer) | High-level SDK for app developers |
+| `@ancore/account-abstraction` | Public (SemVer) | Low-level contract wrapper and XDR utilities |
+| `@ancore/types` | Public (SemVer) | Shared TypeScript types |
+
+---
+
+## Shared types
+
+### `SessionKey` (`@ancore/types`)
+
+```typescript
+enum SessionPermission {
+  SEND_PAYMENT    = 0,
+  MANAGE_DATA     = 1,
+  INVOKE_CONTRACT = 2,
+}
+
+interface SessionKey {
+  publicKey:   string;             // G… Stellar address
+  permissions: SessionPermission[];
+  expiresAt:   number;             // unix milliseconds (ms) — @ancore/types definition
+  // Note: the contract stores/compares in unix seconds. The SDK's TTL helper
+  // auto-detects ms vs seconds (values > 100_000_000_000 treated as ms).
+  label?:      string;             // off-chain label only, not stored on-chain
+}
+```
+
+### `TransactionResult` (`@ancore/types`)
+
+```typescript
+interface TransactionResult {
+  status:    'success' | 'failure' | 'pending';
+  hash?:     string;   // present on success
+  ledger?:   number;   // present on success
+  error?:    string;   // present on failure
+  timestamp: number;   // unix ms
+}
+```
+
+### `InvocationArgs` (`@ancore/account-abstraction`)
+
+```typescript
+interface InvocationArgs {
+  method: string;
+  args:   xdr.ScVal[];
+}
+```
+
+Returned by all builder methods. Pass to your `TransactionBuilder` to construct
+the Stellar operation.
+
+---
+
+## Error hierarchy
+
+```
+AncoreSdkError                       (@ancore/core-sdk)
+├── BuilderValidationError           BUILDER_VALIDATION
+├── SimulationFailedError            SIMULATION_FAILED
+├── SimulationExpiredError           SIMULATION_EXPIRED
+├── TransactionSubmissionError       SUBMISSION_FAILED
+├── SessionKeyManagementError        SESSION_KEY_MANAGEMENT_FAILED
+├── SessionKeyExecutionValidationError  SESSION_KEY_EXECUTION_VALIDATION
+└── SessionKeyExecutionError         SESSION_KEY_EXECUTION_*
+
+AccountContractError                 (@ancore/account-abstraction)
+├── AlreadyInitializedError          ALREADY_INITIALIZED
+├── NotInitializedError              NOT_INITIALIZED
+├── UnauthorizedError                UNAUTHORIZED
+├── InvalidNonceError                INVALID_NONCE
+├── SessionKeyNotFoundError          SESSION_KEY_NOT_FOUND
+├── SessionKeyExpiredError           SESSION_KEY_EXPIRED
+├── InsufficientPermissionError      INSUFFICIENT_PERMISSION
+└── ContractInvocationError          CONTRACT_INVOCATION
+```
+
+All errors expose a `.code` string for programmatic handling.
+
+---
+
+## `@ancore/core-sdk`
+
+### `AncoreClient`
+
+High-level client. Instantiate once per account contract.
+
+```typescript
+import { AncoreClient } from '@ancore/core-sdk';
+
+const client = new AncoreClient({ accountContractId: 'C...' });
+```
+
+**Constructor**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `options.accountContractId` | `string` | ✓ | Deployed contract ID (C… address) |
+
+Throws `BuilderValidationError` if `accountContractId` is empty.
+
+---
+
+#### `client.addSessionKey`
+
+Build the `InvocationArgs` for `add_session_key`. Synchronous — does not submit.
+
+```typescript
+addSessionKey(params: AddSessionKeyParams): InvocationArgs
+```
+
+```typescript
+interface AddSessionKeyParams {
+  publicKey:   string;             // G… Ed25519 public key
+  permissions: SessionPermission[];
+  expiresAt:   number;             // unix seconds (passed to contract)
+  // Note: @ancore/types SessionKey.expiresAt is unix ms — convert if reading
+  // from a stored SessionKey: Math.floor(sessionKey.expiresAt / 1000)
+}
+```
+
+**Validation rules**
+
+| Field | Rule |
+|-------|------|
+| `publicKey` | Non-empty string |
+| `permissions` | Must be an array |
+| `expiresAt` | Finite number |
+
+**Errors**
+
+| Error | Code | Condition |
+|-------|------|-----------|
+| `BuilderValidationError` | `BUILDER_VALIDATION` | Any field fails validation |
+| `SessionKeyManagementError` | `SESSION_KEY_MANAGEMENT_FAILED` | Unexpected error from contract layer |
+
+**Example**
+
+```typescript
+const invocation = client.addSessionKey({
+  publicKey:   'GABC...XYZ',
+  permissions: [SessionPermission.SEND_PAYMENT],
+  expiresAt:   Math.floor(Date.now() / 1000) + 3600, // 1 hour
+});
+// Pass invocation to your transaction builder
+```
+
+---
+
+#### `client.revokeSessionKey`
+
+Build the `InvocationArgs` for `revoke_session_key`. Synchronous — does not submit.
+
+```typescript
+revokeSessionKey(params: RevokeSessionKeyParams): InvocationArgs
+```
+
+```typescript
+interface RevokeSessionKeyParams {
+  publicKey: string; // G… Ed25519 public key to revoke
+}
+```
+
+**Errors**
+
+| Error | Code | Condition |
+|-------|------|-----------|
+| `BuilderValidationError` | `BUILDER_VALIDATION` | `publicKey` is empty |
+| `SessionKeyManagementError` | `SESSION_KEY_REVOKE_FAILED` | Unexpected error from contract layer |
+
+---
+
+### `executeWithSessionKey` (standalone export)
+
+> **Not a method on `AncoreClient`** (the one exported from `ancore-client.ts`).
+> This is a standalone function exported from `execute-with-session-key.ts`.
+> It is also available as a method on the internal `AncoreClient` class defined
+> in that same file, which accepts `{ accountContract, executionLayer }`.
+
+Execute a cross-contract call authenticated by a session key. Validates inputs,
+builds the `execute` invocation, delegates to the execution layer for signing
+and submission.
+
+```typescript
+import { executeWithSessionKey, type ExecuteWithSessionKeyParams } from '@ancore/core-sdk';
+```
+
+```typescript
+async function executeWithSessionKey<TResult, TArgs extends readonly xdr.ScVal[]>(
+  params: ExecuteWithSessionKeyParams<TArgs>
+): Promise<ExecuteWithSessionKeyResult<TResult>>
+```
+
+```typescript
+interface ExecuteWithSessionKeyParams<TArgs> {
+  target:        string;                  // target contract address (G… or C…)
+  function:      string;                  // function name on target contract
+  args:          TArgs;                   // xdr.ScVal[] arguments
+  expectedNonce: number;                  // current contract nonce
+  signer: {
+    publicKey:        string;             // session key G… address
+    signAuthEntryXdr: (xdr: string) => Promise<string> | string;
+  };
+}
+
+interface ExecuteWithSessionKeyResult<TResult> {
+  result:           TResult;
+  transactionHash?: string;
+}
+```
+
+**Validation rules**
+
+| Field | Rule |
+|-------|------|
+| `target` | Valid Stellar `Address` (G… or C…) |
+| `function` | Non-empty string |
+| `args` | Must be an array |
+| `expectedNonce` | Non-negative integer |
+| `signer.publicKey` | Valid Ed25519 public key |
+| `signer.signAuthEntryXdr` | Must be a function |
+
+**Errors**
+
+| Error | Code | Condition |
+|-------|------|-----------|
+| `SessionKeyExecutionValidationError` | `SESSION_KEY_EXECUTION_VALIDATION` | Input validation fails |
+| `SessionKeyExecutionError` | `SESSION_KEY_EXECUTION_UNAUTHORIZED` | Contract: `Unauthorized` |
+| `SessionKeyExecutionError` | `SESSION_KEY_EXECUTION_INVALID_NONCE` | Contract: `InvalidNonce` |
+| `SessionKeyExecutionError` | `SESSION_KEY_EXECUTION_NOT_INITIALIZED` | Contract: `NotInitialized` |
+| `SessionKeyExecutionError` | `SESSION_KEY_EXECUTION_CONTRACT` | Any other `AccountContractError` |
+| `SessionKeyExecutionError` | `SESSION_KEY_EXECUTION_FAILED` | Unknown error |
+
+**Async** — returns `Promise<ExecuteWithSessionKeyResult<TResult>>`
+
+---
+
+### `sendPayment`
+
+Build, sign, and submit a Stellar payment transaction.
+
+```typescript
+import { sendPayment, type SendPaymentParams, type SendPaymentDeps } from '@ancore/core-sdk';
+
+const result = await sendPayment(params, deps);
+```
+
+```typescript
+interface SendPaymentParams {
+  to:      string;                                        // destination G… address
+  amount:  string;                                        // decimal string e.g. "10.5000000"
+  asset?:  { code: string; issuer: string } | 'native';  // default: 'native' (XLM)
+  signer:  PaymentSigner;
+}
+
+interface PaymentSigner {
+  sign(transactionXdr: string): Promise<string> | string;
+}
+
+interface SendPaymentDeps {
+  sourceAccount:  Account;                        // loaded Stellar Account
+  builderOptions: AccountTransactionBuilderOptions;
+  stellarClient:  StellarClient;
+}
+```
+
+**Validation rules**
+
+| Field | Rule |
+|-------|------|
+| `to` | Non-empty string |
+| `amount` | Positive numeric string |
+| `signer` | Must implement `PaymentSigner` |
+
+**Internal flow**
+
+1. Validate params
+2. Build `Operation.payment` with resolved asset
+3. `AccountTransactionBuilder.build()` — simulate + assemble
+4. `signer.sign(tx.toXDR())` — sign the assembled transaction
+5. `stellarClient.submitTransaction(signedTx)` — submit to network
+6. Return `TransactionResult`
+
+**Errors**
+
+| Error | Code | Condition |
+|-------|------|-----------|
+| `BuilderValidationError` | `BUILDER_VALIDATION` | Invalid params |
+| `SimulationFailedError` | `SIMULATION_FAILED` | Soroban simulation error |
+| `SimulationExpiredError` | `SIMULATION_EXPIRED` | Simulation requires ledger restoration |
+| `TransactionSubmissionError` | `SUBMISSION_FAILED` | Signing or network submission fails |
+
+**Returns** `Promise<TransactionResult>`
+
+---
+
+### `addSessionKey` (standalone)
+
+Functional form — useful when you don't need the full `AncoreClient`.
+
+```typescript
+import { addSessionKey } from '@ancore/core-sdk';
+
+const invocation = addSessionKey(accountContract, {
+  publicKey:   'GABC...XYZ',
+  permissions: [SessionPermission.SEND_PAYMENT],
+  expiresAt:   Math.floor(Date.now() / 1000) + 3600,
+});
+```
+
+---
+
+### `revokeSessionKey` (standalone)
+
+```typescript
+import { revokeSessionKey } from '@ancore/core-sdk';
+
+const invocation = revokeSessionKey(accountContract, { publicKey: 'GABC...XYZ' });
+```
+
+---
+
+## `@ancore/account-abstraction`
+
+### `AccountContract`
+
+Low-level wrapper around the Soroban account contract. Used internally by
+`@ancore/core-sdk` and available for advanced use cases.
+
+```typescript
+import { AccountContract } from '@ancore/account-abstraction';
+
+const contract = new AccountContract('C...');
+```
+
+#### Builder methods (synchronous)
+
+These return `InvocationArgs` — they do not submit transactions.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `initialize` | `(owner: string): InvocationArgs` | Build `initialize` invocation |
+| `execute` | `(to, fn, args, nonce): InvocationArgs` | Build `execute` invocation |
+| `addSessionKey` | `(publicKey, permissions, expiresAt): InvocationArgs` | Build `add_session_key` invocation (note: TS order differs from contract — contract is `public_key, expires_at, permissions`) |
+| `revokeSessionKey` | `(publicKey): InvocationArgs` | Build `revoke_session_key` invocation |
+
+#### Read methods (async — require RPC server)
+
+```typescript
+interface AccountContractReadOptions {
+  server: {
+    getAccount(id: string): Promise<{ id: string; sequence: string }>;
+    simulateTransaction(tx: unknown): Promise<unknown>;
+  };
+  sourceAccount:     string;
+  networkPassphrase?: string;
+}
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getOwner(options)` | `Promise<string>` | Owner address |
+| `getNonce(options)` | `Promise<number>` | Current nonce |
+| `getSessionKey(publicKey, options)` | `Promise<SessionKey \| null>` | Session key or null |
+
+All read methods throw `AccountContractError` subclasses on failure.
+
+#### `executeContract` / `simulateExecute`
+
+```typescript
+// Full submission
+executeContract<T>(to, fn, args, nonce, options: ExecuteOptions): Promise<ExecuteResult<T>>
+
+// Simulation only (no submission)
+simulateExecute<T>(to, fn, args, nonce, options): Promise<T>
+```
+
+---
+
+## Version compatibility
+
+| SDK version | Contract version | Notes |
+|-------------|-----------------|-------|
+| `0.1.x` | `1` | Initial release |
+
+Breaking changes to public APIs require a major version bump and RFC.
+See [`RFC.md`](../RFC.md) for the process.


### PR DESCRIPTION
Closes #287 


 Description                                                                                                                                             
                                                                                                                                                          
  ## Summary                                                                                                                                              
                                                                                                                                                          
  Adds canonical interface documentation for all contract entrypoints and SDK                                                                             
  wrapper methods, resolving the integration drift described in #287.                                                                                     
                                                                                                                                                          
  ## Files added                                                                                                                                          
                                                                                                                                                          
  | File | Purpose |                                                                                                                                      
  |------|---------|                                                                                                                                      
  | `docs/api-reference.yaml` | Machine-readable source of truth — all contract methods, SDK wrappers, error codes, and events |                          
  | `docs/contract-methods.md` | Human-readable contract entrypoint reference (params, errors, state changes, events) |                                   
  | `docs/sdk-wrappers.md` | SDK wrapper reference with error hierarchy and version compatibility |                                                       
  | `docs/examples/session-key-execute.md` | End-to-end session-key execute flow with platform-specific signing examples |                                
  | `docs/examples/send-payment.md` | End-to-end payment flow with error handling and platform notes |                                                    
  | `docs/integration-guide.md` | Team integration guidelines, error handling patterns, nonce retry pattern, doc-sync process |                           
                                                                                                                                                          
  ## Key decisions                                                                                                                                        
                                                                                                                                                          
  - `docs/api-reference.yaml` is the **source of truth** — all other docs reference it. When a signature changes, update the YAML first.                  
  - Documented the `add_session_key` auth ordering: `InvalidExpiration (11)` fires **before** `require_auth()`.                                           
  - Clarified `PERMISSION_EXECUTE = 1` is a separate contract constant from `SessionPermission.MANAGE_DATA = 1` (same value, different meaning).          
  - Documented the `expiresAt` units discrepancy: `AddSessionKeyParams.expiresAt` is unix **seconds** (contract layer); `@ancore/types                    
  SessionKey.expiresAt` is unix **ms**.                                                                                                                   
  - `executeWithSessionKey` is a standalone export, not a method on the `AncoreClient` exported from `ancore-client.ts` — documented clearly.             
  - `is_session_key_active` and `refresh_session_key_ttl` have no TypeScript wrappers in `AccountContract` — examples use `contract.call()` directly.     
                                                                                                                                                          
  ## Testing                                                                                                                                              
                                                                                                                                                          
  - All code snippets verified against actual source in `contracts/account/src/lib.rs`, `packages/core-sdk/src/`, and `packages/account-abstraction/src/`.
  - No existing files modified; no breaking changes.                                                                                                      
                                                                                                                                                          
  ## Checklist                                                                                                                                            
                                                                                                                                                          
  - [x] All contract entrypoints documented with parameters and error variants                                                                            
  - [x] SDK wrapper methods have complete interface documentation                                                                                         
  - [x] Session-key execute and send-payment examples complete                                                                                            
  - [x] No overlap with existing documentation  
- docs/api-reference.yaml: machine-readable spec for all contract entrypoints and SDK wrapper methods
- docs/contract-methods.md: full contract entrypoint reference with parameters, errors, state changes, and events
- docs/sdk-wrappers.md: SDK wrapper method reference with error hierarchy and version compatibility
- docs/examples/session-key-execute.md: end-to-end session-key execute flow with platform-specific signing examples
- docs/examples/send-payment.md: end-to-end payment flow with error handling and platform notes
- docs/integration-guide.md: team integration guidelines, error handling patterns, and doc-sync process


<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Check all that apply -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/improvement

## Security Impact

<!-- Describe any security implications of this change -->

- [ ] This change involves cryptographic operations
- [ ] This change affects account validation logic
- [ ] This change modifies smart contracts
- [ ] This change handles user private keys
- [ ] This change affects authorization/authentication
- [ ] No security impact

<!-- If you checked any boxes above, explain the security considerations -->

## Testing

<!-- Describe the testing you've performed -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests added/updated (if applicable)

### Test Coverage

<!-- Provide test coverage metrics if applicable -->

- Current coverage: \_\_%
- New/modified code coverage: \_\_%

### Manual Testing Steps

<!-- If you performed manual testing, describe the steps -->

1.
2.
3.

## Breaking Changes

<!-- If this is a breaking change, describe what breaks and migration steps -->

- [ ] This PR introduces breaking changes

<!-- If yes, explain what breaks and how to migrate -->

## Checklist

<!-- Check all items before requesting review -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

### For High-Security Changes

<!-- Only required for changes in contracts/, packages/crypto/, or packages/account-abstraction/ -->

- [ ] I have documented all security assumptions
- [ ] I have considered attack vectors
- [ ] I have added security-focused test cases
- [ ] I have reviewed against the threat model

## Related Issues

<!-- Link related issues here -->



## Additional Context

## Additional Context

<!-- Add any other context, screenshots, or information about the PR here -->

## Reviewer Notes

<!-- Anything specific you want reviewers to focus on? -->

---

<!--
Thank you for contributing to Ancore!

Please ensure you have read:
- CONTRIBUTING.md
- SECURITY.md (for security-sensitive changes)
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API reference documentation for contract methods and SDK interfaces
  * Added integration guide with best practices, checklists, and lifecycle operations for session keys
  * Added end-to-end example tutorials for sending payments and executing contract calls with session keys
  * Added complete SDK wrapper documentation with error handling guidance and type specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->