### PR TITLE
feat(ci): add flaky test quarantine workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -1,0 +1,38 @@
+---
+name: Flaky Test Follow-up
+about: Track a quarantined flaky test until it is fixed
+title: '[FLAKE] '
+labels: flaky-test, quarantine-required
+assignees: ''
+---
+
+## Flaky Test
+
+<!-- Test file, test name, job, and browser/runtime if applicable -->
+
+## Failure Signature
+
+<!-- Paste the smallest stable log line that identifies this flake -->
+
+```text
+
+```
+
+## Quarantine Entry
+
+<!-- Link the PR that added or updated .github/flaky-test-quarantine.json -->
+
+- Quarantine ID:
+- Expires on:
+- Owner:
+
+## Exit Criteria
+
+- [ ] Root cause identified
+- [ ] Fix merged
+- [ ] Quarantine entry removed
+- [ ] CI run linked showing the test is stable without quarantine
+
+## Related Context
+
+<!-- Failed runs, screenshots, traces, affected impact area, or suspected cause -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -72,6 +72,7 @@
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published
+- [ ] Any flaky-test quarantine entry includes a linked follow-up issue, owner, expiry, and stable failure signature
 
 ### For High-Security Changes
 

--- a/.github/flaky-test-quarantine.json
+++ b/.github/flaky-test-quarantine.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "maxQuarantineDays": 30,
+  "labels": ["ci", "flaky-test", "quarantine-required"],
+  "tests": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,51 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
+  quarantine-registry:
+    name: Flaky Test Quarantine Registry
+    runs-on: ubuntu-latest
+    outputs:
+      active_count: ${{ steps.validate.outputs.active_count }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate quarantine registry
+        id: validate
+        run: node scripts/ci/flaky-quarantine.js validate
+
+      - name: Publish quarantine report
+        run: node scripts/ci/flaky-quarantine.js report
+
+      - name: Auto-tag PR with active quarantine labels
+        if: github.event_name == 'pull_request' && steps.validate.outputs.active_count != '0'
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            const fs = require('fs');
+            const registry = JSON.parse(fs.readFileSync('.github/flaky-test-quarantine.json', 'utf8'));
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: registry.labels
+            });
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: quarantine-registry
     steps:
       - uses: actions/checkout@v4
 
@@ -40,6 +81,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: quarantine-registry
     steps:
       - uses: actions/checkout@v4
 
@@ -128,6 +170,7 @@ jobs:
   extension-e2e-smoke:
     name: Extension E2E Smoke
     runs-on: ubuntu-latest
+    needs: quarantine-registry
     strategy:
       fail-fast: false
       matrix:
@@ -153,7 +196,32 @@ jobs:
         run: pnpm --filter @ancore/extension-wallet exec playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run extension smoke suite
-        run: pnpm --filter @ancore/extension-wallet exec playwright test --config=tests/playwright.config.ts --grep @smoke --project=${{ matrix.browser }}
+        id: smoke
+        run: node scripts/ci/flaky-quarantine.js run --area extension-wallet -- pnpm --filter @ancore/extension-wallet exec playwright test --config=tests/playwright.config.ts --grep @smoke --project=${{ matrix.browser }}
+
+      - name: Auto-tag PR when quarantine absorbs a smoke failure
+        if: github.event_name == 'pull_request' && steps.smoke.outputs.quarantined == 'true'
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            const fs = require('fs');
+            const registry = JSON.parse(fs.readFileSync('.github/flaky-test-quarantine.json', 'utf8'));
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: registry.labels
+            });
+
+      - name: Upload flaky quarantine report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-quarantine-report-${{ matrix.browser }}
+          path: .ci/flaky-quarantine-report.md
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Upload extension E2E failure artifacts
         if: failure()
@@ -166,6 +234,7 @@ jobs:
   contracts:
     name: Build & Test Contracts
     runs-on: ubuntu-latest
+    needs: quarantine-registry
     steps:
       - uses: actions/checkout@v4
 
@@ -228,6 +297,7 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
+    needs: quarantine-registry
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/ci-failure-triage.md
+++ b/docs/ci-failure-triage.md
@@ -30,15 +30,51 @@ This document maps common CI failure signatures to their owners and recommended 
 ## Job: Extension E2E Smoke
 
 **Owner**: Extension team  
