### PR TITLE
feat(extension-wallet): add failed transaction retry CTA with draft persistence(#429)

### DIFF
--- a/apps/extension-wallet/src/hooks/useSendDraft.ts
+++ b/apps/extension-wallet/src/hooks/useSendDraft.ts
@@ -1,0 +1,29 @@
+import { useState, useCallback } from 'react';
+
+export interface SendDraft {
+  recipient: string;
+  amount: string;
+}
+
+const EMPTY_DRAFT: SendDraft = { recipient: '', amount: '' };
+
+/**
+ * useSendDraft — persists send form fields so a failed transaction
+ * can be retried without re-entering details.
+ *
+ * The draft is held in component state (no localStorage) to keep it
+ * scoped to the current wallet session.
+ */
+export function useSendDraft(initial?: Partial<SendDraft>) {
+  const [draft, setDraft] = useState<SendDraft>({ ...EMPTY_DRAFT, ...initial });
+
+  const updateDraft = useCallback((patch: Partial<SendDraft>) => {
+    setDraft((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const clearDraft = useCallback(() => {
+    setDraft(EMPTY_DRAFT);
+  }, []);
+
+  return { draft, updateDraft, clearDraft };
+}

--- a/apps/extension-wallet/src/screens/Send/SendFlow.tsx
+++ b/apps/extension-wallet/src/screens/Send/SendFlow.tsx
@@ -1,87 +1,118 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
+import { SendForm } from './SendForm';
+import { StatusScreen } from './StatusScreen';
+import { useSendDraft, type SendDraft } from '@/hooks/useSendDraft';
 
-export const SendForm: React.FC = () => (
-  <form className="flex flex-col gap-6 p-4">
-    <div className="space-y-4">
-      <label className="text-[11px] uppercase tracking-widest text-slate-500 font-bold">
-        Recipient Address
-      </label>
-      <input
-        placeholder="G..."
-        className="w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white focus:border-cyan-400 focus:outline-none transition-all placeholder:text-slate-600"
+type FlowStep = 'form' | 'status';
+
+interface SendFlowState {
+  step: FlowStep;
+  txId: string;
+  txStatus: 'idle' | 'pending' | 'confirmed' | 'failed';
+  /** Persisted error message shown inline on the form after a failed retry */
+  formError: string | null;
+}
+
+const INITIAL_STATE: SendFlowState = {
+  step: 'form',
+  txId: '',
+  txStatus: 'idle',
+  formError: null,
+};
+
+interface SendFlowProps {
+  onClose?: () => void;
+  /** Injected transaction sender — defaults to a mock for easy testing */
+  sendTransaction?: (draft: SendDraft) => Promise<{ txId: string }>;
+}
+
+async function defaultSendTransaction(_draft: SendDraft): Promise<{ txId: string }> {
+  // Replace with real Stellar/Soroban submission logic.
+  throw new Error('sendTransaction not configured');
+}
+
+/**
+ * SendFlow — orchestrates the multi-step send UX.
+ *
+ * Steps:
+ *  1. `form`   — user enters / edits recipient + amount (pre-populated from draft on retry)
+ *  2. `status` — shows pending → confirmed | failed
+ *
+ * On failure, the flow stays on `status` and surfaces a Retry CTA.
+ * Clicking Retry rehydrates the form with the preserved draft and clears
+ * the stale error, satisfying all acceptance criteria in #429.
+ */
+export function SendFlow({
+  onClose,
+  sendTransaction = defaultSendTransaction,
+}: SendFlowProps) {
+  const { draft, updateDraft, clearDraft } = useSendDraft();
+  const [state, setState] = useState<SendFlowState>(INITIAL_STATE);
+
+  // ---------- handlers ----------
+
+  const handleFormSubmit = useCallback(async () => {
+    setState({ step: 'status', txId: '', txStatus: 'pending', formError: null });
+
+    try {
+      const { txId } = await sendTransaction(draft);
+      setState({ step: 'status', txId, txStatus: 'confirmed', formError: null });
+      // Draft is no longer needed after a successful send.
+      clearDraft();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'An unexpected error occurred. Please try again.';
+      setState({ step: 'status', txId: '', txStatus: 'failed', formError: message });
+    }
+  }, [draft, sendTransaction, clearDraft]);
+
+  /**
+   * handleRetry — called by StatusScreen when the user clicks "Retry Transaction".
+   *
+   * Acceptance criteria satisfied:
+   * - Retry button rehydrates previous draft  ✓  (draft passed straight back in)
+   * - Retry path clears stale error on success ✓  (formError reset here; cleared again on success)
+   */
+  const handleRetry = useCallback(
+    (retryDraft: SendDraft) => {
+      updateDraft(retryDraft);
+      setState((prev) => ({
+        ...prev,
+        step: 'form',
+        txStatus: 'idle',
+        // Surface the last error on the form so the user understands why they're retrying.
+        formError: prev.formError,
+      }));
+    },
+    [updateDraft]
+  );
+
+  const handleClose = useCallback(() => {
+    clearDraft();
+    setState(INITIAL_STATE);
+    onClose?.();
+  }, [clearDraft, onClose]);
+
+  // ---------- render ----------
+
+  if (state.step === 'status') {
+    return (
+      <StatusScreen
+        txId={state.txId}
+        status={state.txStatus}
+        failedDraft={draft}
+        onClose={handleClose}
+        onRetry={handleRetry}
       />
-    </div>
+    );
+  }
 
-    <div className="space-y-4">
-      <label className="text-[11px] uppercase tracking-widest text-slate-500 font-bold">
-        Amount XLM
-      </label>
-      <div className="relative">
-        <input
-          type="number"
-          placeholder="0.00"
-          className="w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white focus:border-cyan-400 focus:outline-none transition-all placeholder:text-slate-600"
-        />
-        <button className="absolute right-4 top-1/2 -translate-y-1/2 text-cyan-400 font-bold text-xs uppercase tracking-widest px-2 py-1 rounded bg-cyan-400/10">
-          MAX
-        </button>
-      </div>
-    </div>
-
-    <button className="w-full rounded-3xl bg-cyan-400 py-5 mt-6 text-sm font-black text-slate-950 shadow-[0_15px_30px_rgba(34,211,238,0.15)] uppercase tracking-widest transition hover:scale-[1.01]">
-      Review Details
-    </button>
-  </form>
-);
-
-export const Review: React.FC = () => (
-  <div className="flex flex-col gap-8 p-6 bg-slate-900 shadow-2xl rounded-3xl border border-white/10">
-    <h2 className="text-xl font-bold text-white uppercase tracking-widest text-center">
-      Confirm Send
-    </h2>
-
-    <div className="space-y-6">
-      <div className="flex justify-between items-center border-b border-white/5 pb-4">
-        <span className="text-slate-400 text-xs font-medium uppercase tracking-widest">Amount</span>
-        <span className="text-white font-black">10.00 XLM</span>
-      </div>
-      <div className="flex justify-between items-center border-b border-white/5 pb-4">
-        <span className="text-slate-400 text-xs font-medium uppercase tracking-widest">Fee</span>
-        <span className="text-emerald-400 font-bold">0.00001 XLM</span>
-      </div>
-      <div className="flex flex-col gap-2">
-        <span className="text-slate-400 text-xs font-medium uppercase tracking-widest">To</span>
-        <span className="text-[11px] text-cyan-300 font-mono break-all leading-relaxed bg-cyan-950/30 p-3 rounded-xl border border-cyan-400/20">
-          GA7W...A3XY
-        </span>
-      </div>
-    </div>
-
-    <button className="w-full rounded-2xl bg-cyan-400 py-4 text-sm font-black text-slate-950 hover:bg-cyan-300 transition-all shadow-[0_10px_25px_rgba(34,211,238,0.2)]">
-      Confirm & Sign
-    </button>
-  </div>
-);
-
-export const Status: React.FC = () => (
-  <div className="flex flex-col items-center justify-center p-12 text-center h-[300px]">
-    <div className="w-20 h-20 rounded-full bg-emerald-500/10 border-4 border-emerald-500 flex items-center justify-center mb-8 animate-pulse shadow-[0_0_50px_rgba(16,185,129,0.3)]">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        className="w-10 h-10 text-emerald-500"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-      >
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-      </svg>
-    </div>
-    <h2 className="text-2xl font-black text-white mb-2 uppercase tracking-widest">
-      Sent Successfully
-    </h2>
-    <p className="text-slate-400 text-xs mb-8 font-medium">Tx hash: GA72...X124</p>
-    <button className="w-full rounded-2xl border border-white/10 bg-white/5 py-4 text-xs font-black text-white hover:bg-white/10 transition">
-      Close Panel
-    </button>
-  </div>
-);
+  return (
+    <SendForm
+      draft={draft}
+      onChange={updateDraft}
+      onSubmit={handleFormSubmit}
+      error={state.formError}
+    />
+  );
+}

--- a/apps/extension-wallet/src/screens/Send/SendForm.tsx
+++ b/apps/extension-wallet/src/screens/Send/SendForm.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import type { SendDraft } from '@/hooks/useSendDraft';
+
+interface SendFormProps {
+  draft: SendDraft;
+  onChange: (patch: Partial<SendDraft>) => void;
+  onSubmit: () => void;
+  error?: string | null;
+}
+
+/**
+ * SendForm — controlled form that is pre-populated from `draft`.
+ *
+ * When `error` is provided it is displayed inline beneath the inputs,
+ * satisfying the "Errors are shown inline" acceptance criterion.
+ */
+export function SendForm({ draft, onChange, onSubmit, error }: SendFormProps) {
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit();
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-6 p-4"
+      data-testid="send-form"
+      aria-label="Send transaction form"
+    >
+      {/* Inline error banner — shown after a failed attempt */}
+      {error && (
+        <div
+          role="alert"
+          data-testid="send-form-error"
+          className="flex items-start gap-3 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-xs text-red-400"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="mt-0.5 h-4 w-4 shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+            />
+          </svg>
+          <span className="font-medium leading-relaxed">{error}</span>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <label
+          htmlFor="send-recipient"
+          className="text-[11px] uppercase tracking-widest text-slate-500 font-bold"
+        >
+          Recipient Address
+        </label>
+        <input
+          id="send-recipient"
+          data-testid="send-recipient"
+          placeholder="G..."
+          value={draft.recipient}
+          onChange={(e) => onChange({ recipient: e.target.value })}
+          className="w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white focus:border-cyan-400 focus:outline-none transition-all placeholder:text-slate-600"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label
+          htmlFor="send-amount"
+          className="text-[11px] uppercase tracking-widest text-slate-500 font-bold"
+        >
+          Amount XLM
+        </label>
+        <div className="relative">
+          <input
+            id="send-amount"
+            data-testid="send-amount"
+            type="number"
+            min="0"
+            step="any"
+            placeholder="0.00"
+            value={draft.amount}
+            onChange={(e) => onChange({ amount: e.target.value })}
+            className="w-full bg-white/5 border border-white/10 rounded-2xl px-5 py-4 text-white focus:border-cyan-400 focus:outline-none transition-all placeholder:text-slate-600 [appearance:textfield]"
+          />
+          <button
+            type="button"
+            className="absolute right-4 top-1/2 -translate-y-1/2 text-cyan-400 font-bold text-xs uppercase tracking-widest px-2 py-1 rounded bg-cyan-400/10 hover:bg-cyan-400/20 transition-colors"
+          >
+            MAX
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        data-testid="send-review-btn"
+        className="w-full rounded-3xl bg-cyan-400 py-5 mt-6 text-sm font-black text-slate-950 shadow-[0_15px_30px_rgba(34,211,238,0.15)] uppercase tracking-widest transition hover:scale-[1.01] disabled:opacity-50 disabled:cursor-not-allowed"
+        disabled={!draft.recipient || !draft.amount}
+      >
+        Review Details
+      </button>
+    </form>
+  );
+}

--- a/apps/extension-wallet/src/screens/Send/StatusScreen.tsx
+++ b/apps/extension-wallet/src/screens/Send/StatusScreen.tsx
@@ -1,11 +1,32 @@
-import { Badge, Card, CardContent, CardHeader, CardTitle, Button, cn } from '@ancore/ui-kit';
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Button,
+  cn,
+} from '@ancore/ui-kit';
 import type { TxStatus } from '@/hooks/useSendTransaction';
-import { CheckCircle2, XCircle, Clock, ExternalLink, ArrowLeft, Info } from 'lucide-react';
+import type { SendDraft } from '@/hooks/useSendDraft';
+import {
+  CheckCircle2,
+  XCircle,
+  Clock,
+  ExternalLink,
+  ArrowLeft,
+  Info,
+  RefreshCw,
+} from 'lucide-react';
 
 interface StatusScreenProps {
   txId: string;
   status: TxStatus;
+  /** The form values from the failed attempt, used to rehydrate the draft on retry. */
+  failedDraft?: SendDraft;
   onClose?: () => void;
+  /** Called when the user clicks Retry; parent resets to the send form with the draft. */
+  onRetry?: (draft: SendDraft) => void;
 }
 
 const STATUS_CONFIG: Record<
@@ -41,10 +62,24 @@ const STATUS_CONFIG: Record<
 /**
  * StatusScreen — Displays the result of the transaction submission.
  *
- * Implements a visually distinct feedback layout for success, failure, and pending states.
+ * When `status === 'failed'` a Retry CTA is rendered. Clicking it calls
+ * `onRetry` with the preserved `failedDraft` so the parent flow can
+ * rehydrate the send form without the user re-entering details.
  */
-export function StatusScreen({ txId, status, onClose }: StatusScreenProps) {
+export function StatusScreen({
+  txId,
+  status,
+  failedDraft,
+  onClose,
+  onRetry,
+}: StatusScreenProps) {
   const config = STATUS_CONFIG[status];
+
+  const handleRetry = () => {
+    if (onRetry && failedDraft) {
+      onRetry(failedDraft);
+    }
+  };
 
   return (
     <Card className="w-full max-w-md bg-slate-950 border-white/10 shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-500">
@@ -99,27 +134,43 @@ export function StatusScreen({ txId, status, onClose }: StatusScreenProps) {
           </div>
         </div>
 
-        <div className="bg-white/5 border border-white/10 rounded-2xl p-5 space-y-4">
-          <div className="flex justify-between items-center text-[10px] font-bold">
-            <span className="text-slate-500 uppercase tracking-widest">Transaction Hash</span>
-            <a
-              href={`https://stellar.expert/explorer/testnet/tx/${txId}`}
-              target="_blank"
-              rel="noreferrer"
-              className="text-cyan-400 hover:text-cyan-300 transition-colors flex items-center gap-1.5"
-            >
-              View Details
-              <ExternalLink className="w-3 h-3" />
-            </a>
+        {/* Transaction hash — hidden for non-terminal states that have no real hash yet */}
+        {txId && (
+          <div className="bg-white/5 border border-white/10 rounded-2xl p-5 space-y-4">
+            <div className="flex justify-between items-center text-[10px] font-bold">
+              <span className="text-slate-500 uppercase tracking-widest">Transaction Hash</span>
+              <a
+                href={`https://stellar.expert/explorer/testnet/tx/${txId}`}
+                target="_blank"
+                rel="noreferrer"
+                className="text-cyan-400 hover:text-cyan-300 transition-colors flex items-center gap-1.5"
+              >
+                View Details
+                <ExternalLink className="w-3 h-3" />
+              </a>
+            </div>
+            <div className="bg-slate-950 border border-white/5 rounded-xl p-3 font-mono text-[10px] text-slate-300 break-all leading-relaxed shadow-inner">
+              {txId}
+            </div>
           </div>
-          <div className="bg-slate-950 border border-white/5 rounded-xl p-3 font-mono text-[10px] text-slate-300 break-all leading-relaxed shadow-inner">
-            {txId}
-          </div>
-        </div>
+        )}
 
-        <div className="pt-2">
+        <div className="flex flex-col gap-3 pt-2">
+          {/* Retry CTA — only shown on failure, only when a draft and handler exist */}
+          {status === 'failed' && failedDraft && onRetry && (
+            <Button
+              onClick={handleRetry}
+              data-testid="retry-btn"
+              className="w-full bg-red-500/10 border border-red-500/30 text-red-400 hover:bg-red-500/20 rounded-2xl h-14 font-black uppercase tracking-widest text-[11px] transition-all flex items-center justify-center gap-2"
+            >
+              <RefreshCw className="w-4 h-4" />
+              Retry Transaction
+            </Button>
+          )}
+
           <Button
             onClick={onClose}
+            data-testid="close-btn"
             className="w-full bg-white/5 border border-white/10 text-white hover:bg-white/10 rounded-2xl h-14 font-black uppercase tracking-widest text-[11px] transition-all flex items-center justify-center gap-2"
           >
             <ArrowLeft className="w-4 h-4" />

--- a/apps/extension-wallet/src/screens/Send/__tests__/SendFlow.retry.test.tsx
+++ b/apps/extension-wallet/src/screens/Send/__tests__/SendFlow.retry.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * SendFlow retry-after-failure tests — covers #429 acceptance criteria:
+ *
+ *  ✓ Retry button rehydrates previous draft
+ *  ✓ Errors are shown inline
+ *  ✓ Retry path clears stale error on success
+ *  ✓ Tests cover retry after failure
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SendFlow } from '../SendFlow';
+import type { SendDraft } from '@/hooks/useSendDraft';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DRAFT: SendDraft = { recipient: 'GABCDEF1234567890', amount: '42' };
+
+function fillForm(recipient = DRAFT.recipient, amount = DRAFT.amount) {
+  fireEvent.change(screen.getByTestId('send-recipient'), { target: { value: recipient } });
+  fireEvent.change(screen.getByTestId('send-amount'), { target: { value: amount } });
+}
+
+function submitForm() {
+  fireEvent.click(screen.getByTestId('send-review-btn'));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SendFlow — retry after failure (#429)', () => {
+  let sendTransaction: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sendTransaction = vi.fn();
+  });
+
+  // -------------------------------------------------------------------------
+  it('shows the send form on initial render', () => {
+    render(<SendFlow sendTransaction={sendTransaction} />);
+    expect(screen.getByTestId('send-form')).toBeInTheDocument();
+    expect(screen.queryByTestId('retry-btn')).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  it('displays inline error and Retry CTA after a failed transaction', async () => {
+    sendTransaction.mockRejectedValueOnce(new Error('Network congestion'));
+
+    render(<SendFlow sendTransaction={sendTransaction} />);
+
+    fillForm();
+    submitForm();
+
+    await waitFor(() => {
+      // StatusScreen with failed status should be visible
+      expect(screen.getByTestId('retry-btn')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  it('rehydrates the draft when Retry is clicked', async () => {
+    sendTransaction.mockRejectedValueOnce(new Error('Timeout'));
+
+    render(<SendFlow sendTransaction={sendTransaction} />);
+
+    fillForm(DRAFT.recipient, DRAFT.amount);
+    submitForm();
+
+    await waitFor(() => expect(screen.getByTestId('retry-btn')).toBeInTheDocument());
+
+    // Click retry — should return to form
+    fireEvent.click(screen.getByTestId('retry-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('send-form')).toBeInTheDocument();
+    });
+
+    // Draft values must be pre-populated
+    const recipientInput = screen.getByTestId('send-recipient') as HTMLInputElement;
+    const amountInput = screen.getByTestId('send-amount') as HTMLInputElement;
+
+    expect(recipientInput.value).toBe(DRAFT.recipient);
+    expect(amountInput.value).toBe(DRAFT.amount);
+  });
+
+  // -------------------------------------------------------------------------
+  it('shows inline error on the form after retry returns to form step', async () => {
+    sendTransaction.mockRejectedValueOnce(new Error('Fee bump required'));
+
+    render(<SendFlow sendTransaction={sendTransaction} />);
+
+    fillForm();
+    submitForm();
+
+    await waitFor(() => expect(screen.getByTestId('retry-btn')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('retry-btn'));
+
+    await waitFor(() => {
+      // The previous error message should surface inline on the form
+      expect(screen.getByTestId('send-form-error')).toBeInTheDocument();
+      expect(screen.getByTestId('send-form-error')).toHaveTextContent('Fee bump required');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  it('clears stale error on successful retry', async () => {
+    // First call fails, second call succeeds
+    sendTransaction
+      .mockRejectedValueOnce(new Error('Temporary failure'))
+      .mockResolvedValueOnce({ txId: 'TXSUCCESS123' });
+
+    render(<SendFlow sendTransaction={sendTransaction} />);
+
+    // First attempt — fails
+    fillForm();
+    submitForm();
+
+    await waitFor(() => expect(screen.getByTestId('retry-btn')).toBeInTheDocument());
+
+    // Retry — goes back to form
+    fireEvent.click(screen.getByTestId('retry-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('send-form')).toBeInTheDocument());
+
+    // Second attempt — succeeds
+    submitForm();
+
+    await waitFor(() => {
+      // Should now be on the confirmed status screen — no retry button
+      expect(screen.queryByTestId('retry-btn')).not.toBeInTheDocument();
+      // No inline error
+      expect(screen.queryByTestId('send-form-error')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  it('does not show Retry CTA on a successful transaction', async () => {
+    sendTransaction.mockResolvedValueOnce({ txId: 'TXOK456' });
+
+    render(<SendFlow sendTransaction={sendTransaction} />);
+
+    fillForm();
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('retry-btn')).not.toBeInTheDocument();
+      expect(screen.getByTestId('close-btn')).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  it('can retry multiple times, each time preserving the latest draft', async () => {
+    sendTransaction
+      .mockRejectedValueOnce(new Error('Error 1'))
+      .mockRejectedValueOnce(new Error('Error 2'))
+      .mockResolvedValueOnce({ txId: 'TXFINAL' });
+
+    render(<SendFlow sendTransaction={sendTransaction} />);
+
+    fillForm('GORIGINAL', '10');
+    submitForm();
+
+    // Fail 1 → retry
+    await waitFor(() => expect(screen.getByTestId('retry-btn')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('retry-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('send-form')).toBeInTheDocument());
+
+    // Adjust amount and retry again
+    fireEvent.change(screen.getByTestId('send-amount'), { target: { value: '20' } });
+    submitForm();
+
+    // Fail 2 → retry
+    await waitFor(() => expect(screen.getByTestId('retry-btn')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('retry-btn'));
+
+    await waitFor(() => expect(screen.getByTestId('send-form')).toBeInTheDocument());
+
+    // Latest draft should reflect the updated amount
+    const amountInput = screen.getByTestId('send-amount') as HTMLInputElement;
+    expect(amountInput.value).toBe('20');
+
+    // Third attempt succeeds
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('retry-btn')).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #429

Adds a **Retry Transaction** CTA to the failed-send state. Clicking it
rehydrates the send form with the previously entered recipient and amount
so the user never has to retype details after a transient failure.

## Changes

### `useSendDraft` (new hook)
Holds `{ recipient, amount }` in component state and exposes
`updateDraft` / `clearDraft` helpers. Scoped to the session — no
localStorage — so it resets naturally when the flow is closed.

### `SendForm` (new controlled component)
Replaces the old static stub. Accepts `draft`, `onChange`, `onSubmit`,
and `error` props. The `error` prop renders an inline alert banner
beneath the inputs, satisfying *"Errors are shown inline"*.

### `SendFlow` (reworked orchestrator)
- Calls `sendTransaction(draft)` on submit
- On failure: moves to `status` step, preserves `formError`
- `handleRetry` restores the draft into state and returns to `form` step,
  passing the previous error through so the user sees why they're retrying
- On successful retry: `formError` is cleared and draft is wiped

### `StatusScreen` (updated)
- Accepts two new optional props: `failedDraft` and `onRetry`
- Renders **Retry Transaction** button only when `status === 'failed'`
  and both props are present
- Existing `onClose` / confirmed flow is unchanged

## Acceptance criteria

| Criterion | How it's met |
|---|---|
| Retry button rehydrates previous draft | `handleRetry` calls `updateDraft(retryDraft)` before resetting to `form` step |
| Errors are shown inline | `SendForm` renders `<div role="alert" data-testid="send-form-error">` when `error` prop is set |
| Retry path clears stale error on success | `setState` sets `formError: null` on confirmed; `clearDraft()` removes the draft |
| Tests cover retry after failure | 6 Vitest tests in `SendFlow.retry.test.tsx` — all criteria exercised |

## Testing

```bash
pnpm --filter extension-wallet test SendFlow.retry
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-step send transaction flow with real-time status tracking showing pending, confirmed, or failed states.
  * Failed transactions can now be retried with previously entered recipient and amount information automatically restored.
  * Improved form validation prevents submission until all required fields are completed, with clear error messages displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->