### PR TITLE
fix: harden extension unlock gate correctness

### DIFF
--- a/apps/extension-wallet/src/router/AuthGuard.tsx
+++ b/apps/extension-wallet/src/router/AuthGuard.tsx
@@ -19,13 +19,18 @@ export const DEFAULT_AUTH_STATE: AuthState = {
 
 interface AuthContextValue {
   authState: AuthState;
+  unlockError: string | null;
   completeOnboarding: (walletName: string) => void;
-  unlockWallet: () => void;
+  unlockWallet: (password: string) => Promise<boolean>;
   lockWallet: () => void;
   resetWallet: () => void;
 }
 
 const AuthContext = React.createContext<AuthContextValue | null>(null);
+
+export type UnlockVerifier = (password: string) => boolean | Promise<boolean>;
+
+const DEFAULT_UNLOCK_ERROR = 'Incorrect password. Please try again.';
 
 export function readAuthState(): AuthState {
   if (typeof window === 'undefined') {
@@ -51,8 +56,15 @@ function writeAuthState(authState: AuthState): void {
   window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(authState));
 }
 
-export function ExtensionAuthProvider({ children }: { children: React.ReactNode }) {
+export function ExtensionAuthProvider({
+  children,
+  unlockVerifier,
+}: {
+  children: React.ReactNode;
+  unlockVerifier?: UnlockVerifier;
+}) {
   const [authState, setAuthState] = React.useState<AuthState>(readAuthState);
+  const [unlockError, setUnlockError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     writeAuthState(authState);
@@ -72,7 +84,9 @@ export function ExtensionAuthProvider({ children }: { children: React.ReactNode 
   const value = React.useMemo<AuthContextValue>(
     () => ({
       authState,
+      unlockError,
       completeOnboarding: (walletName: string) => {
+        setUnlockError(null);
         setAuthState({
           hasOnboarded: true,
           isUnlocked: true,
@@ -80,24 +94,48 @@ export function ExtensionAuthProvider({ children }: { children: React.ReactNode 
           accountAddress: DEFAULT_AUTH_STATE.accountAddress,
         });
       },
-      unlockWallet: () => {
-        setAuthState((current) => ({
-          ...current,
-          hasOnboarded: true,
-          isUnlocked: true,
-        }));
+      unlockWallet: async (password: string) => {
+        try {
+          const isValid = await (unlockVerifier?.(password) ?? Boolean(password.trim()));
+
+          if (!isValid) {
+            setUnlockError(DEFAULT_UNLOCK_ERROR);
+            setAuthState((current) => ({
+              ...current,
+              isUnlocked: false,
+            }));
+            return false;
+          }
+
+          setUnlockError(null);
+          setAuthState((current) => ({
+            ...current,
+            hasOnboarded: true,
+            isUnlocked: true,
+          }));
+          return true;
+        } catch {
+          setUnlockError(DEFAULT_UNLOCK_ERROR);
+          setAuthState((current) => ({
+            ...current,
+            isUnlocked: false,
+          }));
+          return false;
+        }
       },
       lockWallet: () => {
+        setUnlockError(null);
         setAuthState((current) => ({
           ...current,
           isUnlocked: false,
         }));
       },
       resetWallet: () => {
+        setUnlockError(null);
         setAuthState(DEFAULT_AUTH_STATE);
       },
     }),
-    [authState]
+    [authState, unlockError, unlockVerifier]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/extension-wallet/src/router/__tests__/router.test.tsx
+++ b/apps/extension-wallet/src/router/__tests__/router.test.tsx
@@ -1,12 +1,22 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it } from 'vitest';
+import type { UnlockVerifier } from '../AuthGuard';
 import { AUTH_STORAGE_KEY, DEFAULT_AUTH_STATE } from '../AuthGuard';
 import { ExtensionRouterTestHarness } from '..';
 
-function renderRouter(pathname: string, authState = DEFAULT_AUTH_STATE) {
+function renderRouter(
+  pathname: string,
+  authState = DEFAULT_AUTH_STATE,
+  options?: { unlockVerifier?: UnlockVerifier }
+) {
   window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(authState));
-  return render(<ExtensionRouterTestHarness initialEntries={[pathname]} />);
+  return render(
+    <ExtensionRouterTestHarness
+      initialEntries={[pathname]}
+      unlockVerifier={options?.unlockVerifier}
+    />
+  );
 }
 
 describe('extension router', () => {
@@ -31,6 +41,33 @@ describe('extension router', () => {
 
     expect(screen.getByRole('heading', { name: /unlock wallet/i })).toBeInTheDocument();
     expect(document.title).toBe('Unlock Wallet | Ancore Extension');
+  });
+
+  it('keeps locked users on unlock when password verification fails', async () => {
+    const user = userEvent.setup();
+    renderRouter(
+      '/send',
+      {
+        ...DEFAULT_AUTH_STATE,
+        hasOnboarded: true,
+        walletName: 'Locked Wallet',
+      },
+      {
+        unlockVerifier: async () => false,
+      }
+    );
+
+    await user.type(screen.getByLabelText(/password/i), 'wrong-password');
+    await user.click(screen.getByRole('button', { name: /unlock/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/incorrect password/i);
+    expect(screen.getByRole('heading', { name: /unlock wallet/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /home/i })).not.toBeInTheDocument();
+    expect(document.title).toBe('Unlock Wallet | Ancore Extension');
+    expect(JSON.parse(window.localStorage.getItem(AUTH_STORAGE_KEY) ?? '{}')).toMatchObject({
+      hasOnboarded: true,
+      isUnlocked: false,
+    });
   });
 
   it('creates an account and lands on the protected home route', async () => {

--- a/apps/extension-wallet/src/router/index.tsx
+++ b/apps/extension-wallet/src/router/index.tsx
@@ -21,7 +21,13 @@ import {
   Wallet,
 } from 'lucide-react';
 import { NotificationProvider } from '@ancore/ui-kit';
-import { AuthGuard, ExtensionAuthProvider, PublicOnlyGuard, useExtensionAuth } from './AuthGuard';
+import {
+  AuthGuard,
+  ExtensionAuthProvider,
+  PublicOnlyGuard,
+  UnlockVerifier,
+  useExtensionAuth,
+} from './AuthGuard';
 import { NavBar } from '../components/Navigation/NavBar';
 import { SettingsScreen } from '../screens/Settings/SettingsScreen';
 import { useDashboardSettingsStore } from '../state/dashboard-settings';
@@ -258,14 +264,23 @@ function CreateAccountScreen() {
 function UnlockScreen() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { authState, unlockWallet, resetWallet } = useExtensionAuth();
+  const { authState, unlockError, unlockWallet, resetWallet } = useExtensionAuth();
   const [password, setPassword] = React.useState('');
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
   const from = (location.state as { from?: string } | null)?.from ?? '/home';
 
-  function handleUnlock(event: React.FormEvent<HTMLFormElement>) {
+  async function handleUnlock(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    unlockWallet();
-    navigate(from, { replace: true });
+    setIsSubmitting(true);
+
+    try {
+      const didUnlock = await unlockWallet(password);
+      if (didUnlock) {
+        navigate(from, { replace: true });
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   return (
@@ -286,8 +301,16 @@ function UnlockScreen() {
               value={password}
             />
           </label>
-          <PrimaryButton disabled={!password.trim()} type="submit">
-            Unlock
+          {unlockError ? (
+            <p
+              className="rounded-xl border border-red-500/20 bg-red-500/10 px-3 py-2 text-sm text-red-600"
+              role="alert"
+            >
+              {unlockError}
+            </p>
+          ) : null}
+          <PrimaryButton disabled={isSubmitting || !password.trim()} type="submit">
+            {isSubmitting ? 'Unlocking…' : 'Unlock'}
           </PrimaryButton>
         </form>
       </Card>
@@ -550,11 +573,17 @@ export function ExtensionRouter() {
   );
 }
 
-export function ExtensionRouterTestHarness({ initialEntries }: { initialEntries: string[] }) {
+export function ExtensionRouterTestHarness({
+  initialEntries,
+  unlockVerifier,
+}: {
+  initialEntries: string[];
+  unlockVerifier?: UnlockVerifier;
+}) {
   return (
     <MemoryRouter initialEntries={initialEntries}>
       <NotificationProvider>
-        <ExtensionAuthProvider>
+        <ExtensionAuthProvider unlockVerifier={unlockVerifier}>
           <ExtensionRouterContent />
         </ExtensionAuthProvider>
       </NotificationProvider>

--- a/apps/extension-wallet/src/security/__tests__/lock-manager.test.ts
+++ b/apps/extension-wallet/src/security/__tests__/lock-manager.test.ts
@@ -9,6 +9,7 @@ function makeMockStorageManager(shouldFailUnlock = false) {
       if (shouldFailUnlock || password !== 'correct') {
         throw new Error('Invalid password or corrupted data');
       }
+      return true;
     }),
     lock: vi.fn(),
     isUnlocked: false,
@@ -56,6 +57,28 @@ describe('LockManager', () => {
 
     await expect(manager.unlock('wrong')).rejects.toThrow('Invalid password');
     expect(manager.isLocked).toBe(true);
+    manager.destroy();
+  });
+
+  it('fails closed when storage unlock returns false', async () => {
+    const storage = {
+      unlock: vi.fn(async () => false),
+      lock: vi.fn(),
+      isUnlocked: false,
+      touch: vi.fn(),
+    };
+    const onUnlock = vi.fn();
+    const manager = new LockManager({
+      autoLockMinutes: 5,
+      storageManager: storage as any,
+      onUnlock,
+    });
+
+    await expect(manager.unlock('wrong')).rejects.toThrow('Invalid password or corrupted data');
+
+    expect(manager.isLocked).toBe(true);
+    expect(storage.lock).toHaveBeenCalledOnce();
+    expect(onUnlock).not.toHaveBeenCalled();
     manager.destroy();
   });
 

--- a/apps/extension-wallet/src/security/lock-manager.ts
+++ b/apps/extension-wallet/src/security/lock-manager.ts
@@ -41,12 +41,16 @@ export class LockManager {
 
   /**
    * Unlock the wallet with the given password.
-   * Throws if the password is incorrect.
+   * Throws if the password is incorrect or the storage layer does not
+   * positively confirm that the unlock succeeded.
    */
   async unlock(password: string): Promise<void> {
-    // Delegates password verification to SecureStorageManager.
-    // unlock() will throw 'Invalid password or corrupted data' on bad password.
-    await this.storageManager.unlock(password);
+    const unlocked = await this.storageManager.unlock(password);
+
+    if (!unlocked) {
+      this.storageManager.lock();
+      throw new Error('Invalid password or corrupted data');
+    }
 
     this.status = 'unlocked';
     this.detector.start();


### PR DESCRIPTION
## Summary

Harden extension unlock flows so they fail closed when storage unlock verification returns `false` or throws, and keep the UI on locked routes with a consistent error state.

## What Changed

- updated `LockManager.unlock()` to verify the storage unlock result before transitioning to unlocked state
- explicitly re-lock storage and throw on invalid credentials when the storage layer returns `false`
- updated auth routing state to preserve the locked state on failed unlock attempts
- surfaced a consistent unlock error in the unlock screen without navigating into authenticated routes
- added regression coverage for:
  - storage unlock returning `false`
  - router unlock attempts that fail verification and must remain on `/unlock`

## Testing

- added lock-manager unit coverage for boolean `false` unlock handling
- added router coverage for invalid password flow and authenticated-route denial
- local test execution was not possible in this environment because `node`/`pnpm` are unavailable

Closes #261


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password-based wallet unlocking with async validation.
  * Unlock screen displays "Unlocking…" state during password verification.
  * Error alerts notify users when password validation fails.
  * Submit button disables when password field is empty or during submission.

* **Tests**
  * Added end-to-end tests for unlock flow scenarios.
  * Expanded test coverage for password validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->