### PR TITLE
feat: Add explicit negative contract coverage for owner-only upgrade() authorization.

### DIFF
--- a/contracts/account/src/lib.rs
+++ b/contracts/account/src/lib.rs
@@ -476,9 +476,9 @@ mod test {
     use ed25519_dalek::{Signer, SigningKey};
     use rand::rngs::OsRng;
     use soroban_sdk::{
-        testutils::{Address as _, Events, Ledger},
+        testutils::{Address as _, Events, Ledger, MockAuth, MockAuthInvoke},
         xdr::ToXdr,
-        Address, Bytes, Env,
+        Address, Bytes, Env, IntoVal,
     };
 
     fn sign_payload(
@@ -1744,16 +1744,23 @@ mod test {
         let client = AncoreAccountClient::new(&env, &contract_id);
 
         let owner = Address::generate(&env);
+        let non_owner = Address::generate(&env);
         client.initialize(&owner);
 
-        // Do NOT mock auth — non-owner caller should be rejected before wasm call
         let dummy_hash = BytesN::from_array(&env, &[0u8; 32]);
-        // Calling upgrade without owner auth must panic (auth required)
+
+        env.mock_auths(&[MockAuth {
+            address: &non_owner,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "upgrade",
+                args: (dummy_hash.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
         let result = client.try_upgrade(&dummy_hash);
-        assert!(
-            result.is_err(),
-            "upgrade without owner auth must be rejected"
-        );
+        assert!(result.is_err(), "non-owner upgrade must be rejected");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add explicit negative contract coverage for owner-only `upgrade()` authorization.

## What Changed

- updated the account contract tests to authorize a non-owner caller explicitly
- asserted that `upgrade()` is rejected for that non-owner path
- kept the existing owner-authorized upgrade coverage intact

## Testing

- attempted: `cargo test -p ancore-account test_upgrade_unauthorized_caller_rejected -- --exact --nocapture`
- blocked locally by toolchain/dependency mismatch:
  - Cargo `1.75.0`
  - `time-core 0.1.8` requires `edition2024`

Closes #209


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced contract upgrade authorization testing with improved mocking of non-owner authorization scenarios to ensure proper security validation and rejection of unauthorized callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->