### PR TITLE
feat: add deterministic extension E2E smoke gate for release candidates (#281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,32 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+  extension-e2e-smoke:
+    name: Extension E2E Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser dependencies
+        run: pnpm --filter @ancore/extension-wallet exec playwright install --with-deps chromium
+
+      - name: Run extension smoke suite
+        run: pnpm --filter @ancore/extension-wallet test:e2e:smoke
+
   contracts:
     name: Build & Test Contracts
     runs-on: ubuntu-latest

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -251,6 +251,39 @@ jobs:
         run: echo "status=${{ job.status }}" >> "$GITHUB_OUTPUT"
 
 # ─────────────────────────────────────────────────────────────────────────────
+# GATE 6 — Extension E2E smoke suite
+# ─────────────────────────────────────────────────────────────────────────────
+  gate-extension-e2e-smoke:
+    name: '[Gate 6] Extension E2E Smoke'
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.result.outputs.status }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser dependencies
+        run: pnpm --filter @ancore/extension-wallet exec playwright install --with-deps chromium
+
+      - name: Run extension smoke suite
+        run: pnpm --filter @ancore/extension-wallet test:e2e:smoke
+
+      - id: result
+        if: always()
+        run: echo "status=${{ job.status }}" >> "$GITHUB_OUTPUT"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # SUMMARY — Collect all gate results and publish artifact
 # ─────────────────────────────────────────────────────────────────────────────
   gate-summary:
@@ -261,6 +294,7 @@ jobs:
       - gate-security
       - gate-observability
       - gate-release-docs
+      - gate-extension-e2e-smoke
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -274,6 +308,7 @@ jobs:
           GATE3: ${{ needs.gate-security.outputs.status }}
           GATE4: ${{ needs.gate-observability.outputs.status }}
           GATE5: ${{ needs.gate-release-docs.outputs.status }}
+          GATE6: ${{ needs.gate-extension-e2e-smoke.outputs.status }}
           REF:   ${{ github.ref_name }}
           SHA:   ${{ github.sha }}
           ACTOR: ${{ github.actor }}
@@ -293,6 +328,7 @@ jobs:
               "Security Audit":          os.environ["GATE3"],
               "Observability Configs":   os.environ["GATE4"],
               "Release Docs":            os.environ["GATE5"],
+              "Extension E2E Smoke":     os.environ["GATE6"],
           }
 
           all_pass = all(v == "success" for v in gates.values())

