### PR TITLE
feat: Implement loading skeleton for account balance card (#428)

### DIFF
--- a/apps/extension-wallet/src/screens/HomeScreen.tsx
+++ b/apps/extension-wallet/src/screens/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAccountBalance, formatBalance } from '@/hooks/useAccountBalance';
-import { EmptyState } from '@ancore/ui-kit';
+import { EmptyState, Skeleton } from '@ancore/ui-kit';
 
 const HomeScreen: React.FC = () => {
   const { balance, isLoading, error, refreshBalance } = useAccountBalance();
@@ -36,13 +36,15 @@ const HomeScreen: React.FC = () => {
 
   return (
     <div className="flex flex-col gap-4">
-      <header
-        className={`rounded-3xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm transition-opacity ${isLoading ? 'opacity-50' : 'opacity-100'}`}
-      >
+      <header className="rounded-3xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm">
         <p className="text-xs uppercase tracking-[0.25em] text-cyan-400">Main Account</p>
-        <h2 className="mt-1 text-2xl font-bold text-white">
-          {isLoading ? '---' : formatBalance(balance)}
-        </h2>
+        <div className="mt-1 h-8 flex items-center">
+          {isLoading ? (
+            <Skeleton className="h-6 w-32 bg-white/10" />
+          ) : (
+            <h2 className="text-2xl font-bold text-white">{formatBalance(balance)}</h2>
+          )}
+        </div>
       </header>
 
       <div className="grid grid-cols-2 gap-3">
@@ -59,11 +61,16 @@ const HomeScreen: React.FC = () => {
           <h3 className="text-sm font-medium text-slate-400 uppercase tracking-widest">
             Recent Activity
           </h3>
-          {isLoading && (
-            <div className="w-4 h-4 border-2 border-cyan-400 border-t-transparent rounded-full animate-spin" />
-          )}
         </div>
-        <EmptyState title="No transactions yet" />
+        {isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-12 w-full bg-white/5 rounded-2xl" />
+            <Skeleton className="h-12 w-full bg-white/5 rounded-2xl" />
+            <Skeleton className="h-12 w-full bg-white/5 rounded-2xl" />
+          </div>
+        ) : (
+          <EmptyState title="No transactions yet" />
+        )}
       </section>
     </div>
   );

--- a/apps/extension-wallet/src/screens/__tests__/HomeScreen.test.tsx
+++ b/apps/extension-wallet/src/screens/__tests__/HomeScreen.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import HomeScreen from '../HomeScreen';
+import { useAccountBalance } from '@/hooks/useAccountBalance';
+
+// Mock the hook
+vi.mock('@/hooks/useAccountBalance', () => ({
+  useAccountBalance: vi.fn(),
+  formatBalance: (b: number) => `${b.toFixed(2)} XLM`,
+}));
+
+// Mock ui-kit components
+vi.mock('@ancore/ui-kit', () => ({
+  EmptyState: () => <div data-testid="empty-state" />,
+  Skeleton: ({ className }: { className?: string }) => (
+    <div data-testid="skeleton" className={className} />
+  ),
+}));
+
+describe('HomeScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading skeleton when balance is fetching', () => {
+    (useAccountBalance as any).mockReturnValue({
+      balance: 0,
+      isLoading: true,
+      error: null,
+      refreshBalance: vi.fn(),
+    });
+
+    render(<HomeScreen />);
+
+    // Should show skeletons for balance
+    const skeletons = screen.getAllByTestId('skeleton');
+    expect(skeletons.length).toBeGreaterThan(0);
+    
+    // Check for the specific balance skeleton
+    expect(skeletons[0].className).toContain('w-32');
+    
+    // Should NOT show the balance amount
+    expect(screen.queryByText(/XLM/)).toBeNull();
+  });
+
+  it('renders balance when loading is complete', () => {
+    (useAccountBalance as any).mockReturnValue({
+      balance: 125.5,
+      isLoading: false,
+      error: null,
+      refreshBalance: vi.fn(),
+    });
+
+    render(<HomeScreen />);
+
+    // Should show the formatted balance
+    expect(screen.getByText('125.50 XLM')).toBeDefined();
+    
+    // Should NOT show skeletons
+    expect(screen.queryByTestId('skeleton')).toBeNull();
+  });
+
+  it('renders error state when fetch fails', () => {
+    (useAccountBalance as any).mockReturnValue({
+      balance: 0,
+      isLoading: false,
+      error: new Error('Failed to load'),
+      refreshBalance: vi.fn(),
+    });
+
+    render(<HomeScreen />);
+
+    expect(screen.getByText('Failed to load')).toBeDefined();
+    expect(screen.getByText('Try Again')).toBeDefined();
+  });
+});


### PR DESCRIPTION
Description
This PR implements loading skeleton placeholders for the account balance card and recent activity section on the Home Dashboard. It replaces the abrupt "---" and spinner loading states with pulse-animated skeletons that match the final content shape, significantly reducing visual friction and preventing layout shifts during initial data fetches.

Type of Change
 ✨ New feature (non-breaking change which adds functionality)
 ✅ Test addition/improvement
Security Impact
 No security impact
Testing
 Unit tests added/updated
 Manual testing performed
Test Coverage
New/modified code coverage: ~100% for HomeScreen loading state logic.
Manual Testing Steps
Open the extension wallet to the Home screen.
Observe the Skeleton pulse animation appearing in the balance area while the data is fetching (simulated network delay).
Verify that the header height remains stable (no layout jumping) when the loading state transitions to the actual balance.
Verify that the "Recent Activity" section also displays skeleton items before showing the empty state.
Breaking Changes
 This PR introduces breaking changes
Checklist
 My code follows the project's style guidelines
 I have performed a self-review of my own code
 I have commented my code, particularly in hard-to-understand areas
 My changes generate no new warnings or errors
 I have added tests that prove my fix is effective or that my feature works
 New and existing unit tests pass locally with my changes
Related Issues
Closes #428

Reviewer Notes
The balance skeleton is wrapped in a fixed-height container (h-8) to ensure zero layout shift. The Skeleton component from @ancore/ui-kit was used for consistency with the design system.