### PR TITLE
feat(account-abstraction): implement nonce drift detection utilities

### DIFF
--- a/packages/account-abstraction/src/__tests__/nonce-drift.test.ts
+++ b/packages/account-abstraction/src/__tests__/nonce-drift.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for detectNonceDrift and isValidNonce.
+ *
+ * All tests are deterministic and require no network/DB access.
+ */
+
+import {
+  detectNonceDrift,
+  isValidNonce,
+  NonceDriftKind,
+  NONCE_DRIFT_RETRY_GUIDANCE,
+} from '../nonce-drift';
+
+// ── isValidNonce ──────────────────────────────────────────────────────────────
+
+describe('isValidNonce', () => {
+  it('accepts zero', () => expect(isValidNonce(0)).toBe(true));
+  it('accepts positive integers', () => expect(isValidNonce(42)).toBe(true));
+  it('accepts large safe integer', () => expect(isValidNonce(Number.MAX_SAFE_INTEGER)).toBe(true));
+
+  it('rejects negative integers', () => expect(isValidNonce(-1)).toBe(false));
+  it('rejects floats', () => expect(isValidNonce(1.5)).toBe(false));
+  it('rejects NaN', () => expect(isValidNonce(NaN)).toBe(false));
+  it('rejects Infinity', () => expect(isValidNonce(Infinity)).toBe(false));
+  it('rejects -Infinity', () => expect(isValidNonce(-Infinity)).toBe(false));
+});
+
+// ── detectNonceDrift — ExactMatch ─────────────────────────────────────────────
+
+describe('detectNonceDrift — ExactMatch', () => {
+  it('classifies equal nonces as ExactMatch', () => {
+    const result = detectNonceDrift(5, 5);
+    expect(result.kind).toBe(NonceDriftKind.ExactMatch);
+    expect(result.delta).toBe(0);
+  });
+
+  it('sets the correct retry guidance for ExactMatch', () => {
+    const result = detectNonceDrift(0, 0);
+    expect(result.retryGuidance).toBe(NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.ExactMatch]);
+  });
+
+  it('works for zero nonces', () => {
+    expect(detectNonceDrift(0, 0).kind).toBe(NonceDriftKind.ExactMatch);
+  });
+});
+
+// ── detectNonceDrift — ObservedAhead ─────────────────────────────────────────
+
+describe('detectNonceDrift — ObservedAhead', () => {
+  it('classifies observed > expected as ObservedAhead', () => {
+    const result = detectNonceDrift(3, 5);
+    expect(result.kind).toBe(NonceDriftKind.ObservedAhead);
+    expect(result.delta).toBe(2);
+  });
+
+  it('ObservedAhead delta is positive', () => {
+    const { delta } = detectNonceDrift(0, 1);
+    expect(delta).toBeGreaterThan(0);
+  });
+
+  it('sets the correct retry guidance for ObservedAhead', () => {
+    const result = detectNonceDrift(1, 3);
+    expect(result.retryGuidance).toBe(NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.ObservedAhead]);
+  });
+
+  it('includes both nonces and delta in message', () => {
+    const { message } = detectNonceDrift(4, 6);
+    expect(message).toContain('6');
+    expect(message).toContain('4');
+  });
+});
+
+// ── detectNonceDrift — ObservedBehind ────────────────────────────────────────
+
+describe('detectNonceDrift — ObservedBehind', () => {
+  it('classifies observed < expected as ObservedBehind', () => {
+    const result = detectNonceDrift(5, 3);
+    expect(result.kind).toBe(NonceDriftKind.ObservedBehind);
+    expect(result.delta).toBe(-2);
+  });
+
+  it('ObservedBehind delta is negative', () => {
+    const { delta } = detectNonceDrift(5, 4);
+    expect(delta).toBeLessThan(0);
+  });
+
+  it('sets the correct retry guidance for ObservedBehind', () => {
+    const result = detectNonceDrift(10, 8);
+    expect(result.retryGuidance).toBe(NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.ObservedBehind]);
+  });
+});
+
+// ── detectNonceDrift — ExcessiveDrift ────────────────────────────────────────
+
+describe('detectNonceDrift — ExcessiveDrift', () => {
+  it('classifies delta > threshold as ExcessiveDrift (ahead)', () => {
+    const result = detectNonceDrift(0, 11); // default threshold = 10
+    expect(result.kind).toBe(NonceDriftKind.ExcessiveDrift);
+    expect(result.delta).toBe(11);
+  });
+
+  it('classifies delta > threshold as ExcessiveDrift (behind)', () => {
+    const result = detectNonceDrift(11, 0);
+    expect(result.kind).toBe(NonceDriftKind.ExcessiveDrift);
+    expect(result.delta).toBe(-11);
+  });
+
+  it('delta == threshold is NOT excessive (ObservedAhead)', () => {
+    const result = detectNonceDrift(0, 10); // exactly at threshold
+    expect(result.kind).toBe(NonceDriftKind.ObservedAhead);
+  });
+
+  it('respects a custom excessiveDriftThreshold', () => {
+    const result = detectNonceDrift(0, 3, { excessiveDriftThreshold: 2 });
+    expect(result.kind).toBe(NonceDriftKind.ExcessiveDrift);
+  });
+
+  it('custom threshold of 1: delta of 2 is excessive', () => {
+    expect(detectNonceDrift(0, 2, { excessiveDriftThreshold: 1 }).kind).toBe(
+      NonceDriftKind.ExcessiveDrift
+    );
+  });
+
+  it('sets the correct retry guidance for ExcessiveDrift', () => {
+    const result = detectNonceDrift(0, 50);
+    expect(result.retryGuidance).toBe(NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.ExcessiveDrift]);
+  });
+
+  it('message includes threshold value', () => {
+    const result = detectNonceDrift(0, 11);
+    expect(result.message).toContain('threshold=10');
+  });
+});
+
+// ── detectNonceDrift — InvalidNonceState ─────────────────────────────────────
+
+describe('detectNonceDrift — InvalidNonceState', () => {
+  it('classifies negative expected as InvalidNonceState', () => {
+    expect(detectNonceDrift(-1, 5).kind).toBe(NonceDriftKind.InvalidNonceState);
+  });
+
+  it('classifies negative observed as InvalidNonceState', () => {
+    expect(detectNonceDrift(5, -1).kind).toBe(NonceDriftKind.InvalidNonceState);
+  });
+
+  it('classifies NaN expected as InvalidNonceState', () => {
+    expect(detectNonceDrift(NaN, 5).kind).toBe(NonceDriftKind.InvalidNonceState);
+  });
+
+  it('classifies NaN observed as InvalidNonceState', () => {
+    expect(detectNonceDrift(5, NaN).kind).toBe(NonceDriftKind.InvalidNonceState);
+  });
+
+  it('classifies Infinity expected as InvalidNonceState', () => {
+    expect(detectNonceDrift(Infinity, 5).kind).toBe(NonceDriftKind.InvalidNonceState);
+  });
+
+  it('classifies float expected as InvalidNonceState', () => {
+    expect(detectNonceDrift(1.5, 2).kind).toBe(NonceDriftKind.InvalidNonceState);
+  });
+
+  it('delta is NaN for invalid inputs', () => {
+    expect(detectNonceDrift(-1, 5).delta).toBeNaN();
+  });
+
+  it('sets the correct retry guidance for InvalidNonceState', () => {
+    const result = detectNonceDrift(-1, 5);
+    expect(result.retryGuidance).toBe(
+      NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.InvalidNonceState]
+    );
+  });
+});
+
+// ── Composability / determinism ───────────────────────────────────────────────
+
+describe('detectNonceDrift — determinism and composability', () => {
+  it('produces identical results on repeated calls with same inputs', () => {
+    const a = detectNonceDrift(7, 9);
+    const b = detectNonceDrift(7, 9);
+    expect(a).toEqual(b);
+  });
+
+  it('result can be used as a discriminated union on kind', () => {
+    const result = detectNonceDrift(5, 5);
+    if (result.kind === NonceDriftKind.ExactMatch) {
+      expect(result.delta).toBe(0);
+    } else {
+      fail('Expected ExactMatch');
+    }
+  });
+
+  it('all NonceDriftKind values have retry guidance entries', () => {
+    const kinds = Object.values(NonceDriftKind);
+    for (const kind of kinds) {
+      expect(NONCE_DRIFT_RETRY_GUIDANCE[kind]).toBeTruthy();
+    }
+  });
+});