--- a/apps/extension-wallet/README.md
+++ b/apps/extension-wallet/README.md
@@ -64,3 +64,26 @@ Configure timeout via `useSettingsStore().setAutoLockMinutes(n)` (0 = never lock
 
 - `storage` — persist wallet state
 - `activeTab` — interact with active tab for dApp connections
+
+## E2E Smoke Suite
+
+Release candidates use a deterministic Playwright smoke suite that validates:
+
+- onboarding (`/welcome` -> `/home`)
+- lock/unlock (`/unlock` -> `/home`)
+- send/receive navigation (`/send`, `/receive`)
+- session key access controls (`/session-keys`)
+
+Run locally:
+
+```bash
+pnpm --filter @ancore/extension-wallet test:e2e:smoke
+```
+
+Debug locally (headed, single worker, traces on):
+
+```bash
+pnpm --filter @ancore/extension-wallet test:e2e:smoke:debug
+```
+
+See `docs/testing/extension-e2e-smoke.md` for troubleshooting and CI behavior.

--- a/apps/extension-wallet/package.json
+++ b/apps/extension-wallet/package.json
@@ -10,6 +10,8 @@
     "test:watch": "vitest",
     "lint": "eslint src/",
     "test:e2e": "playwright test --config=tests/playwright.config.ts",
+    "test:e2e:smoke": "playwright test --config=tests/playwright.config.ts --grep @smoke",
+    "test:e2e:smoke:debug": "playwright test --config=tests/playwright.config.ts --grep @smoke --headed --workers=1 --project=chromium --trace=on",
     "analyze": "node scripts/analyze-bundle.js"
   },
   "dependencies": {

--- a/apps/extension-wallet/tests/e2e/smoke.spec.ts
+++ b/apps/extension-wallet/tests/e2e/smoke.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect, navigateTo } from '../fixtures/extension';
+
+test.describe('Extension release-candidate smoke @smoke', () => {
+  test('onboarding creates wallet and lands on home', async ({ page, clearWallet, freezeTime }) => {
+    await freezeTime('2026-01-15T10:00:00.000Z');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await clearWallet();
+
+    await page.goto('/welcome');
+    await page.getByText('Create a wallet').click();
+    await expect(page).toHaveURL(/\/create-account/);
+
+    const walletName = page.getByPlaceholder('My Ancore Wallet');
+    await walletName.fill('Smoke Wallet');
+    await page.getByRole('button', { name: /Create wallet/i }).click();
+
+    await expect(page).toHaveURL(/\/home/);
+    await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
+  });
+
+  test('locked wallet unlocks and returns to home', async ({ page, seedWallet, freezeTime }) => {
+    await freezeTime('2026-01-15T10:00:00.000Z');
+    await seedWallet('onboarded-locked');
+    await navigateTo(page, '/');
+
+    await expect(page).toHaveURL(/\/unlock/);
+    await page.getByPlaceholder('Enter your password').fill('smoke-pass');
+    await page.getByRole('button', { name: /Unlock/i }).click();
+
+    await expect(page).toHaveURL(/\/home/);
+    await expect(page.getByText('Available balance')).toBeVisible();
+  });
+
+  test('send and receive core screens are reachable', async ({ page, seedWallet, freezeTime }) => {
+    await freezeTime('2026-01-15T10:00:00.000Z');
+    await seedWallet('onboarded-unlocked');
+    await navigateTo(page, '/home');
+
+    await page.getByText('Send funds').click();
+    await expect(page).toHaveURL(/\/send/);
+    await expect(page.getByPlaceholder('Recipient address')).toBeVisible();
+    await expect(page.getByPlaceholder('Amount')).toBeVisible();
+
+    await navigateTo(page, '/home');
+    await page.getByText('Receive funds').click();
+    await expect(page).toHaveURL(/\/receive/);
+    await expect(page.getByRole('button', { name: /Copy address/i })).toBeVisible();
+  });
+
+  test('session key page is available for unlocked wallet and blocked when logged out', async ({
+    page,
+    seedWallet,
+    clearWallet,
+    freezeTime,
+  }) => {
+    await freezeTime('2026-01-15T10:00:00.000Z');
+    await seedWallet('onboarded-unlocked');
+    await navigateTo(page, '/session-keys');
+
+    await expect(page.getByText('Active keys')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Add session key/i })).toBeVisible();
+
+    await clearWallet();
+    await navigateTo(page, '/session-keys');
+    await expect(page).not.toHaveURL(/\/session-keys$/);
+  });
+});

