### PR TITLE
feat: transaction status mapping + deterministic clock abstraction

### DIFF
--- a/apps/extension-wallet/src/hooks/useSendTransaction.ts
+++ b/apps/extension-wallet/src/hooks/useSendTransaction.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { amountSchema, isStellarAddress } from '@ancore/ui-kit';
+import { mapRpcStatus, isTerminalStatus } from '@/utils/transaction-status';
 
 export type SendStep = 'form' | 'review' | 'confirm' | 'status';
 export type TxStatus = 'idle' | 'pending' | 'confirmed' | 'failed';
@@ -182,10 +183,11 @@ export function useSendTransaction(options: UseSendTransactionOptions = {}) {
         setStep('status');
 
         pollRef.current = setInterval(async () => {
-          const next = await service.fetchTransactionStatus(submission.txId);
-          setStatus(next);
+          const raw = await service.fetchTransactionStatus(submission.txId);
+          const appStatus = mapRpcStatus(raw);
+          setStatus(raw); // keep TxStatus in local state for hook consumers
 
-          if (next === 'confirmed' || next === 'failed') {
+          if (isTerminalStatus(appStatus)) {
             if (pollRef.current) {
               clearInterval(pollRef.current);
             }

--- a/apps/extension-wallet/src/security/inactivity-detector.ts
+++ b/apps/extension-wallet/src/security/inactivity-detector.ts
@@ -3,7 +3,11 @@
  *
  * Tracks user activity events and fires a callback after a configurable
  * period of inactivity. Cleans up all listeners on destroy().
+ *
+ * Accepts an optional Clock for deterministic testing.
  */
+
+import { type Clock, systemClock } from '@/utils/clock';
 
 const ACTIVITY_EVENTS: (keyof WindowEventMap)[] = [
   'mousemove',
@@ -19,10 +23,12 @@ export class InactivityDetector {
   private readonly onInactive: () => void;
   private timeoutMs: number;
   private active = false;
+  private readonly clock: Clock;
 
-  constructor(onInactive: () => void, timeoutMs: number) {
+  constructor(onInactive: () => void, timeoutMs: number, clock: Clock = systemClock) {
     this.onInactive = onInactive;
     this.timeoutMs = timeoutMs;
+    this.clock = clock;
     this.handleActivity = this.handleActivity.bind(this);
   }
 
@@ -60,14 +66,14 @@ export class InactivityDetector {
   private resetTimer(): void {
     this.clearTimer();
     if (this.timeoutMs <= 0) return; // 0 = never lock
-    this.timer = setTimeout(() => {
+    this.timer = this.clock.setTimeout(() => {
       this.onInactive();
     }, this.timeoutMs);
   }
 
   private clearTimer(): void {
     if (this.timer !== null) {
-      clearTimeout(this.timer);
+      this.clock.clearTimeout(this.timer);
       this.timer = null;
     }
   }

--- a/apps/extension-wallet/src/utils/clock.ts
+++ b/apps/extension-wallet/src/utils/clock.ts
@@ -1,0 +1,179 @@
+/**
+ * Clock Abstraction
+ *
+ * Provides a deterministic, injectable clock interface so that any
+ * time-dependent feature (inactivity detection, polling intervals,
+ * timestamp generation) can be tested without real timers.
+ *
+ * Usage in production:  pass `systemClock` (or omit — it's the default).
+ * Usage in tests:       pass a `ManualClock` instance and advance time
+ *                       explicitly with `tick()` / `setNow()`.
+ */
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+export interface Clock {
+  /** Returns the current time as a Unix timestamp in milliseconds. */
+  now(): number;
+
+  /**
+   * Schedules `fn` to run after `ms` milliseconds.
+   * Returns an opaque handle that can be passed to `clearTimeout`.
+   */
+  setTimeout(fn: () => void, ms: number): ReturnType<typeof setTimeout>;
+
+  /** Cancels a timeout created by this clock's `setTimeout`. */
+  clearTimeout(handle: ReturnType<typeof setTimeout>): void;
+
+  /**
+   * Schedules `fn` to run repeatedly every `ms` milliseconds.
+   * Returns an opaque handle that can be passed to `clearInterval`.
+   */
+  setInterval(fn: () => void, ms: number): ReturnType<typeof setInterval>;
+
+  /** Cancels an interval created by this clock's `setInterval`. */
+  clearInterval(handle: ReturnType<typeof setInterval>): void;
+}
+
+// ---------------------------------------------------------------------------
+// System clock (production default)
+// ---------------------------------------------------------------------------
+
+/**
+ * Thin wrapper around the real browser/Node timer APIs.
+ * This is the clock used in production code.
+ */
+export const systemClock: Clock = {
+  now: () => Date.now(),
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (h) => clearTimeout(h),
+  setInterval: (fn, ms) => setInterval(fn, ms),
+  clearInterval: (h) => clearInterval(h),
+};
+
+// ---------------------------------------------------------------------------
+// Manual clock (test / deterministic use)
+// ---------------------------------------------------------------------------
+
+interface ScheduledCallback {
+  id: number;
+  triggerAt: number;
+  fn: () => void;
+  interval: number | null; // null = one-shot, >0 = repeating
+}
+
+/**
+ * A fully deterministic clock for use in tests and simulations.
+ *
+ * Time only advances when you call `tick(ms)` or `setNow(ms)`.
+ * All scheduled callbacks fire synchronously when their trigger time
+ * is reached during an advance.
+ *
+ * @example
+ * const clock = new ManualClock(1_000);
+ * const fired: number[] = [];
+ *
+ * clock.setTimeout(() => fired.push(clock.now()), 500);
+ * clock.tick(499); // fired = []
+ * clock.tick(1);   // fired = [1500]
+ */
+export class ManualClock implements Clock {
+  private _now: number;
+  private _nextId = 1;
+  private _pending: ScheduledCallback[] = [];
+
+  constructor(startMs = 0) {
+    this._now = startMs;
+  }
+
+  now(): number {
+    return this._now;
+  }
+
+  setTimeout(fn: () => void, ms: number): ReturnType<typeof setTimeout> {
+    const id = this._nextId++;
+    this._pending.push({ id, triggerAt: this._now + ms, fn, interval: null });
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }
+
+  clearTimeout(handle: ReturnType<typeof setTimeout>): void {
+    const id = handle as unknown as number;
+    this._pending = this._pending.filter((c) => c.id !== id);
+  }
+
+  setInterval(fn: () => void, ms: number): ReturnType<typeof setInterval> {
+    const id = this._nextId++;
+    this._pending.push({ id, triggerAt: this._now + ms, fn, interval: ms });
+    return id as unknown as ReturnType<typeof setInterval>;
+  }
+
+  clearInterval(handle: ReturnType<typeof setInterval>): void {
+    const id = handle as unknown as number;
+    this._pending = this._pending.filter((c) => c.id !== id);
+  }
+
+  /**
+   * Advance the clock by `ms` milliseconds, firing all callbacks whose
+   * trigger time falls within the new range (in chronological order).
+   */
+  tick(ms: number): void {
+    this.setNow(this._now + ms);
+  }
+
+  /**
+   * Jump the clock to an absolute timestamp, firing all pending callbacks
+   * whose trigger time is ≤ the new time (in chronological order).
+   */
+  setNow(absoluteMs: number): void {
+    if (absoluteMs < this._now) {
+      throw new Error(
+        `ManualClock: cannot go backwards (current=${this._now}, requested=${absoluteMs})`
+      );
+    }
+
+    this._now = absoluteMs;
+    this._flush();
+  }
+
+  /** Returns the number of pending (not-yet-fired) callbacks. */
+  get pendingCount(): number {
+    return this._pending.length;
+  }
+
+  /** Cancels all pending callbacks without firing them. */
+  reset(newNow = 0): void {
+    this._now = newNow;
+    this._pending = [];
+  }
+
+  private _flush(): void {
+    // Keep firing until no more callbacks are due — intervals reschedule
+    // themselves, so we loop until the queue is stable.
+    let safety = 10_000;
+
+    while (safety-- > 0) {
+      const due = this._pending
+        .filter((c) => c.triggerAt <= this._now)
+        .sort((a, b) => a.triggerAt - b.triggerAt);
+
+      if (due.length === 0) break;
+
+      for (const cb of due) {
+        // Remove before firing so the callback can reschedule if needed
+        this._pending = this._pending.filter((c) => c.id !== cb.id);
+
+        cb.fn();
+
+        // Reschedule repeating intervals
+        if (cb.interval !== null) {
+          this._pending.push({
+            ...cb,
+            triggerAt: cb.triggerAt + cb.interval,
+          });
+        }
+      }
+    }
+  }
+}

--- a/apps/extension-wallet/src/utils/transaction-status.ts
+++ b/apps/extension-wallet/src/utils/transaction-status.ts
@@ -1,0 +1,83 @@
+/**
+ * Transaction Status Mapping
+ *
+ * Maps RPC / SDK status strings to the app-level TransactionStatusKind
+ * used by UI components (TransactionStatus badge, TransactionDetail, etc.).
+ *
+ * Centralising this mapping means RPC contract changes only need to be
+ * updated here, not scattered across components and hooks.
+ */
+
+import type { TransactionStatusKind } from '@/components/TransactionStatus';
+
+/**
+ * Status values returned by the Stellar RPC / Horizon API.
+ * Mirrors TransactionResult.status from packages/types/src/user-operation.ts
+ * plus the additional states Horizon can return.
+ */
+export type RpcTransactionStatus =
+  | 'success'
+  | 'failure'
+  | 'pending'
+  | 'not_found'
+  | 'error'
+  | 'timeout';
+
+/**
+ * Status values produced by the send-transaction polling loop
+ * (TxStatus from useSendTransaction).
+ */
+export type PollingTxStatus = 'idle' | 'pending' | 'confirmed' | 'failed';
+
+/**
+ * Union of every raw status string that can arrive from any RPC source.
+ */
+export type AnyRpcStatus = RpcTransactionStatus | PollingTxStatus;
+
+/** Exhaustive map from every known RPC status → app status. */
+const RPC_TO_APP: Record<AnyRpcStatus, TransactionStatusKind> = {
+  // Soroban / Horizon RPC statuses
+  success: 'confirmed',
+  failure: 'failed',
+  pending: 'pending',
+  not_found: 'pending', // still propagating through the network
+  error: 'failed',
+  timeout: 'failed',
+
+  // Polling loop statuses (useSendTransaction)
+  idle: 'pending',
+  confirmed: 'confirmed',
+  failed: 'failed',
+};
+
+/**
+ * Map an RPC / polling status string to the app-level TransactionStatusKind.
+ *
+ * Unknown strings fall back to `'pending'` so the UI never crashes on
+ * unexpected values from a future API version.
+ *
+ * @example
+ * mapRpcStatus('success')   // → 'confirmed'
+ * mapRpcStatus('failure')   // → 'failed'
+ * mapRpcStatus('not_found') // → 'pending'
+ * mapRpcStatus('UNKNOWN')   // → 'pending'  (safe fallback)
+ */
+export function mapRpcStatus(raw: string): TransactionStatusKind {
+  const normalised = raw.toLowerCase() as AnyRpcStatus;
+  return RPC_TO_APP[normalised] ?? 'pending';
+}
+
+/**
+ * Type-guard: returns true when `raw` is a known RPC status string.
+ */
+export function isKnownRpcStatus(raw: string): raw is AnyRpcStatus {
+  return raw.toLowerCase() in RPC_TO_APP;
+}
+
+/**
+ * Returns true when the given app status represents a terminal state
+ * (i.e. polling should stop).
+ */
+export function isTerminalStatus(status: TransactionStatusKind): boolean {
+  return status === 'confirmed' || status === 'failed' || status === 'cancelled';
+}


### PR DESCRIPTION


Two foundational utilities to improve correctness, testability, and maintainability of time-based and transaction-tracking features.

---

## Changes

### `src/utils/transaction-status.ts` — RPC → app status mapper

The codebase had hardcoded status string comparisons scattered across hooks and components (`next === 'confirmed' || next === 'failed'`). Any RPC contract change would require hunting those down manually.

This utility centralises the mapping in one place:

- `mapRpcStatus(raw)` — maps any RPC or polling status string to the app-level `TransactionStatusKind` used by UI components. Covers Soroban/Horizon statuses (`success`, `failure`, `pending`, `not_found`, `error`, `timeout`) and the send-flow polling statuses (`idle`, `confirmed`, `failed`). Unknown strings fall back to `'pending'` so the UI never crashes on unexpected API values.
- `isTerminalStatus(status)` — returns `true` for `confirmed | failed | cancelled`, the single source of truth for when polling should stop.
- `isKnownRpcStatus(raw)` — type guard for narrowing raw strings to the known union.

### `src/utils/clock.ts` — deterministic clock abstraction

Time-dependent code (`InactivityDetector`, polling loops, timestamp generation) called `Date.now()`, `setTimeout`, and `setInterval` directly, making it impossible to test without real timers or `jest.useFakeTimers` hacks.

This utility introduces a `Clock` interface and two implementations:

- `systemClock` — thin wrapper over real browser APIs, zero overhead in production.
- `ManualClock` — fully deterministic implementation for tests. Time only advances when you call `tick(ms)` or `setNow(ms)`. Callbacks fire synchronously in chronological order; intervals reschedule themselves automatically. Includes a `reset()` helper for test teardown.

### `src/security/inactivity-detector.ts` — clock injection

`InactivityDetector` now accepts an optional `Clock` parameter (defaults to `systemClock`). Its internal `setTimeout`/`clearTimeout` calls go through the abstraction. Auto-lock timeout behaviour can now be tested deterministically with a `ManualClock`.

### `src/hooks/useSendTransaction.ts` — use mapper + terminal check

The polling loop's hardcoded `next === 'confirmed' || next === 'failed'` guard is replaced with `mapRpcStatus` + `isTerminalStatus`. Adding a new terminal state (e.g. `cancelled`) now only requires updating the mapper.

---

## Why

| Before                                                        | After                                              |
| ------------------------------------------------------------- | -------------------------------------------------- |
| Status strings compared inline across multiple files          | Single mapper, one place to update                 |
| `setTimeout` called directly — untestable without fake timers | Injectable `Clock` — tests use `ManualClock`       |
| Polling stop condition duplicated in hook                     | `isTerminalStatus()` is the single source of truth |
| Unknown RPC statuses could cause silent UI bugs               | Unknown values safely fall back to `'pending'`     |

---

## Files changed

```
apps/extension-wallet/src/utils/transaction-status.ts   (new)
apps/extension-wallet/src/utils/clock.ts                (new)
apps/extension-wallet/src/security/inactivity-detector.ts
apps/extension-wallet/src/hooks/useSendTransaction.ts
```



closes #452
closes #453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved transaction polling status handling with flexible mapping logic
  * Enhanced inactivity detection with deterministic timing support for more reliable behavior
  * Added modular utilities for transaction status mapping and time control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->