-**Artifact**: `extension-e2e-failure-artifacts` (uploaded on failure, retained 7 days)
+**Artifact**: `extension-e2e-failure-artifacts` (uploaded on failure, retained 7 days), `flaky-quarantine-report-*` (uploaded when quarantine handling reports a match)
 
 | Failure signature | Action |
 |---|---|
 | Playwright timeout | Check screenshots/traces in the artifact; may be a flake — re-run first |
 | Browser install failure | Verify `playwright install --with-deps chromium` step succeeded |
 | Build step fails before tests | Fix build errors; E2E cannot run without a built extension |
+| `Quarantined flaky test matched` warning | Confirm the linked follow-up issue is active, then prioritize removing the quarantine before its expiry |
 
 Download artifacts from the failed run's **Summary** page → **Artifacts** section.
+
+---
+
+## Job: Flaky Test Quarantine Registry
+
+**Owner**: DevOps / Maintainers
+**Artifact**: `flaky-quarantine-report-*` when a quarantined failure is absorbed by a wrapped test command
+
+The quarantine registry lives at `.github/flaky-test-quarantine.json`. Every active entry must include:
+
+- `id`: kebab-case identifier
+- `area`: one of `smart-contracts`, `sdk`, `extension-wallet`, `mobile-wallet`, `web-dashboard`, `documentation`, `infrastructure`, `security`, or `other`
+- `owner`: team or GitHub handle responsible for removal
+- `issue`: a GitHub follow-up issue, for example `#123` or a full GitHub issue URL
+- `openedOn` and `expiresOn`: quarantine window, capped by `maxQuarantineDays`
+- `matchers`: stable failure signatures used by CI to recognize the known flake
+
+Example entry:
+
+```json
+{
+  "id": "extension-smoke-unlock-timeout",
+  "title": "Extension smoke unlock occasionally times out in Firefox",
+  "area": "extension-wallet",
+  "owner": "@ancore-org/extension",
+  "issue": "https://github.com/ancore-org/ancore/issues/123",
+  "openedOn": "2026-04-28",
+  "expiresOn": "2026-05-12",
+  "matchers": ["Timeout 30000ms exceeded", "tests/e2e/lock-unlock.spec.ts"]
+}
+```
+
+If a quarantined signature matches in a wrapped lane, CI posts a warning, uploads a report, labels the PR with the registry labels, and lets the run continue. Expired entries or entries without follow-up issues fail CI.
+
+When the flake overlaps existing Stellar Wave extension work, cross-reference the current coverage issues: #263 background wallet state, #264 auth/session consistency tests, #266 send flow simulation/failure UX, and #268 home dashboard resilience.
 
 ---
 
@@ -75,4 +111,5 @@ Download artifacts from the failed run's **Summary** page → **Artifacts** sect
 2. Expand the failed step to read the full error message.
 3. Download any uploaded artifacts (Summary → Artifacts).
 4. Reproduce locally with the same commands shown in the job.
-5. Fix, push, and verify CI goes green.
+5. If the failure is confirmed flaky and blocks unrelated work, open a flaky-test follow-up issue before adding a short-lived quarantine entry.
+6. Fix, push, and verify CI goes green.

