### PR TITLE
feat(contracts): start validation modules MVP

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -27,6 +27,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ancore-validation-modules"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 
 members = [
     "account",
-    # Additional contracts can be added here as they are developed
+    "validation-modules",
 ]
 
 [workspace.package]

--- a/contracts/account/README.md
+++ b/contracts/account/README.md
@@ -105,6 +105,19 @@ fn get_session_key(env: Env, public_key: BytesN<32>) -> Option<SessionKey>
 
 Manage session keys for the account.
 
+### Validation Module Boundary
+
+Pluggable validation modules are defined in `contracts/validation-modules/`.
+The MVP account integration boundary is interface-level only: the account
+contract does not yet store module addresses or invoke modules during
+`execute`.
+
+Future module-aware execution should validate the existing owner/session-key
+authority and nonce first, build a `ValidationContext` from the exact target,
+function, canonical argument digest, and nonce, invoke the configured module's
+`validate` function, then increment nonce and dispatch only after module
+approval. Module failures must fail closed.
+
 ## Contract Errors
 
 The contract uses structured error codes to provide clear feedback for failure conditions. These error codes are essential for SDK and frontend error handling.

--- a/contracts/validation-modules/Cargo.toml
+++ b/contracts/validation-modules/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ancore-validation-modules"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk.workspace = true
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/validation-modules/README.md
+++ b/contracts/validation-modules/README.md
@@ -1,22 +1,95 @@
-# Validation Modules (Planned Scaffold)
+# Validation Modules
 
-This directory is intentionally reserved for pluggable account validation contracts.
+This directory contains the MVP pluggable validation module interface and the
+first concrete policy module for Ancore account contracts.
 
-## Why this exists
+## Module interface
 
-- Preserve the intended modular contract architecture.
-- Let contributors work on isolated validation modules without changing `account` internals.
-- Keep roadmap scope visible in-repo.
+Every validation module exposes:
 
-## Planned module candidates
+```rust
+fn validate(env: Env, context: ValidationContext) -> Result<(), ValidationModuleError>
+```
 
-- Policy-based session key guards
-- Spending/velocity limits
-- Destination allow/deny lists
-- Time-window execution controls
-- Step-up verification gates
+`ValidationContext` is the account-to-module boundary:
 
-## Current status
+| Field | Meaning |
+| --- | --- |
+| `account` | Account contract requesting validation |
+| `authorizer` | Owner or session-key authority represented as an address |
+| `target` | Contract address the account wants to invoke |
+| `function` | Function symbol the account wants to invoke |
+| `args_hash` | Fixed-size digest of the execution arguments |
+| `nonce` | Account nonce bound to the execution |
 
-- Scaffold only (no production contract implementation yet)
-- Tracked as planned feature work
+The interface keeps validation bounded by passing a fixed-size context instead
+of an unbounded argument vector. Modules that need argument-aware rules should
+validate `args_hash` against policy commitments.
+
+## Target allowlist module
+
+`TargetAllowlistModule` approves execution only when `context.target` is in the
+module allowlist and the module is enabled.
+
+Lifecycle:
+
+1. `initialize(admin)` stores the module admin and enables validation.
+2. `set_allowed_target(target, true)` adds a target contract.
+3. `set_allowed_target(target, false)` removes a target contract.
+4. `set_enabled(false)` pauses approvals without deleting policy state.
+5. `validate(context)` returns `Ok(())` for allowed targets or a structured
+   `ValidationModuleError` for denial.
+
+Policy semantics:
+
+- Deny by default: unconfigured targets fail with `TargetNotAllowed`.
+- Admin controlled: policy mutations require `admin.require_auth()`.
+- Pauseable: disabled modules fail closed with `Disabled`.
+- Target-only MVP: `function`, `args_hash`, `nonce`, `account`, and
+  `authorizer` are part of the stable interface but are not interpreted by this
+  concrete allowlist module.
+
+## Complexity
+
+Let `n` be the number of allowlisted targets.
+
+| Operation | Time | Space |
+| --- | --- | --- |
+| `initialize` | O(1) | O(1) |
+| `set_enabled` | O(1) | O(1) |
+| `set_allowed_target` | O(1) | O(1) per target |
+| `is_allowed_target` | O(1) | O(1) |
+| `validate` | O(1) | O(1) |
+
+Total module storage is O(n).
+
+## Account integration boundary
+
+For the MVP, account integration is intentionally interface-level only. The
+account contract should call a module before `env.invoke_contract` and treat any
+module error as a failed validation. The account should derive `args_hash` from
+the exact execution arguments it will invoke and bind the same nonce already
+used for replay protection.
+
+Recommended future call order inside `account.execute`:
+
+1. Validate owner/session-key authority and nonce.
+2. Build `ValidationContext` from the pending execution.
+3. Invoke the configured validation module contract.
+4. Increment nonce and dispatch only after module validation succeeds.
+
+The account contract does not yet store module addresses or invoke modules in
+this MVP.
+
+## Security assumptions
+
+- The module admin is trusted to manage policy entries.
+- Account contracts must fail closed when module validation fails.
+- Account contracts must pass the same target, function, argument digest, and
+  nonce that will be executed.
+- `args_hash` must be computed with a canonical encoding before integration is
+  enabled in `account`.
+- Allowlist entries are stored in persistent storage because policy state must
+  survive beyond a single ledger TTL window.
+- Instance storage is limited to small module configuration values needed on
+  every invocation.

