### PR TITLE
Add QR scanner permission-denied recovery UI

### DIFF
--- a/Add QR scanner permission-denied recovery UI
+++ b/Add QR scanner permission-denied recovery UI
@@ -1,0 +1,1 @@
+https://www.figma.com/design/Yja14jB0ZqnCj09eG64A8E/Untitled?node-id=62-362&t=7PXUWMTMw5WnPg87-1 #431


### PR DESCRIPTION
I generated the 'Camera Permission Recovery' screen which fulfills all the criteria of the request. 
It includes:

Clear Status: A visual indicator that camera access was denied.
Actionable Steps: Simple instructions for enabling permissions in the browser.
Primary Action: A 'Try Again' button to re-check permissions.
Manual Fallback: An 'Enter Address Manually' option for users who prefer not to use the camera. Closes #431 