--- a/scripts/ci/flaky-quarantine.js
+++ b/scripts/ci/flaky-quarantine.js
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const DEFAULT_REGISTRY = '.github/flaky-test-quarantine.json';
+const REPORT_PATH = '.ci/flaky-quarantine-report.md';
+const VALID_AREAS = new Set([
+  'smart-contracts',
+  'sdk',
+  'extension-wallet',
+  'mobile-wallet',
+  'web-dashboard',
+  'documentation',
+  'infrastructure',
+  'security',
+  'other',
+]);
+
+function usage() {
+  console.error(`Usage:
+  node scripts/ci/flaky-quarantine.js validate [--registry path]
+  node scripts/ci/flaky-quarantine.js report [--registry path]
+  node scripts/ci/flaky-quarantine.js run [--registry path] [--area name] -- <command> [args...]`);
+}
+
+function parseOptions(args) {
+  const options = { registry: DEFAULT_REGISTRY, area: undefined, command: [] };
+  const commandIndex = args.indexOf('--');
+  const optionArgs = commandIndex === -1 ? args : args.slice(0, commandIndex);
+  options.command = commandIndex === -1 ? [] : args.slice(commandIndex + 1);
+
+  for (let i = 0; i < optionArgs.length; i += 1) {
+    const arg = optionArgs[i];
+    if (arg === '--registry') {
+      options.registry = optionArgs[++i];
+    } else if (arg === '--area') {
+      options.area = optionArgs[++i];
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function readRegistry(registryPath) {
+  const absolutePath = path.resolve(registryPath);
+  const raw = fs.readFileSync(absolutePath, 'utf8');
+  return { registry: JSON.parse(raw) };
+}
+
+function parseDate(value, fieldName) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value || '')) {
+    throw new Error(`${fieldName} must use YYYY-MM-DD format`);
+  }
+  return new Date(`${value}T00:00:00.000Z`);
+}
+
+function daysBetween(start, end) {
+  const millis = end.getTime() - start.getTime();
+  return Math.ceil(millis / 86_400_000);
+}
+
+function validateRegistry(registry) {
+  const errors = [];
+  const warnings = [];
+  const today = new Date();
+  const todayUtc = new Date(
+    Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate())
+  );
+  const ids = new Set();
+
+  if (registry.version !== 1) {
+    errors.push('version must be 1');
+  }
+
+  if (!Number.isInteger(registry.maxQuarantineDays) || registry.maxQuarantineDays < 1) {
+    errors.push('maxQuarantineDays must be a positive integer');
+  }
+
+  if (
+    !Array.isArray(registry.labels) ||
+    registry.labels.length === 0 ||
+    registry.labels.some((label) => typeof label !== 'string' || label.trim() === '')
+  ) {
+    errors.push('labels must be a non-empty string array');
+  }
+
+  if (!Array.isArray(registry.tests)) {
+    errors.push('tests must be an array');
+    return { errors, warnings };
+  }
+
+  registry.tests.forEach((entry, index) => {
+    const prefix = `tests[${index}]`;
+    for (const field of ['id', 'title', 'area', 'owner', 'issue', 'expiresOn', 'matchers']) {
+      if (entry[field] === undefined) {
+        errors.push(`${prefix}.${field} is required`);
+      }
+    }
+
+    if (typeof entry.id === 'string') {
+      if (!/^[a-z0-9][a-z0-9-]+$/.test(entry.id)) {
+        errors.push(`${prefix}.id must be kebab-case`);
+      }
+      if (ids.has(entry.id)) {
+        errors.push(`${prefix}.id duplicates another quarantine entry`);
+      }
+      ids.add(entry.id);
+    }
+
+    if (!VALID_AREAS.has(entry.area)) {
+      errors.push(`${prefix}.area must be one of: ${Array.from(VALID_AREAS).join(', ')}`);
+    }
+
+    if (
+      typeof entry.issue !== 'string' ||
+      !/^#\d+$|^https:\/\/github\.com\/[^/]+\/[^/]+\/issues\/\d+$/.test(entry.issue)
+    ) {
+      errors.push(
+        `${prefix}.issue must be a GitHub issue reference such as #123 or https://github.com/org/repo/issues/123`
+      );
+    }
+
+    if (!Array.isArray(entry.matchers) || entry.matchers.length === 0) {
+      errors.push(`${prefix}.matchers must contain at least one failure signature`);
+    } else if (
+      entry.matchers.some((matcher) => typeof matcher !== 'string' || matcher.trim() === '')
+    ) {
+      errors.push(`${prefix}.matchers values must be non-empty strings`);
+    }
+
+    if (entry.expiresOn) {
+      try {
+        const expiresOn = parseDate(entry.expiresOn, `${prefix}.expiresOn`);
+        const openedOn = entry.openedOn
+          ? parseDate(entry.openedOn, `${prefix}.openedOn`)
+          : todayUtc;
+        const remainingDays = daysBetween(todayUtc, expiresOn);
+        const totalDays = daysBetween(openedOn, expiresOn);
+
+        if (remainingDays < 0) {
+          errors.push(`${prefix}.expiresOn is expired`);
+        } else if (remainingDays <= 7) {
+          warnings.push(`${prefix}.expiresOn expires in ${remainingDays} day(s)`);
+        }
+
+        if (registry.maxQuarantineDays && totalDays > registry.maxQuarantineDays) {
+          errors.push(
+            `${prefix}.expiresOn exceeds maxQuarantineDays (${registry.maxQuarantineDays})`
+          );
+        }
+      } catch (error) {
+        errors.push(error.message);
+      }
+    }
+  });
+
+  return { errors, warnings };
+}
+
+function matcherHits(matcher, text) {
+  if (matcher.startsWith('/') && matcher.endsWith('/') && matcher.length > 2) {
+    return new RegExp(matcher.slice(1, -1), 'm').test(text);
+  }
+
+  return text.includes(matcher);
+}
+
+function matchingEntries(registry, text, area) {
+  return registry.tests.filter((entry) => {
+    if (area && entry.area !== area) {
+      return false;
+    }
+    return entry.matchers.some((matcher) => matcherHits(matcher, text));
+  });
+}
+
+function writeGitHubOutput(values) {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${value}`);
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
+}
+
+function appendStepSummary(markdown) {
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
+  }
+}
+
+function registryReport(registry, matchedEntries = []) {
+  const activeEntries = registry.tests;
+  const matchedIds = new Set(matchedEntries.map((entry) => entry.id));
+  const lines = ['## Flaky Test Quarantine', ''];
+
+  if (activeEntries.length === 0) {
+    lines.push('No active quarantined tests.');
+  } else {
+    lines.push('| ID | Area | Owner | Follow-up | Expires | Status |');
+    lines.push('|---|---|---|---|---|---|');
+    for (const entry of activeEntries) {
+      const status = matchedIds.has(entry.id) ? 'Matched this run' : 'Active';
+      lines.push(
+        `| ${entry.id} | ${entry.area} | ${entry.owner} | ${entry.issue} | ${entry.expiresOn} | ${status} |`
+      );
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function ensureReportDir() {
+  fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true });
+}
+
+function validateCommand(options) {
+  const { registry } = readRegistry(options.registry);
+  const result = validateRegistry(registry);
+  for (const warning of result.warnings) {
+    console.warn(`::warning::${warning}`);
+  }
+  if (result.errors.length > 0) {
+    for (const error of result.errors) {
+      console.error(`::error::${error}`);
+    }
+    writeGitHubOutput({ active_count: registry.tests?.length || 0, valid: false });
+    return 1;
+  }
+
+  const activeCount = registry.tests.length;
+  writeGitHubOutput({ active_count: activeCount, valid: true });
+  console.log(
+    `Flaky quarantine registry is valid with ${activeCount} active entr${
+      activeCount === 1 ? 'y' : 'ies'
+    }.`
+  );
+  return 0;
+}
+
+function reportCommand(options) {
+  const { registry } = readRegistry(options.registry);
+  const markdown = registryReport(registry);
+  ensureReportDir();
+  fs.writeFileSync(REPORT_PATH, markdown);
+  appendStepSummary(markdown);
+  console.log(markdown);
+  return 0;
+}
+
+function runCommand(options) {
+  if (options.command.length === 0) {
+    throw new Error('run requires a command after --');
+  }
+
+  const { registry } = readRegistry(options.registry);
+  const validation = validateRegistry(registry);
+  if (validation.errors.length > 0) {
+    for (const error of validation.errors) {
+      console.error(`::error::${error}`);
+    }
+    return 1;
+  }
+
+  const result = spawnSync(options.command[0], options.command.slice(1), {
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'pipe'],
+  });
+
+  if (result.stdout) {
+    process.stdout.write(result.stdout);
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+
+  if (result.status === 0) {
+    return 0;
+  }
+
+  const combinedOutput = `${result.stdout || ''}\n${result.stderr || ''}`;
+  const matches = matchingEntries(registry, combinedOutput, options.area);
+  if (matches.length === 0) {
+    return result.status || 1;
+  }
+
+  const markdown = registryReport(registry, matches);
+  ensureReportDir();
+  fs.writeFileSync(REPORT_PATH, markdown);
+  appendStepSummary(markdown);
+  writeGitHubOutput({ quarantined: true, matched_count: matches.length });
+
+  for (const entry of matches) {
+    console.warn(`::warning::Quarantined flaky test matched: ${entry.id} (${entry.issue})`);
+  }
+  console.warn(
+    'A quarantined flaky signature matched this failure. CI will continue, but the follow-up issue remains required.'
+  );
+  return 0;
+}
+
+function main() {
+  const [command, ...args] = process.argv.slice(2);
+  try {
+    const options = parseOptions(args);
+    if (command === 'validate') {
+      process.exitCode = validateCommand(options);
+    } else if (command === 'report') {
+      process.exitCode = reportCommand(options);
+    } else if (command === 'run') {
+      process.exitCode = runCommand(options);
+    } else {
+      usage();
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    usage();
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
I added a CI quarantine workflow so known flaky tests can be isolated, labeled, reported, and tied to required follow-up issues instead of repeatedly blocking merges or hiding real regressions.

closes #383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a flaky test quarantine system to track and manage quarantined tests with ownership, expiry dates, and exit criteria.
  * Added automated quarantine registry validation in CI pipeline.
  * Automatic PR labeling when quarantined test signatures match failures.
  * New issue template for tracking flaky test follow-ups.

* **Documentation**
  * Updated CI failure triage guide with flaky test quarantine workflow and registry reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->