--- a/packages/account-abstraction/src/index.ts
+++ b/packages/account-abstraction/src/index.ts
@@ -61,3 +61,11 @@ export {
   formatPermissionLabels,
   formatPermissions,
 } from './permission-formatter';
+
+export {
+  NonceDriftKind,
+  NONCE_DRIFT_RETRY_GUIDANCE,
+  isValidNonce,
+  detectNonceDrift,
+} from './nonce-drift';
+export type { NonceDriftResult, NonceDriftOptions } from './nonce-drift';

--- a/packages/account-abstraction/src/nonce-drift.ts
+++ b/packages/account-abstraction/src/nonce-drift.ts
@@ -1,0 +1,179 @@
+/**
+ * Nonce drift detection helper for account abstraction retry safety.
+ *
+ * Compares an expected nonce against the value observed on-chain and
+ * returns a deterministic classification that callers can use to decide
+ * whether to retry, resync, or abort.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Classification of the relationship between an expected nonce and the
+ * nonce observed on-chain.
+ */
+export enum NonceDriftKind {
+  /** Expected and observed nonces are identical — safe to submit. */
+  ExactMatch = 'ExactMatch',
+
+  /**
+   * The observed nonce is ahead of the expected nonce, meaning a previous
+   * transaction already incremented it. The operation was likely already
+   * processed.
+   */
+  ObservedAhead = 'ObservedAhead',
+
+  /**
+   * The observed nonce is behind the expected nonce, suggesting the chain
+   * has not yet processed a prior transaction or the expected nonce was
+   * incremented locally without an on-chain confirmation.
+   */
+  ObservedBehind = 'ObservedBehind',
+
+  /**
+   * The absolute difference between expected and observed exceeds the
+   * configured `excessiveDriftThreshold`. Manual intervention is required
+   * rather than automatic retry.
+   */
+  ExcessiveDrift = 'ExcessiveDrift',
+
+  /**
+   * One or both nonce inputs are invalid (negative, non-integer, NaN,
+   * or infinite).
+   */
+  InvalidNonceState = 'InvalidNonceState',
+}
+
+/** Retry guidance associated with each drift kind. */
+export const NONCE_DRIFT_RETRY_GUIDANCE: Record<NonceDriftKind, string> = {
+  [NonceDriftKind.ExactMatch]:
+    'Nonces match — proceed with submission.',
+  [NonceDriftKind.ObservedAhead]:
+    'Transaction may have already been processed. Verify on-chain before retrying.',
+  [NonceDriftKind.ObservedBehind]:
+    'Chain nonce is behind expected. Wait for prior transactions to confirm, then resync.',
+  [NonceDriftKind.ExcessiveDrift]:
+    'Drift exceeds safe threshold. Resync the local nonce from the chain before retrying.',
+  [NonceDriftKind.InvalidNonceState]:
+    'One or both nonce values are invalid. Validate inputs before retrying.',
+};
+
+/** Result returned by `detectNonceDrift`. */
+export interface NonceDriftResult {
+  /** Classification of the drift. */
+  kind: NonceDriftKind;
+  /** Signed delta: observed − expected. Positive = observed is ahead. */
+  delta: number;
+  /** Human-readable message describing the drift and recommended action. */
+  message: string;
+  /** Actionable retry guidance for the caller. */
+  retryGuidance: string;
+}
+
+/** Options for `detectNonceDrift`. */
+export interface NonceDriftOptions {
+  /**
+   * Absolute delta above which drift is classified as ExcessiveDrift rather
+   * than ObservedAhead / ObservedBehind.
+   *
+   * @default 10
+   */
+  excessiveDriftThreshold?: number;
+}
+
+// ── Implementation ────────────────────────────────────────────────────────────
+
+/**
+ * Returns `true` if `n` is a safe, non-negative integer (finite, not NaN,
+ * integer-valued, and ≥ 0).
+ */
+export function isValidNonce(n: number): boolean {
+  return Number.isFinite(n) && Number.isInteger(n) && n >= 0;
+}
+
+/**
+ * Detect and classify the drift between an expected nonce and the nonce
+ * currently observed on-chain.
+ *
+ * The function is **pure** (no side effects, no I/O) and therefore fully
+ * deterministic — identical inputs always produce identical outputs.
+ *
+ * @param expected  - The nonce the caller believes is current.
+ * @param observed  - The nonce read from the chain / contract state.
+ * @param options   - Optional configuration.
+ * @returns A `NonceDriftResult` with classification, delta, message, and
+ *          retry guidance.
+ *
+ * @example
+ * ```ts
+ * const result = detectNonceDrift(5, 5);
+ * // { kind: NonceDriftKind.ExactMatch, delta: 0, ... }
+ *
+ * const stale = detectNonceDrift(3, 5);
+ * // { kind: NonceDriftKind.ObservedAhead, delta: 2, ... }
+ * ```
+ */
+export function detectNonceDrift(
+  expected: number,
+  observed: number,
+  options?: NonceDriftOptions
+): NonceDriftResult {
+  const threshold =
+    options?.excessiveDriftThreshold !== undefined
+      ? options.excessiveDriftThreshold
+      : 10;
+
+  // Validate inputs first.
+  if (!isValidNonce(expected) || !isValidNonce(observed)) {
+    return {
+      kind: NonceDriftKind.InvalidNonceState,
+      delta: NaN,
+      message: `Invalid nonce input — expected: ${expected}, observed: ${observed}. Both must be non-negative integers.`,
+      retryGuidance: NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.InvalidNonceState],
+    };
+  }
+
+  const delta = observed - expected;
+  const absDelta = Math.abs(delta);
+
+  if (delta === 0) {
+    return {
+      kind: NonceDriftKind.ExactMatch,
+      delta: 0,
+      message: `Nonces match (expected=${expected}, observed=${observed}).`,
+      retryGuidance: NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.ExactMatch],
+    };
+  }
+
+  if (absDelta > threshold) {
+    return {
+      kind: NonceDriftKind.ExcessiveDrift,
+      delta,
+      message:
+        `Excessive nonce drift detected — expected=${expected}, observed=${observed}, ` +
+        `delta=${delta} (threshold=${threshold}).`,
+      retryGuidance: NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.ExcessiveDrift],
+    };
+  }
+
+  if (delta > 0) {
+    return {
+      kind: NonceDriftKind.ObservedAhead,
+      delta,
+      message:
+        `Observed nonce (${observed}) is ahead of expected (${expected}) by ${delta}. ` +
+        `A prior transaction may already be confirmed.`,
+      retryGuidance: NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.ObservedAhead],
+    };
+  }
+
+  // delta < 0
+  return {
+    kind: NonceDriftKind.ObservedBehind,
+    delta,
+    message:
+      `Observed nonce (${observed}) is behind expected (${expected}) by ${absDelta}. ` +
+      `The chain has not yet processed a prior transaction.`,
+    retryGuidance: NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.ObservedBehind],
+  };
+}


