### PR TITLE
[CORE-SDK] Add retry policy presets (low-latency, reliable, aggressiv…

### DIFF
--- a/packages/core-sdk/src/__tests__/retry-presets.test.ts
+++ b/packages/core-sdk/src/__tests__/retry-presets.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for retry policy presets
+ */
+
+import {
+  LOW_LATENCY,
+  RELIABLE,
+  AGGRESSIVE,
+  RETRY_PRESETS,
+  type RetryPresetName,
+  getRetryPreset,
+} from '../retry-presets';
+import type { RetryOptions } from '@ancore/stellar';
+
+describe('retry-presets', () => {
+  describe('LOW_LATENCY preset', () => {
+    it('should have correct configuration for low-latency operations', () => {
+      expect(LOW_LATENCY.maxRetries).toBe(2);
+      expect(LOW_LATENCY.baseDelayMs).toBe(200);
+      expect(LOW_LATENCY.exponential).toBe(false);
+    });
+
+    it('should use linear backoff for predictable timing', () => {
+      expect(LOW_LATENCY.exponential).toBe(false);
+    });
+
+    it('should have minimal retry attempts for fast failure', () => {
+      expect(LOW_LATENCY.maxRetries).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('RELIABLE preset', () => {
+    it('should have correct configuration for critical operations', () => {
+      expect(RELIABLE.maxRetries).toBe(8);
+      expect(RELIABLE.baseDelayMs).toBe(3000);
+      expect(RELIABLE.exponential).toBe(true);
+    });
+
+    it('should use exponential backoff for extended outages', () => {
+      expect(RELIABLE.exponential).toBe(true);
+    });
+
+    it('should have maximum retry attempts for reliability', () => {
+      expect(RELIABLE.maxRetries).toBeGreaterThanOrEqual(8);
+    });
+
+    it('should have longer base delay to wait out issues', () => {
+      expect(RELIABLE.baseDelayMs).toBeGreaterThanOrEqual(3000);
+    });
+  });
+
+  describe('AGGRESSIVE preset', () => {
+    it('should have correct configuration for high-throughput', () => {
+      expect(AGGRESSIVE.maxRetries).toBe(4);
+      expect(AGGRESSIVE.baseDelayMs).toBe(500);
+      expect(AGGRESSIVE.exponential).toBe(true);
+    });
+
+    it('should use exponential backoff for balanced retry', () => {
+      expect(AGGRESSIVE.exponential).toBe(true);
+    });
+
+    it('should have moderate retry attempts', () => {
+      expect(AGGRESSIVE.maxRetries).toBe(4);
+    });
+
+    it('should have shorter base delay for throughput', () => {
+      expect(AGGRESSIVE.baseDelayMs).toBe(500);
+    });
+  });
+
+  describe('RETRY_PRESETS collection', () => {
+    it('should contain all presets', () => {
+      expect(RETRY_PRESETS.LOW_LATENCY).toBeDefined();
+      expect(RETRY_PRESETS.RELIABLE).toBeDefined();
+      expect(RETRY_PRESETS.AGGRESSIVE).toBeDefined();
+    });
+
+    it('should have exactly three presets', () => {
+      expect(Object.keys(RETRY_PRESETS)).toHaveLength(3);
+    });
+
+    it('should match individual preset exports', () => {
+      expect(RETRY_PRESETS.LOW_LATENCY).toEqual(LOW_LATENCY);
+      expect(RETRY_PRESETS.RELIABLE).toEqual(RELIABLE);
+      expect(RETRY_PRESETS.AGGRESSIVE).toEqual(AGGRESSIVE);
+    });
+  });
+
+  describe('getRetryPreset function', () => {
+    it('should return LOW_LATENCY preset', () => {
+      const preset = getRetryPreset('LOW_LATENCY');
+      expect(preset).toEqual(LOW_LATENCY);
+    });
+
+    it('should return RELIABLE preset', () => {
+      const preset = getRetryPreset('RELIABLE');
+      expect(preset).toEqual(RELIABLE);
+    });
+
+    it('should return AGGRESSIVE preset', () => {
+      const preset = getRetryPreset('AGGRESSIVE');
+      expect(preset).toEqual(AGGRESSIVE);
+    });
+
+    it('should return a copy, not the original', () => {
+      const preset = getRetryPreset('LOW_LATENCY');
+      preset.maxRetries = 999; // Mutate the copy
+      expect(LOW_LATENCY.maxRetries).toBe(2); // Original should be unchanged
+    });
+
+    it('should throw error for unknown preset name', () => {
+      expect(() => {
+        getRetryPreset('UNKNOWN' as RetryPresetName);
+      }).toThrow('Unknown retry preset: UNKNOWN');
+    });
+  });
+
+  describe('RetryPresetName type', () => {
+    it('should accept valid preset names', () => {
+      const names: RetryPresetName[] = ['LOW_LATENCY', 'RELIABLE', 'AGGRESSIVE'];
+      expect(names).toHaveLength(3);
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('should maintain RetryOptions compatibility', () => {
+      const presets: RetryOptions[] = [LOW_LATENCY, RELIABLE, AGGRESSIVE];
+      presets.forEach((preset) => {
+        expect(preset).toHaveProperty('maxRetries');
+        expect(preset).toHaveProperty('baseDelayMs');
+        expect(preset).toHaveProperty('exponential');
+        expect(typeof preset.maxRetries).toBe('number');
+        expect(typeof preset.baseDelayMs).toBe('number');
+        expect(typeof preset.exponential).toBe('boolean');
+      });
+    });
+
+    it('should allow partial override of presets', () => {
+      const custom = { ...RELIABLE, maxRetries: 10 };
+      expect(custom.maxRetries).toBe(10);
+      expect(custom.baseDelayMs).toBe(3000);
+      expect(custom.exponential).toBe(true);
+    });
+  });
+
+  describe('preset behavior validation', () => {
+    it('should calculate correct delays for LOW_LATENCY (linear)', () => {
+      // Linear: all delays are baseDelayMs
+      const baseMs = LOW_LATENCY.baseDelayMs!;
+      expect(baseMs).toBe(200);
+      expect(LOW_LATENCY.exponential).toBe(false);
+    });
+
+    it('should calculate correct delays for RELIABLE (exponential)', () => {
+      // Exponential: 3s, 6s, 12s, 24s, 48s, 96s, 192s, 384s
+      const baseMs = RELIABLE.baseDelayMs!;
+      expect(baseMs).toBe(3000);
+      expect(RELIABLE.exponential).toBe(true);
+    });
+
+    it('should calculate correct delays for AGGRESSIVE (exponential)', () => {
+      // Exponential: 500ms, 1s, 2s, 4s
+      const baseMs = AGGRESSIVE.baseDelayMs!;
+      expect(baseMs).toBe(500);
+      expect(AGGRESSIVE.exponential).toBe(true);
+    });
+  });
+});

--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -59,6 +59,16 @@ export {
   TransactionSubmissionError,
 } from './errors';
 
+// Retry policy presets
+export {
+  LOW_LATENCY,
+  RELIABLE,
+  AGGRESSIVE,
+  RETRY_PRESETS,
+  type RetryPresetName,
+  getRetryPreset,
+} from './retry-presets';
+
 export {
   mapExecuteWithSessionKeyError,
   type ExecuteWithSessionKeyParams,

--- a/packages/core-sdk/src/retry-presets.ts
+++ b/packages/core-sdk/src/retry-presets.ts
@@ -1,0 +1,135 @@
+/**
+ * Retry policy presets for common network operation scenarios.
+ *
+ * These presets provide standardized retry configurations to reduce
+ * ad-hoc retry tuning across applications.
+ *
+ * @module retry-presets
+ */
+
+import type { RetryOptions } from '@ancore/stellar';
+
+/**
+ * Low-latency preset for time-sensitive operations.
+ *
+ * Optimized for quick failures with minimal waiting:
+ * - 2 retry attempts to fail fast
+ * - 200ms base delay for rapid feedback
+ * - Linear backoff for predictable timing
+ *
+ * Use when:
+ * - User-facing operations requiring quick response
+ * - Real-time or interactive applications
+ * - Operations where fast failure is preferred over retries
+ *
+ * @example
+ * ```typescript
+ * import { LOW_LATENCY, withRetry } from '@ancore/core-sdk';
+ *
+ * const result = await withRetry(
+ *   () => fetchQuickStatus(),
+ *   LOW_LATENCY
+ * );
+ * ```
+ */
+export const LOW_LATENCY: RetryOptions = {
+  maxRetries: 2,
+  baseDelayMs: 200,
+  exponential: false,
+};
+
+/**
+ * Reliable preset for critical operations.
+ *
+ * Maximizes success rate with extensive retry logic:
+ * - 8 retry attempts to handle extended outages
+ * - 3000ms base delay to wait out temporary issues
+ * - Exponential backoff (3s, 6s, 12s, 24s, ...)
+ *
+ * Use when:
+ * - Critical transactions that must succeed
+ * - Operations during known network instability
+ * - Background jobs where time is less critical
+ *
+ * @example
+ * ```typescript
+ * import { RELIABLE, withRetry } from '@ancore/core-sdk';
+ *
+ * const result = await withRetry(
+ *   () => submitCriticalTransaction(tx),
+ *   RELIABLE
+ * );
+ * ```
+ */
+export const RELIABLE: RetryOptions = {
+  maxRetries: 8,
+  baseDelayMs: 3000,
+  exponential: true,
+};
+
+/**
+ * Aggressive preset for high-throughput scenarios.
+ *
+ * Balanced for throughput with moderate resilience:
+ * - 4 retry attempts for reasonable fault tolerance
+ * - 500ms base delay to keep operations moving
+ * - Exponential backoff (500ms, 1s, 2s, 4s)
+ *
+ * Use when:
+ * - Bulk operations or batch processing
+ * - High-volume API calls
+ * - Scenarios where some failures are acceptable
+ *
+ * @example
+ * ```typescript
+ * import { AGGRESSIVE, withRetry } from '@ancore/core-sdk';
+ *
+ * const results = await Promise.all(
+ *   items.map(item =>
+ *     withRetry(() => processItem(item), AGGRESSIVE)
+ *   )
+ * );
+ * ```
+ */
+export const AGGRESSIVE: RetryOptions = {
+  maxRetries: 4,
+  baseDelayMs: 500,
+  exponential: true,
+};
+
+/**
+ * All available retry presets for enumeration or dynamic selection.
+ */
+export const RETRY_PRESETS = {
+  LOW_LATENCY,
+  RELIABLE,
+  AGGRESSIVE,
+} as const;
+
+/**
+ * Type representing the name of a retry preset.
+ */
+export type RetryPresetName = keyof typeof RETRY_PRESETS;
+
+/**
+ * Get a retry preset by name.
+ *
+ * @param name - The name of the preset to retrieve
+ * @returns The retry options for the specified preset
+ * @throws Error if the preset name is not recognized
+ *
+ * @example
+ * ```typescript
+ * import { getRetryPreset } from '@ancore/core-sdk';
+ *
+ * const preset = getRetryPreset('RELIABLE');
+ * // Use preset with withRetry or StellarClient
+ * ```
+ */
+export function getRetryPreset(name: RetryPresetName): RetryOptions {
+  const preset = RETRY_PRESETS[name];
+  if (!preset) {
+    throw new Error(`Unknown retry preset: ${name}`);
+  }
+  return { ...preset }; // Return a copy to prevent mutation
+}


### PR DESCRIPTION
- Add retry-presets.ts with LOW_LATENCY, RELIABLE, AGGRESSIVE presets
- Export presets from core-sdk index.ts
- Add comprehensive tests for preset configurations
- Each preset documented with use cases and examples
- Backward compatible with existing RetryOptions

closes: #449 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added retry policy presets for simplified network retry configuration. Three presets are now available: LOW_LATENCY for fast failover, RELIABLE for high-attempt scenarios, and AGGRESSIVE for moderate attempts with faster recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->