--- a/apps/extension-wallet/tests/fixtures/extension.ts
+++ b/apps/extension-wallet/tests/fixtures/extension.ts
@@ -28,12 +28,13 @@ const AUTH_PRESETS = {
 export interface ExtensionFixtures {
   seedWallet: (state: WalletState) => Promise<void>;
   clearWallet: () => Promise<void>;
+  freezeTime: (isoDate: string) => Promise<void>;
 }
 
 export const test = base.extend<ExtensionFixtures>({
   seedWallet: async ({ page }, use) => {
     await use(async (state: WalletState) => {
-      await page.goto('/');
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
       await page.evaluate(
         ([key, value]) => {
           localStorage.setItem(key, JSON.stringify(value));
@@ -48,11 +49,23 @@ export const test = base.extend<ExtensionFixtures>({
       await page.evaluate((key) => localStorage.removeItem(key), AUTH_KEY);
     });
   },
+
+  freezeTime: async ({ page }, use) => {
+    await use(async (isoDate: string) => {
+      const fixedTime = new Date(isoDate).getTime();
+      await page.addInitScript((mockedNow) => {
+        const realNow = Date.now.bind(Date);
+        Date.now = () => mockedNow;
+        (window as Window & { __restoreDateNow?: () => void }).__restoreDateNow = () => {
+          Date.now = realNow;
+        };
+      }, fixedTime);
+    });
+  },
 });
 
 export { expect } from '@playwright/test';
 
 export async function navigateTo(page: Page, path: string): Promise<void> {
-  await page.goto(path);
-  await page.waitForLoadState('networkidle');
+  await page.goto(path, { waitUntil: 'domcontentloaded' });
 }

--- a/apps/extension-wallet/tests/playwright.config.ts
+++ b/apps/extension-wallet/tests/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
 
   webServer: {
     // ui-kit must be built before dev server starts; CI runs `pnpm build:deps` first
-    command: 'pnpm --filter @ancore/ui-kit build && pnpm dev',
+    command: 'corepack pnpm --filter @ancore/ui-kit build && corepack pnpm dev',
     url: 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/docs/testing/extension-e2e-smoke.md
+++ b/docs/testing/extension-e2e-smoke.md
@@ -1,0 +1,44 @@
+# Extension E2E Smoke Suite
+
+This suite is the minimum release-candidate confidence gate for the extension wallet.
+
+## Coverage
+
+- Onboarding: create wallet flow reaches `home`
+- Lock/Unlock: locked wallet unlocks to `home`
+- Send/Receive: core transfer screens are reachable
+- Session Keys: unlocked access allowed, logged-out access blocked
+
+## Determinism Guarantees
+
+- Stable auth fixtures seeded directly into `localStorage` (`tests/fixtures/extension.ts`)
+- Fixed clock per test via `freezeTime()` to avoid timing drift
+- No remote dependencies required for smoke assertions
+- Single tagged test target (`@smoke`) to keep suite scope explicit
+
+## Local Runner
+
+From repository root:
+
+```bash
+pnpm --filter @ancore/extension-wallet test:e2e:smoke
+```
+
+Debug mode:
+
+```bash
+pnpm --filter @ancore/extension-wallet test:e2e:smoke:debug
+```
+
+## Debugging Tips
+
+- If selectors fail, inspect current route and assert URL first before UI expectations.
+- Keep smoke assertions focused on user-critical outcomes, not full-page snapshots.
+- Prefer fixture seeding over multi-step setup when reproducing a failure quickly.
+- Use Playwright traces from debug mode to inspect exact action timing and DOM state.
+
+## CI Integration
+
+- Pull request and branch CI includes a required `Extension E2E Smoke` job.
+- Release gate includes `[Gate 6] Extension E2E Smoke`.
+- Any failure blocks release gate completion unless a manual override is explicitly used for other failing gates.


### PR DESCRIPTION
Closes #281
 ## Summary
- Add a deterministic Playwright smoke suite for extension release candidates covering onboarding, lock/unlock, send/receive, and session keys.
- Introduce stable E2E fixture helpers (`seedWallet`, `clearWallet`, `freezeTime`) and tighten route navigation timing for lower flake risk.
- Make smoke suite a required CI/release gate via `Extension E2E Smoke` in CI and `[Gate 6] Extension E2E Smoke` in release gating.
- Add local runner and debugging docs for quick failure triage.

## Scope
### Added
- `apps/extension-wallet/tests/e2e/smoke.spec.ts`
- `docs/testing/extension-e2e-smoke.md`

### Updated
- `.github/workflows/ci.yml`
- `.github/workflows/release-gate.yml`
- `apps/extension-wallet/tests/fixtures/extension.ts`
- `apps/extension-wallet/tests/playwright.config.ts`
- `apps/extension-wallet/package.json`
- `apps/extension-wallet/README.md`

## Determinism Notes
- Smoke tests use seeded auth fixtures instead of multi-step setup where possible.
- Time-sensitive behavior uses fixed clock injection through `freezeTime()`.
- Assertions target core user-critical outcomes and stable route/UI states.

## Test Plan
- [x] Local smoke run: `corepack pnpm --filter @ancore/extension-wallet test:e2e:smoke`
- [x] 4 smoke specs pass locally
- [ ] CI `Extension E2E Smoke` job passes
- [ ] Release gate `[Gate 6] Extension E2E Smoke` passes

## Issue
Closes #281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated smoke test suite for extension releases validating core workflows including onboarding, wallet operations, and session key functionality.

* **Chores**
  * Implemented release gate requiring extension E2E smoke tests to pass before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->