### PR DESCRIPTION
## Summary

- Add `detectNonceDrift(expected, observed, options?)` in `packages/account-abstraction/src/nonce-drift.ts` — a **pure, deterministic** helper that classifies the relationship between an expected nonce and the on-chain observed nonce
- Five `NonceDriftKind` variants: `ExactMatch`, `ObservedAhead`, `ObservedBehind`, `ExcessiveDrift`, `InvalidNonceState`
- Each result carries: signed `delta` (observed − expected), `message`, and `retryGuidance` from `NONCE_DRIFT_RETRY_GUIDANCE`
- `excessiveDriftThreshold` configurable (default 10) — delta > threshold → `ExcessiveDrift` regardless of direction
- `isValidNonce()` guard exported for callers that need pre-validation
- All public symbols exported from `packages/account-abstraction/src/index.ts`

## Test plan

- [ ] `ExactMatch` on equal nonces (including zero)
- [ ] `ObservedAhead` when observed > expected (within threshold)
- [ ] `ObservedBehind` when observed < expected (within threshold)
- [ ] `ExcessiveDrift` for |delta| > threshold in both directions
- [ ] Threshold boundary: `delta == threshold` is NOT excessive
- [ ] Custom `excessiveDriftThreshold` respected
- [ ] `InvalidNonceState` for negative, float, NaN, Infinity inputs
- [ ] Determinism: identical inputs produce identical outputs
- [ ] All `NonceDriftKind` values have `NONCE_DRIFT_RETRY_GUIDANCE` entries
- [ ] 30+ unit tests pass: `pnpm --filter @ancore/account-abstraction test`

Fixes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)