### PR TITLE
feat: add empty-account onboarding hints to dashboard account overview

### DIFF
--- a/apps/web-dashboard/src/widgets/AccountOverviewGrid.tsx
+++ b/apps/web-dashboard/src/widgets/AccountOverviewGrid.tsx
@@ -2,27 +2,33 @@ import React from 'react';
 import { useAccountOverview } from '../hooks/useAccountOverview';
 import { BalanceWidget, NonceWidget, AccountStatusWidget } from './AccountWidgets';
 import { WidgetErrorBoundary } from './WidgetErrorBoundary';
+import { OnboardingHints } from './OnboardingHints';
 
 interface AccountOverviewGridProps {
   publicKey: string;
 }
 
-
 export const AccountOverviewGrid: React.FC<AccountOverviewGridProps> = ({ publicKey }) => {
   const { data, isLoading, error } = useAccountOverview(publicKey);
 
+  const showOnboardingHints =
+    !isLoading && !error && data && data.balance === 0 && data.nonce === 0;
+
   return (
-    <div className="grid gap-4 md:grid-cols-3">
-      <WidgetErrorBoundary>
-        <BalanceWidget balance={data?.balance} isLoading={isLoading} error={error} />
-      </WidgetErrorBoundary>
-      <WidgetErrorBoundary>
-        <NonceWidget nonce={data?.nonce} isLoading={isLoading} error={error} />
-      </WidgetErrorBoundary>
-      <WidgetErrorBoundary>
-        <AccountStatusWidget status={data?.status} isLoading={isLoading} error={error} />
-      </WidgetErrorBoundary>
-    </div>
+    <>
+      <div className="grid gap-4 md:grid-cols-3">
+        <WidgetErrorBoundary>
+          <BalanceWidget balance={data?.balance} isLoading={isLoading} error={error} />
+        </WidgetErrorBoundary>
+        <WidgetErrorBoundary>
+          <NonceWidget nonce={data?.nonce} isLoading={isLoading} error={error} />
+        </WidgetErrorBoundary>
+        <WidgetErrorBoundary>
+          <AccountStatusWidget status={data?.status} isLoading={isLoading} error={error} />
+        </WidgetErrorBoundary>
+      </div>
+      {showOnboardingHints && <OnboardingHints />}
+    </>
   );
 };
 

--- a/apps/web-dashboard/src/widgets/OnboardingHints.tsx
+++ b/apps/web-dashboard/src/widgets/OnboardingHints.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { EmptyState, Button } from '@ancore/ui-kit';
+import { ArrowDownLeft, Send } from 'lucide-react';
+
+export const OnboardingHints: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 mt-4">
+      <EmptyState
+        icon={<ArrowDownLeft className="h-6 w-6" />}
+        title="Fund Your Account"
+        description="Add XLM to your wallet to get started with transactions."
+        action={
+          <Button size="sm" onClick={() => navigate('/request')}>
+            Request Funds
+          </Button>
+        }
+      />
+      <EmptyState
+        icon={<Send className="h-6 w-6" />}
+        title="Make Your First Transaction"
+        description="Send XLM to another Stellar address to activate your account."
+        action={
+          <Button size="sm" variant="outline" onClick={() => navigate('/send')}>
+            Send XLM
+          </Button>
+        }
+      />
+    </div>
+  );
+};
+
+export default OnboardingHints;

--- a/apps/web-dashboard/src/widgets/__tests__/OnboardingHints.test.tsx
+++ b/apps/web-dashboard/src/widgets/__tests__/OnboardingHints.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OnboardingHints } from '../OnboardingHints';
+import React from 'react';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('lucide-react', () => ({
+  ArrowDownLeft: () => <div data-testid="arrow-down-left-icon" />,
+  Send: () => <div data-testid="send-icon" />,
+}));
+
+vi.mock('@ancore/ui-kit', () => ({
+  EmptyState: ({ title, description, action }: any) => (
+    <div>
+      <h3>{title}</h3>
+      {description && <p>{description}</p>}
+      {action}
+    </div>
+  ),
+  Button: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+}));
+
+describe('OnboardingHints', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders the Fund Your Account hint', () => {
+    render(<OnboardingHints />);
+    expect(screen.getByText('Fund Your Account')).toBeInTheDocument();
+    expect(
+      screen.getByText('Add XLM to your wallet to get started with transactions.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the Make Your First Transaction hint', () => {
+    render(<OnboardingHints />);
+    expect(screen.getByText('Make Your First Transaction')).toBeInTheDocument();
+    expect(
+      screen.getByText('Send XLM to another Stellar address to activate your account.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders both action buttons', () => {
+    render(<OnboardingHints />);
+    expect(screen.getByRole('button', { name: 'Request Funds' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send XLM' })).toBeInTheDocument();
+  });
+
+  it('navigates to /request when Request Funds is clicked', () => {
+    render(<OnboardingHints />);
+    fireEvent.click(screen.getByRole('button', { name: 'Request Funds' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/request');
+  });
+
+  it('navigates to /send when Send XLM is clicked', () => {
+    render(<OnboardingHints />);
+    fireEvent.click(screen.getByRole('button', { name: 'Send XLM' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/send');
+  });
+});


### PR DESCRIPTION
 ## Summary

  Closes #373

  - **`OnboardingHints.tsx`** — new pure-presentational component that renders  
  two side-by-side `EmptyState` cards ("Fund Your Account" → `/request`, "Make
  Your First Transaction" → `/send`) using `@ancore/ui-kit` and                 
  `react-router-dom`                                        
  - **`AccountOverviewGrid.tsx`** — detects the new-account condition
  (`data.balance === 0 && data.nonce === 0`, guarded by `!isLoading && !error &&
   data`) and renders `<OnboardingHints />` below the existing metric grid
  - **`OnboardingHints.test.tsx`** — 5 tests: both hint cards render, both      
  action buttons render, navigation to `/request` and `/send` is triggered      
  correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added onboarding hints component for newly created accounts with zero balance and no transaction history.
  * Provides quick action buttons to simplify account funding and first transaction workflows.
  * Automatically surfaces for new accounts, guiding users through essential getting-started steps with clear next actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->