### PR TITLE
Fixed Issue #448 --- Add fiat display formatter utility with locale fallback

### DIFF
--- a/apps/extension-wallet/src/hooks/useAccountBalance.ts
+++ b/apps/extension-wallet/src/hooks/useAccountBalance.ts
@@ -126,6 +126,7 @@ export function convertToUSD(xlmAmount: number, rate: number = 0.12): number {
 
 /**
  * Utility function to format USD value
+ * @deprecated Use `formatFiatAmount` from `@ancore/core-sdk` instead.
  */
 export function formatUSD(amount: number): string {
   return new Intl.NumberFormat('en-US', {

--- a/fiat-formatter.test.ts
+++ b/fiat-formatter.test.ts
@@ -1,0 +1,42 @@
+import { formatFiatAmount } from './fiat-formatter';
+
+describe('formatFiatAmount', () => {
+  it('formats USD with en-US locale by default', () => {
+    expect(formatFiatAmount(1234.56)).toBe('$1,234.56');
+  });
+
+  it('formats EUR with de-DE locale', () => {
+    const result = formatFiatAmount(1234.56, { currency: 'EUR', locale: 'de-DE' });
+    // Handling potential non-breaking spaces that Intl.NumberFormat might insert depending on the Node version
+    expect(result.replace(/\u00A0|\u202F/g, ' ')).toBe('1.234,56 €');
+  });
+
+  it('formats JPY with ja-JP locale and handles zero decimal rounding', () => {
+    const result = formatFiatAmount(1234.56, { 
+      currency: 'JPY', 
+      locale: 'ja-JP',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0
+    });
+    expect(result).toBe('￥1,235'); // Rounds up due to half-expand rounding
+  });
+
+  it('formats GBP with en-GB locale', () => {
+    expect(formatFiatAmount(1234.56, { currency: 'GBP', locale: 'en-GB' })).toBe('£1,234.56');
+  });
+
+  it('applies rounding rules correctly (half-expand)', () => {
+    expect(formatFiatAmount(1.004)).toBe('$1.00');
+    expect(formatFiatAmount(1.005)).toBe('$1.01');
+  });
+
+  it('falls back to en-US for invalid locale', () => {
+    const result = formatFiatAmount(1234.56, { locale: 'invalid-locale' });
+    expect(result).toBe('$1,234.56');
+  });
+
+  it('falls back to basic formatting for completely invalid inputs', () => {
+    const result = formatFiatAmount(1234.56, { currency: 'INVALID_CURRENCY' });
+    expect(result).toBe('1234.56 INVALID_CURRENCY');
+  });
+});

--- a/fiat-formatter.ts
+++ b/fiat-formatter.ts
@@ -1,0 +1,79 @@
+/**
+ * Options for fiat currency formatting
+ */
+export interface FiatFormatOptions {
+  /**
+   * Currency code (ISO 4217)
+   * @default 'USD'
+   */
+  currency?: string;
+
+  /**
+   * Locale string for formatting
+   * Fallback behavior: If the provided locale is invalid or unsupported,
+   * it falls back to the system default locale, and ultimately to 'en-US'.
+   * @default 'en-US'
+   */
+  locale?: string | string[];
+
+  /**
+   * Minimum fraction digits
+   * @default 2
+   */
+  minimumFractionDigits?: number;
+
+  /**
+   * Maximum fraction digits.
+   * Rounding rule: Uses half-expand rounding (standard Intl.NumberFormat behavior)
+   * where it rounds to the nearest number, and in case of a tie, rounds away from zero.
+   * E.g., 1.005 becomes 1.01, and 1.004 becomes 1.00
+   * @default 2
+   */
+  maximumFractionDigits?: number;
+}
+
+/**
+ * Formats a numeric amount as a fiat currency string.
+ *
+ * Rounding rules:
+ * Uses standard Intl.NumberFormat rounding (half-expand).
+ *
+ * Fallback behavior:
+ * - If locale is invalid, falls back to standard Intl fallback ('en-US' usually)
+ * - If Intl is not available or parameters are severely malformed, falls back to basic string formatting
+ *
+ * @param amount The numerical amount to format
+ * @param options Formatting options
+ * @returns Formatted currency string
+ */
+export function formatFiatAmount(amount: number, options: FiatFormatOptions = {}): string {
+  const {
+    currency = 'USD',
+    locale = 'en-US',
+    minimumFractionDigits = 2,
+    maximumFractionDigits = 2,
+  } = options;
+
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency,
+      minimumFractionDigits,
+      maximumFractionDigits,
+    }).format(amount);
+  } catch (error) {
+    // Fallback if Intl fails (e.g., due to an invalid locale input)
+    try {
+      return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency,
+        minimumFractionDigits,
+        maximumFractionDigits,
+      }).format(amount);
+    } catch (fallbackError) {
+      // Ultimate fallback if even en-US fails (e.g., completely invalid currency code)
+      // Return a basic string representation with maximum fraction digits and the currency code.
+      return `${amount.toFixed(maximumFractionDigits)} ${currency}`;
+    }
+  }
+}


### PR DESCRIPTION
Closes #448

---

Fixed Issue #448 --- Add fiat display formatter utility with locale fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advanced currency formatting with support for multiple currencies (USD, EUR, JPY, GBP) and locales, featuring intelligent fallback handling for edge cases.

* **Deprecations**
  * Previous currency formatter is now deprecated; migrate to the new multi-currency formatting solution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->