--- a/contracts/validation-modules/src/lib.rs
+++ b/contracts/validation-modules/src/lib.rs
@@ -1,0 +1,318 @@
+#![no_std]
+
+//! Pluggable validation module primitives for Ancore accounts.
+//!
+//! The MVP defines a stable validation boundary and implements one concrete
+//! policy module: an O(1) target allowlist. Account contracts can invoke
+//! `validate` before dispatching an execution request.
+
+use soroban_sdk::{
+    contract, contractclient, contracterror, contractimpl, contracttype, Address, BytesN, Env,
+    Symbol,
+};
+
+const INSTANCE_BUMP_AMOUNT: u32 = 30 * 17_280;
+const INSTANCE_BUMP_THRESHOLD: u32 = 15 * 17_280;
+const ALLOWLIST_BUMP_AMOUNT: u32 = 30 * 17_280;
+const ALLOWLIST_BUMP_THRESHOLD: u32 = 15 * 17_280;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ValidationModuleError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Disabled = 3,
+    TargetNotAllowed = 4,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValidationContext {
+    pub account: Address,
+    pub authorizer: Address,
+    pub target: Address,
+    pub function: Symbol,
+    pub args_hash: BytesN<32>,
+    pub nonce: u64,
+}
+
+#[contractclient(name = "ValidationModuleClient")]
+pub trait ValidationModuleInterface {
+    fn validate(env: Env, context: ValidationContext) -> Result<(), ValidationModuleError>;
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum DataKey {
+    Admin,
+    Enabled,
+    AllowedTarget(Address),
+}
+
+mod events {
+    use soroban_sdk::{Env, Symbol};
+
+    pub fn initialized(env: &Env) -> Symbol {
+        Symbol::new(env, "initialized")
+    }
+
+    pub fn enabled_set(env: &Env) -> Symbol {
+        Symbol::new(env, "enabled_set")
+    }
+
+    pub fn target_set(env: &Env) -> Symbol {
+        Symbol::new(env, "target_set")
+    }
+}
+
+#[contract]
+pub struct TargetAllowlistModule;
+
+#[contractimpl]
+impl TargetAllowlistModule {
+    pub fn initialize(env: Env, admin: Address) -> Result<(), ValidationModuleError> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(ValidationModuleError::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Enabled, &true);
+        extend_instance_ttl(&env);
+
+        env.events().publish((events::initialized(&env),), admin);
+
+        Ok(())
+    }
+
+    pub fn set_enabled(env: Env, enabled: bool) -> Result<(), ValidationModuleError> {
+        require_admin(&env)?;
+
+        env.storage().instance().set(&DataKey::Enabled, &enabled);
+        extend_instance_ttl(&env);
+
+        env.events().publish((events::enabled_set(&env),), enabled);
+
+        Ok(())
+    }
+
+    pub fn set_allowed_target(
+        env: Env,
+        target: Address,
+        allowed: bool,
+    ) -> Result<(), ValidationModuleError> {
+        require_admin(&env)?;
+
+        let key = DataKey::AllowedTarget(target.clone());
+        if allowed {
+            env.storage().persistent().set(&key, &true);
+            env.storage().persistent().extend_ttl(
+                &key,
+                ALLOWLIST_BUMP_THRESHOLD,
+                ALLOWLIST_BUMP_AMOUNT,
+            );
+        } else {
+            env.storage().persistent().remove(&key);
+        }
+        extend_instance_ttl(&env);
+
+        env.events()
+            .publish((events::target_set(&env),), (target, allowed));
+
+        Ok(())
+    }
+
+    pub fn is_allowed_target(env: Env, target: Address) -> Result<bool, ValidationModuleError> {
+        ensure_initialized(&env)?;
+
+        Ok(env
+            .storage()
+            .persistent()
+            .has(&DataKey::AllowedTarget(target)))
+    }
+
+    pub fn admin(env: Env) -> Result<Address, ValidationModuleError> {
+        admin(&env)
+    }
+}
+
+#[contractimpl]
+impl ValidationModuleInterface for TargetAllowlistModule {
+    fn validate(env: Env, context: ValidationContext) -> Result<(), ValidationModuleError> {
+        ensure_initialized(&env)?;
+
+        let enabled = env
+            .storage()
+            .instance()
+            .get(&DataKey::Enabled)
+            .unwrap_or(false);
+        if !enabled {
+            return Err(ValidationModuleError::Disabled);
+        }
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::AllowedTarget(context.target))
+        {
+            Ok(())
+        } else {
+            Err(ValidationModuleError::TargetNotAllowed)
+        }
+    }
+}
+
+fn ensure_initialized(env: &Env) -> Result<(), ValidationModuleError> {
+    if env.storage().instance().has(&DataKey::Admin) {
+        Ok(())
+    } else {
+        Err(ValidationModuleError::NotInitialized)
+    }
+}
+
+fn admin(env: &Env) -> Result<Address, ValidationModuleError> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(ValidationModuleError::NotInitialized)
+}
+
+fn require_admin(env: &Env) -> Result<Address, ValidationModuleError> {
+    let admin = admin(env)?;
+    admin.require_auth();
+    Ok(admin)
+}
+
+fn extend_instance_ttl(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Env};
+
+    fn context(env: &Env, target: Address) -> ValidationContext {
+        ValidationContext {
+            account: Address::generate(env),
+            authorizer: Address::generate(env),
+            target,
+            function: symbol_short!("execute"),
+            args_hash: BytesN::from_array(env, &[0; 32]),
+            nonce: 0,
+        }
+    }
+
+    #[test]
+    fn initialize_sets_admin_and_enabled_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TargetAllowlistModule);
+        let client = TargetAllowlistModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.initialize(&admin);
+
+        assert_eq!(client.admin(), admin);
+    }
+
+    #[test]
+    fn initialize_rejects_second_initialization() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TargetAllowlistModule);
+        let client = TargetAllowlistModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+
+        client.initialize(&admin);
+
+        let result = client.try_initialize(&admin);
+        assert_eq!(result, Err(Ok(ValidationModuleError::AlreadyInitialized)));
+    }
+
+    #[test]
+    fn validate_allows_configured_target() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TargetAllowlistModule);
+        let client = TargetAllowlistModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let target = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.set_allowed_target(&target, &true);
+
+        assert!(client.is_allowed_target(&target));
+        assert_eq!(client.try_validate(&context(&env, target)), Ok(Ok(())));
+    }
+
+    #[test]
+    fn validate_rejects_unconfigured_target() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TargetAllowlistModule);
+        let client = TargetAllowlistModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let target = Address::generate(&env);
+
+        client.initialize(&admin);
+
+        let result = client.try_validate(&context(&env, target));
+        assert_eq!(result, Err(Ok(ValidationModuleError::TargetNotAllowed)));
+    }
+
+    #[test]
+    fn validate_rejects_when_disabled() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TargetAllowlistModule);
+        let client = TargetAllowlistModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let target = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.set_allowed_target(&target, &true);
+        client.set_enabled(&false);
+
+        let result = client.try_validate(&context(&env, target));
+        assert_eq!(result, Err(Ok(ValidationModuleError::Disabled)));
+    }
+
+    #[test]
+    fn removing_target_revokes_validation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TargetAllowlistModule);
+        let client = TargetAllowlistModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let target = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.set_allowed_target(&target, &true);
+        client.set_allowed_target(&target, &false);
+
+        assert!(!client.is_allowed_target(&target));
+        let result = client.try_validate(&context(&env, target));
+        assert_eq!(result, Err(Ok(ValidationModuleError::TargetNotAllowed)));
+    }
+
+    #[test]
+    fn read_paths_reject_before_initialization() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, TargetAllowlistModule);
+        let client = TargetAllowlistModuleClient::new(&env, &contract_id);
+        let target = Address::generate(&env);
+
+        assert_eq!(
+            client.try_is_allowed_target(&target),
+            Err(Ok(ValidationModuleError::NotInitialized))
+        );
+        assert_eq!(
+            client.try_validate(&context(&env, target)),
+            Err(Ok(ValidationModuleError::NotInitialized))
+        );
+    }
+}


### PR DESCRIPTION
Closes #419 

# PR Description

Fixes #419 by turning the validation modules scaffold into a first MVP contract crate. The change defines a reusable Soroban validation module interface, adds a fixed-size validation context for account-to-module checks, and implements a target allowlist policy module that denies by default, requires admin auth for policy changes, and fails closed when disabled. This matters because Ancore accounts now have a concrete, tested boundary for future pluggable security policies without changing account execution behavior in this MVP.

# Changed

- Added `contracts/validation-modules` as a Soroban workspace crate.
- Defined `ValidationModuleInterface` and `ValidationContext`.
- Implemented `TargetAllowlistModule` with admin-controlled target allowlisting.
- Documented account integration boundary, policy lifecycle, complexity, and security assumptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced pluggable validation modules framework enabling custom validation logic for contract execution
  * Added TargetAllowlistModule for controlling authorized contract interactions through allowlist policies

* **Documentation**
  * Updated validation module architecture specification with integration guidelines
  * Added account contract integration details and module boundary documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ancore-org/ancore/pull/690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->