### PR TITLE
feat(indexer): add migration lint script for naming and ordering vali…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Check formatting
         run: pnpm format:check
 
+      - name: Lint indexer migrations
+        run: pnpm indexer:lint-migrations
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/apps/extension-wallet/manifest.json
+++ b/apps/extension-wallet/manifest.json
@@ -24,7 +24,5 @@
     "service_worker": "background/service-worker.js",
     "type": "module"
   },
-  "permissions": [
-    "storage"
-  ]
+  "permissions": ["storage"]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "contracts:fmt": "cd contracts && cargo fmt --check",
     "contracts:clippy": "cd contracts && cargo clippy -- -D warnings",
     "indexer:check": "cd services/indexer && cargo check",
+    "indexer:lint-migrations": "node services/indexer/scripts/lint-migrations.mjs",
     "audit:security": "node tools/security-audit.js",
     "verify": "pnpm lint && pnpm typecheck && pnpm test",
     "prepare": "husky"

--- a/services/indexer/README.md
+++ b/services/indexer/README.md
@@ -119,6 +119,22 @@ TEST_DATABASE_URL=postgresql://user:password@localhost:5432/ancore_test
 psql $DATABASE_URL -f migrations/001_create_account_activity_table.sql
 ```
 
+### Linting Migrations
+
+The lint script validates that every file in `migrations/` follows the naming convention and that no two files share the same sequence number.
+
+**Convention:** `NNN_snake_case_description.sql` — three zero-padded digits, lowercase body, `.sql` extension.
+
+```bash
+# From the repo root
+pnpm indexer:lint-migrations
+
+# Or directly
+node services/indexer/scripts/lint-migrations.mjs
+```
+
+The script also runs automatically in CI as part of the `lint` job.
+
 ### Development
 
 ```bash

--- a/services/indexer/scripts/lint-migrations.mjs
+++ b/services/indexer/scripts/lint-migrations.mjs
@@ -12,10 +12,7 @@ import { readdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
-const MIGRATIONS_DIR = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  '../migrations',
-);
+const MIGRATIONS_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../migrations');
 
 const VALID = /^\d{3}_[a-z][a-z0-9_]*\.sql$/;
 
@@ -34,9 +31,7 @@ for (const file of files) {
 
   const seq = file.slice(0, 3);
   if (seen.has(seq)) {
-    errors.push(
-      `  ✗ Duplicate sequence ${seq}: "${seen.get(seq)}" and "${file}"`,
-    );
+    errors.push(`  ✗ Duplicate sequence ${seq}: "${seen.get(seq)}" and "${file}"`);
   } else {
     seen.set(seq, file);
   }
@@ -47,4 +42,6 @@ if (errors.length) {
   process.exit(1);
 }
 
-console.log(`Migration lint passed (${files.length} file${files.length !== 1 ? 's' : ''} checked).`);
+console.log(
+  `Migration lint passed (${files.length} file${files.length !== 1 ? 's' : ''} checked).`
+);

--- a/services/indexer/scripts/lint-migrations.mjs
+++ b/services/indexer/scripts/lint-migrations.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Validates migration filename conventions and catches duplicate sequence numbers.
+//
+// Convention: NNN_snake_case_description.sql
+//   - NNN  : exactly 3 zero-padded digits (001, 002, …)
+//   - body : lowercase letters, digits, underscores only
+//   - ext  : .sql
+//
+// Exits 0 on success, 1 on any violation.
+
+import { readdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const MIGRATIONS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../migrations',
+);
+
+const VALID = /^\d{3}_[a-z][a-z0-9_]*\.sql$/;
+
+const files = readdirSync(MIGRATIONS_DIR)
+  .filter((f) => f.endsWith('.sql'))
+  .sort();
+
+const errors = [];
+const seen = new Map(); // sequence → filename
+
+for (const file of files) {
+  if (!VALID.test(file)) {
+    errors.push(`  ✗ Invalid name: "${file}"  (expected NNN_snake_case.sql)`);
+    continue;
+  }
+
+  const seq = file.slice(0, 3);
+  if (seen.has(seq)) {
+    errors.push(
+      `  ✗ Duplicate sequence ${seq}: "${seen.get(seq)}" and "${file}"`,
+    );
+  } else {
+    seen.set(seq, file);
+  }
+}
+
+if (errors.length) {
+  console.error('Migration lint failed:\n' + errors.join('\n'));
+  process.exit(1);
+}
+
+console.log(`Migration lint passed (${files.length} file${files.length !== 1 ? 's' : ''} checked).`);

--- a/services/indexer/scripts/lint-migrations.mjs
+++ b/services/indexer/scripts/lint-migrations.mjs
@@ -28,7 +28,7 @@ const seen = new Map(); // sequence → filename
 
 for (const file of files) {
   if (!VALID.test(file)) {
-    errors.push(`  ✗ Invalid name: "${file}"  (expected NNN_snake_case.sql)`);
+    errors.push(`  ✗ Invalid name: "${file}"  (expected NNN_snake_case_description.sql)`);
     continue;
   }
 


### PR DESCRIPTION
Closes #476

Adds a lightweight lint script that validates migration filename conventions and catches duplicate sequence numbers.

## Changes
- `services/indexer/scripts/lint-migrations.mjs` — validates `NNN_snake_case_description.sql` convention and detects duplicate sequence numbers; exits non-zero on any violation
- `package.json` — new root script `indexer:lint-migrations`
- `.github/workflows/ci.yml` — hooked into the `lint` job so it runs on every PR
- `services/indexer/README.md` — usage docs added under "Running Migrations"

## Usage
bash
pnpm indexer:lint-migrations

## Failure examples

Migration lint failed:
 ✗ Invalid name: "003_BadName.sql"  (expected NNN_snake_case.sql)
 ✗ Duplicate sequence 003: "003_add_bar.sql" and "003_add_foo.sql"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated validation for database migrations in the CI pipeline to ensure proper naming conventions are followed and duplicate migrations are prevented
  * A new local validation tool allows developers to verify their migrations meet all requirements before submitting changes
  * Documentation expanded with detailed guidance on migration file naming conventions and how to run validation checks locally or in CI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->