### PR TITLE
feat(sdk): add account activity pagination helpers

### DIFF
--- a/packages/stellar/src/__tests__/client.test.ts
+++ b/packages/stellar/src/__tests__/client.test.ts
@@ -241,4 +241,67 @@ describe('StellarClient', () => {
       expect(typeof client.isHealthy).toBe('function');
     });
   });
+
+  describe('account activity pagination helpers', () => {
+    it('should fetch account activity page and return next cursor', async () => {
+      const client = new StellarClient({ network: 'testnet' });
+      const records = [
+        { id: '1', paging_token: 'pt-1' },
+        { id: '2', paging_token: 'pt-2' },
+      ] as unknown as Horizon.HorizonApi.OperationResponse[];
+
+      const call = jest.fn().mockResolvedValue({ records });
+      const cursor = jest.fn().mockReturnValue({ call });
+      const order = jest.fn().mockReturnValue({ call, cursor });
+      const limit = jest.fn().mockReturnValue({ call, order, cursor });
+      const forAccount = jest.fn().mockReturnValue({ call, limit, order, cursor });
+      const operations = jest.fn().mockReturnValue({ forAccount });
+
+      (client as unknown as { horizonServer: { operations: () => unknown } }).horizonServer = {
+        operations,
+      };
+
+      const page = await client.getAccountActivityPage('GABC123', {
+        cursor: 'start',
+        limit: 2,
+        order: 'desc',
+      });
+
+      expect(page.records).toHaveLength(2);
+      expect(page.nextCursor).toBe('pt-2');
+      expect(forAccount).toHaveBeenCalledWith('GABC123');
+      expect(limit).toHaveBeenCalledWith(2);
+      expect(order).toHaveBeenCalledWith('desc');
+      expect(cursor).toHaveBeenCalledWith('start');
+    });
+
+    it('should iterate through pages until completion', async () => {
+      const client = new StellarClient({ network: 'testnet' });
+      const getAccountActivityPage = jest
+        .spyOn(client, 'getAccountActivityPage')
+        .mockResolvedValueOnce({
+          records: [{ id: '1', paging_token: 'pt-1' }] as unknown as Horizon.HorizonApi.OperationResponse[],
+          nextCursor: 'pt-1',
+        })
+        .mockResolvedValueOnce({
+          records: [{ id: '2', paging_token: 'pt-2' }] as unknown as Horizon.HorizonApi.OperationResponse[],
+          nextCursor: null,
+        });
+
+      const seen: string[] = [];
+      for await (const op of client.iterateAccountActivity('GABC123', { limit: 1 })) {
+        seen.push((op as unknown as { id: string }).id);
+      }
+
+      expect(seen).toEqual(['1', '2']);
+      expect(getAccountActivityPage).toHaveBeenNthCalledWith(1, 'GABC123', {
+        limit: 1,
+        cursor: null,
+      });
+      expect(getAccountActivityPage).toHaveBeenNthCalledWith(2, 'GABC123', {
+        limit: 1,
+        cursor: 'pt-1',
+      });
+    });
+  });
 });

--- a/packages/stellar/src/client.ts
+++ b/packages/stellar/src/client.ts
@@ -62,6 +62,17 @@ export interface StellarClientConfig extends NetworkConfig {
   assetMetadataCacheTtlMs?: number;
 }
 
+export interface AccountActivityPageRequest {
+  cursor?: string | null;
+  limit?: number;
+  order?: 'asc' | 'desc';
+}
+
+export interface AccountActivityPage<TRecord> {
+  records: TRecord[];
+  nextCursor: string | null;
+}
+
 interface AssetMetadataCacheEntry {
   metadata: AssetMetadata;
   expiresAt: number;
@@ -192,6 +203,68 @@ export class StellarClient {
       ...this.resolveAssetMetadata(balance),
       balance: balance.balance,
     }));
+  }
+
+  /**
+   * Fetch a paginated account activity page from Horizon operations endpoint.
+   */
+  async getAccountActivityPage(
+    publicKey: string,
+    request: AccountActivityPageRequest = {}
+  ): Promise<AccountActivityPage<Horizon.HorizonApi.OperationResponse>> {
+    const { cursor = null, limit = 20, order = 'desc' } = request;
+
+    return withRetry(async () => {
+      try {
+        const builder = this.horizonServer
+          .operations()
+          .forAccount(publicKey)
+          .limit(limit)
+          .order(order);
+
+        const page = cursor ? await builder.cursor(cursor).call() : await builder.call();
+        const records = page.records as Horizon.HorizonApi.OperationResponse[];
+        const nextCursor = this.getNextCursor(records);
+
+        return { records, nextCursor };
+      } catch (error) {
+        throw new NetworkError('Failed to fetch account activity page', {
+          cause: error instanceof Error ? error : undefined,
+        });
+      }
+    }, this.retryOptions);
+  }
+
+  /**
+   * Async iterator for account activity pagination.
+   */
+  async *iterateAccountActivity(
+    publicKey: string,
+    request: AccountActivityPageRequest = {}
+  ): AsyncGenerator<Horizon.HorizonApi.OperationResponse, void, unknown> {
+    let cursor = request.cursor ?? null;
+
+    while (true) {
+      const page = await this.getAccountActivityPage(publicKey, { ...request, cursor });
+      for (const record of page.records) {
+        yield record;
+      }
+
+      if (!page.nextCursor || page.records.length === 0) {
+        return;
+      }
+      cursor = page.nextCursor;
+    }
+  }
+
+  private getNextCursor(
+    records: Array<{ paging_token?: string }>
+  ): string | null {
+    if (records.length === 0) {
+      return null;
+    }
+    const last = records[records.length - 1];
+    return last.paging_token ?? null;
   }
 
   private resolveAssetMetadata(balance: Horizon.HorizonApi.BalanceLine): AssetMetadata {

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -8,6 +8,8 @@ export const STELLAR_VERSION = '0.1.0';
 // Client
 export { StellarClient } from './client';
 export type {
+  AccountActivityPage,
+  AccountActivityPageRequest,
   AssetMetadata,
   AssetMetadataCacheMetrics,
   Balance,


### PR DESCRIPTION
## Summary
- add typed SDK helpers for account activity pagination in StellarClient
- add getAccountActivityPage with cursor, order, and limit support plus retry-wrapped network handling
- add iterateAccountActivity async generator to consume activity records across pages
- export new pagination request/response types from @ancore/stellar
- add unit tests covering cursor propagation, next cursor extraction, and multi-page iteration

## Validation
- pnpm --filter @ancore/stellar test -- --runInBand src/__tests__/client.test.ts (fails locally: jest not found because node_modules is missing in this clone)

Closes #91
Closes #374
Closes #378
Closes #381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support for account activity queries with configurable limits and ordering.
  * Introduced new request and response interfaces for account activity pagination.

* **Tests**
  * Added comprehensive test coverage for account activity pagination functionality and cursor progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->