### PR TITLE
feat(dashboard): fix #416 bulk payouts and #405 staged lint checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,9 @@ We are committed to providing a welcoming and inclusive environment. Please:
    ```
 
    Follow [Conventional Commits](https://www.conventionalcommits.org/)
+   Staged TypeScript, JavaScript, JSON, and Markdown files are formatted with Prettier during
+   pre-commit. Staged source files under `packages/*`, `apps/*`, and `services/relayer` also run
+   their package-local ESLint autofix command.
 
 6. Push to your fork:
 

--- a/apps/web-dashboard/src/pages/BulkPayouts.tsx
+++ b/apps/web-dashboard/src/pages/BulkPayouts.tsx
@@ -1,0 +1,249 @@
+import { useMemo, useState, type ChangeEvent } from 'react';
+import { AlertCircle, CheckCircle2, Play, Upload } from 'lucide-react';
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@ancore/ui-kit';
+import { buildDefaultRelayPayload, resolveRelayerBaseUrl } from '../services/scheduler-client';
+import {
+  createRelayerPayoutSubmitter,
+  executeBulkPayoutBatch,
+  parseBulkPayoutCsv,
+  type BulkPayoutExecutionSummary,
+  type BulkPayoutParseResult,
+  type BulkPayoutRow,
+  type PayoutSubmission,
+} from '../services/bulk-payouts';
+import { useDashboardAuth } from '../auth';
+
+const EMPTY_PARSE_RESULT: BulkPayoutParseResult = {
+  rows: [],
+  validRows: [],
+  invalidRows: [],
+  totalAmount: '0',
+};
+
+export function BulkPayoutsPage() {
+  const { session } = useDashboardAuth();
+  const [fileName, setFileName] = useState('');
+  const [parseResult, setParseResult] = useState<BulkPayoutParseResult>(EMPTY_PARSE_RESULT);
+  const [executionSummary, setExecutionSummary] = useState<BulkPayoutExecutionSummary | null>(null);
+  const [isExecuting, setIsExecuting] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  const failedExecutions = useMemo(
+    () => executionSummary?.results.filter((result) => result.status === 'failed') ?? [],
+    [executionSummary]
+  );
+  const submitPayoutToQueue = useMemo(
+    () =>
+      createRelayerPayoutSubmitter({
+        baseUrl: resolveRelayerBaseUrl(import.meta.env.VITE_RELAYER_URL),
+        getAuthToken: () => session?.accessToken ?? 'ancore-client-token',
+        buildRelayRequest: (submission: PayoutSubmission) =>
+          withSignedTransactionXdr(
+            buildDefaultRelayPayload(submission.recipient, submission.amount),
+            submission.signedTransactionXdr
+          ),
+      }),
+    [session?.accessToken]
+  );
+
+  const onFileSelected = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    setExecutionSummary(null);
+    setFileError(null);
+
+    if (!file) {
+      return;
+    }
+
+    if (!file.name.toLowerCase().endsWith('.csv')) {
+      setFileError('Upload a CSV file with recipient and amount columns.');
+      setFileName('');
+      setParseResult(EMPTY_PARSE_RESULT);
+      return;
+    }
+
+    const text = await file.text();
+    setFileName(file.name);
+    setParseResult(parseBulkPayoutCsv(text));
+  };
+
+  const executeBatch = async () => {
+    if (parseResult.validRows.length === 0 || parseResult.invalidRows.length > 0) {
+      return;
+    }
+
+    setIsExecuting(true);
+    try {
+      setExecutionSummary(await executeBulkPayoutBatch(parseResult.validRows, submitPayoutToQueue));
+    } finally {
+      setIsExecuting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="text-2xl font-semibold">Bulk Payouts</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Import recipient and amount rows, review validation results, then execute the approved
+          payout batch.
+        </p>
+      </section>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>CSV import</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <label className="flex cursor-pointer items-center justify-center gap-2 rounded-lg border border-dashed border-slate-300 px-4 py-6 text-sm text-slate-600 hover:bg-slate-50">
+            <Upload className="h-4 w-4" />
+            <span>{fileName || 'Upload payout CSV'}</span>
+            <input
+              accept=".csv,text/csv"
+              className="sr-only"
+              onChange={onFileSelected}
+              type="file"
+            />
+          </label>
+
+          {fileError && (
+            <p className="flex items-center gap-2 text-sm text-red-600">
+              <AlertCircle className="h-4 w-4" />
+              {fileError}
+            </p>
+          )}
+
+          <div className="grid gap-3 sm:grid-cols-4">
+            <SummaryTile label="Rows" value={parseResult.rows.length.toString()} />
+            <SummaryTile label="Valid" value={parseResult.validRows.length.toString()} />
+            <SummaryTile label="Invalid" value={parseResult.invalidRows.length.toString()} />
+            <SummaryTile label="Total XLM" value={parseResult.totalAmount} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Preview</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {parseResult.rows.length === 0 ? (
+            <p className="text-sm text-slate-500">No payout rows imported.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[820px] text-left text-sm">
+                <thead className="border-b border-slate-200 text-xs uppercase text-slate-500">
+                  <tr>
+                    <th className="py-2 pr-4">Line</th>
+                    <th className="py-2 pr-4">Recipient</th>
+                    <th className="py-2 pr-4">Amount</th>
+                    <th className="py-2 pr-4">Signed XDR</th>
+                    <th className="py-2 pr-4">Status</th>
+                    <th className="py-2">Errors</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {parseResult.rows.map((row) => (
+                    <PreviewRow key={row.id} row={row} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-slate-600">
+          {parseResult.invalidRows.length > 0
+            ? 'Fix invalid rows before executing this batch.'
+            : 'Validated batches execute sequentially through the payout queue.'}
+        </p>
+        <Button
+          disabled={
+            isExecuting || parseResult.validRows.length === 0 || parseResult.invalidRows.length > 0
+          }
+          onClick={() => void executeBatch()}
+          type="button"
+        >
+          <Play className="h-4 w-4" />
+          {isExecuting ? 'Executing...' : 'Execute payout batch'}
+        </Button>
+      </div>
+
+      {executionSummary && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Execution summary</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-3 sm:grid-cols-3">
+              <SummaryTile label="Submitted" value={executionSummary.total.toString()} />
+              <SummaryTile label="Successful" value={executionSummary.successful.toString()} />
+              <SummaryTile label="Failed" value={executionSummary.failed.toString()} />
+            </div>
+
+            {failedExecutions.length === 0 ? (
+              <p className="flex items-center gap-2 text-sm text-green-700">
+                <CheckCircle2 className="h-4 w-4" />
+                All payout rows completed.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                <h3 className="text-sm font-medium text-slate-900">Failed-row report</h3>
+                {failedExecutions.map((result) => (
+                  <p key={result.row.id} className="text-sm text-red-600">
+                    Line {result.row.lineNumber}: {result.error}
+                  </p>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function withSignedTransactionXdr<T extends { parameters: Record<string, unknown> }>(
+  request: T,
+  signedTransactionXdr?: string
+): T {
+  if (!signedTransactionXdr) {
+    return request;
+  }
+
+  return {
+    ...request,
+    parameters: {
+      ...request.parameters,
+      signedTransactionXdr,
+    },
+  };
+}
+
+function SummaryTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-slate-200 p-3">
+      <p className="text-xs uppercase text-slate-500">{label}</p>
+      <p className="mt-1 text-lg font-semibold text-slate-950">{value}</p>
+    </div>
+  );
+}
+
+function PreviewRow({ row }: { row: BulkPayoutRow }) {
+  const isValid = row.errors.length === 0;
+
+  return (
+    <tr className="border-b border-slate-100 last:border-0">
+      <td className="py-3 pr-4 text-slate-600">{row.lineNumber}</td>
+      <td className="py-3 pr-4 font-mono text-xs">{row.recipient || '-'}</td>
+      <td className="py-3 pr-4">{row.amount || '-'}</td>
+      <td className="py-3 pr-4">{row.signedTransactionXdr ? 'Provided' : '-'}</td>
+      <td className="py-3 pr-4">
+        <Badge variant={isValid ? 'default' : 'destructive'}>{isValid ? 'Valid' : 'Invalid'}</Badge>
+      </td>
+      <td className="py-3 text-slate-600">{isValid ? '-' : row.errors.join('; ')}</td>
+    </tr>
+  );
+}

--- a/apps/web-dashboard/src/router/__tests__/router.test.tsx
+++ b/apps/web-dashboard/src/router/__tests__/router.test.tsx
@@ -111,4 +111,18 @@ describe('dashboard router', () => {
 
     expect(await screen.findByRole('heading', { name: /transactions/i })).toBeInTheDocument();
   });
+
+  it('renders the bulk payouts route for authenticated users', async () => {
+    writeSession({
+      userId: 'user-1',
+      displayName: 'Ops Admin',
+      accessToken: 'token-1',
+      refreshToken: 'refresh-1',
+      accessTokenExpiresAt: Date.now() + 60_000,
+    });
+
+    render(<DashboardAppTestHarness initialEntries={['/dashboard/bulk-payouts']} />);
+
+    expect(await screen.findByRole('heading', { name: /bulk payouts/i })).toBeInTheDocument();
+  });
 });

--- a/apps/web-dashboard/src/router/index.tsx
+++ b/apps/web-dashboard/src/router/index.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-router-dom';
 
 import { DashboardAuthProvider, useDashboardAuth } from '../auth';
+import { BulkPayoutsPage } from '../pages/BulkPayouts';
 import { ScheduledTransfersPage } from '../pages/ScheduledTransfers';
 import { TransactionsPage } from '../pages/transactions';
 
@@ -105,6 +106,7 @@ function DashboardLayout() {
         <nav className="space-y-2 rounded-xl border border-slate-200 bg-white p-4">
           <Link to="/dashboard">Overview</Link>
           <Link to="/dashboard/transactions">Transactions</Link>
+          <Link to="/dashboard/bulk-payouts">Bulk Payouts</Link>
           <Link to="/dashboard/scheduled-transfers">Scheduled Transfers</Link>
           <Link to="/dashboard/reports">Reports</Link>
           <Link to="/dashboard/settings">Settings</Link>
@@ -240,6 +242,7 @@ export function DashboardRouterContent() {
           <Route element={<DashboardLayout />}>
             <Route element={<OverviewPage />} path="/dashboard" />
             <Route element={<TransactionsPage />} path="/dashboard/transactions" />
+            <Route element={<BulkPayoutsPage />} path="/dashboard/bulk-payouts" />
             <Route element={<ScheduledTransfersPage />} path="/dashboard/scheduled-transfers" />
             <Route element={<ReportsPage />} path="/dashboard/reports" />
             <Route element={<SettingsPage />} path="/dashboard/settings" />

--- a/apps/web-dashboard/src/services/__tests__/bulk-payouts.test.ts
+++ b/apps/web-dashboard/src/services/__tests__/bulk-payouts.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createRelayerPayoutSubmitter,
+  executeBulkPayoutBatch,
+  parseBulkPayoutCsv,
+} from '../bulk-payouts';
+
+const VALID_RECIPIENT = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+describe('bulk payout CSV parsing', () => {
+  it('parses valid recipient and amount rows with a deterministic total', () => {
+    const result = parseBulkPayoutCsv(
+      `recipient,amount\n${VALID_RECIPIENT},10.5\n${VALID_RECIPIENT},0.0000001`
+    );
+
+    expect(result.rows).toHaveLength(2);
+    expect(result.invalidRows).toHaveLength(0);
+    expect(result.validRows).toHaveLength(2);
+    expect(result.totalAmount).toBe('10.5000001');
+  });
+
+  it('surfaces actionable validation errors for invalid rows', () => {
+    const badChecksum = `${VALID_RECIPIENT.slice(0, -1)}B`;
+    const result = parseBulkPayoutCsv(`recipient,amount\n${badChecksum},1.12345678\n,0`);
+
+    expect(result.validRows).toHaveLength(0);
+    expect(result.invalidRows).toHaveLength(2);
+    expect(result.rows[0].errors).toEqual([
+      'Recipient must be a valid Stellar G... public key',
+      'Amount must be a positive decimal with up to 7 fractional digits',
+    ]);
+    expect(result.rows[1].errors).toEqual([
+      'Recipient is required',
+      'Amount must be greater than zero',
+    ]);
+  });
+
+  it('accepts quoted CSV fields and recipient header aliases', () => {
+    const result = parseBulkPayoutCsv(`to,amount,signed_xdr\n"${VALID_RECIPIENT}","25","xdr-1"`);
+
+    expect(result.validRows).toHaveLength(1);
+    expect(result.validRows[0]).toMatchObject({
+      recipient: VALID_RECIPIENT,
+      amount: '25',
+      signedTransactionXdr: 'xdr-1',
+    });
+  });
+
+  it('reports missing required headers as an invalid preview row', () => {
+    const result = parseBulkPayoutCsv('recipient,memo\nGABC,payroll');
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.invalidRows[0].errors).toEqual(['Missing required column: amount']);
+  });
+
+  it('rejects amounts above the Stellar int64 asset limit', () => {
+    const result = parseBulkPayoutCsv(`recipient,amount\n${VALID_RECIPIENT},922337203685.4775808`);
+
+    expect(result.invalidRows[0].errors).toEqual([
+      'Amount exceeds the Stellar maximum asset amount',
+    ]);
+  });
+});
+
+describe('bulk payout execution queue', () => {
+  it('executes rows sequentially and reports failed rows', async () => {
+    const parsed = parseBulkPayoutCsv(
+      `recipient,amount\n${VALID_RECIPIENT},1\n${VALID_RECIPIENT},2`
+    );
+    const submitPayout = vi.fn(async ({ amount }: { amount: string }) => {
+      if (amount === '2') {
+        throw new Error('insufficient balance');
+      }
+    });
+
+    const summary = await executeBulkPayoutBatch(parsed.validRows, submitPayout);
+
+    expect(submitPayout).toHaveBeenCalledTimes(2);
+    expect(summary.successful).toBe(1);
+    expect(summary.failed).toBe(1);
+    expect(summary.results[1]).toMatchObject({
+      status: 'failed',
+      error: 'insufficient balance',
+    });
+  });
+
+  it('submits payouts to the relayer with idempotency and surfaces relay failures', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          success: false,
+          error: { message: 'Missing required parameter: signedTransactionXdr' },
+        }),
+        { status: 422, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    const submitPayout = createRelayerPayoutSubmitter({
+      baseUrl: 'https://relayer.test/',
+      getAuthToken: () => 'token-1',
+      fetchImpl,
+      buildRelayRequest: (submission) => ({
+        sessionKey: 'a'.repeat(64),
+        operation: 'relay_execute',
+        parameters: { to: submission.recipient, amount: submission.amount, asset: 'XLM' },
+        signature: 'b'.repeat(128),
+        nonce: 1,
+      }),
+    });
+
+    await expect(
+      submitPayout({
+        recipient: VALID_RECIPIENT,
+        amount: '10',
+        idempotencyKey: 'bulk-payout-row-1',
+      })
+    ).rejects.toThrow('Missing required parameter: signedTransactionXdr');
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://relayer.test/relay/execute',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-1',
+          'Idempotency-Key': 'bulk-payout-row-1',
+        }),
+      })
+    );
+  });
+});

--- a/apps/web-dashboard/src/services/bulk-payouts.ts
+++ b/apps/web-dashboard/src/services/bulk-payouts.ts
@@ -1,0 +1,364 @@
+export type BulkPayoutStatus = 'pending' | 'success' | 'failed';
+
+export interface BulkPayoutRow {
+  id: string;
+  lineNumber: number;
+  recipient: string;
+  amount: string;
+  signedTransactionXdr?: string;
+  status: BulkPayoutStatus;
+  errors: string[];
+}
+
+export interface BulkPayoutParseResult {
+  rows: BulkPayoutRow[];
+  validRows: BulkPayoutRow[];
+  invalidRows: BulkPayoutRow[];
+  totalAmount: string;
+}
+
+export interface BulkPayoutExecution {
+  row: BulkPayoutRow;
+  status: Exclude<BulkPayoutStatus, 'pending'>;
+  error?: string;
+}
+
+export interface BulkPayoutExecutionSummary {
+  total: number;
+  successful: number;
+  failed: number;
+  results: BulkPayoutExecution[];
+}
+
+export interface PayoutSubmission {
+  recipient: string;
+  amount: string;
+  signedTransactionXdr?: string;
+  idempotencyKey: string;
+}
+
+export type PayoutSubmitter = (submission: PayoutSubmission) => Promise<void>;
+
+export interface RelayExecuteRequest {
+  sessionKey: string;
+  operation: 'relay_execute' | 'add_session_key' | 'revoke_session_key';
+  parameters: Record<string, unknown>;
+  signature: string;
+  nonce: number;
+}
+
+export interface RelayerPayoutSubmitterOptions {
+  baseUrl: string;
+  getAuthToken: () => string | Promise<string>;
+  buildRelayRequest: (submission: PayoutSubmission) => RelayExecuteRequest;
+  fetchImpl?: typeof fetch;
+}
+
+const REQUIRED_HEADERS = ['recipient', 'amount'] as const;
+type CsvHeader = (typeof REQUIRED_HEADERS)[number] | 'signedTransactionXdr';
+const HEADER_ALIASES: Record<string, CsvHeader> = {
+  address: 'recipient',
+  destination: 'recipient',
+  recipient: 'recipient',
+  to: 'recipient',
+  amount: 'amount',
+  signedtransactionxdr: 'signedTransactionXdr',
+  signedxdr: 'signedTransactionXdr',
+  xdr: 'signedTransactionXdr',
+};
+const STRKEY_ED25519_PUBLIC_KEY_VERSION_BYTE = 6 << 3;
+const STRKEY_BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const MAX_STROOPS = 9_223_372_036_854_775_807n;
+
+export function parseBulkPayoutCsv(csv: string): BulkPayoutParseResult {
+  const records = parseCsvRecords(csv);
+  if (records.length === 0) {
+    return toParseResult([]);
+  }
+
+  const headers = records[0].map((header) => HEADER_ALIASES[normalizeHeader(header)] ?? '');
+  const missingHeaders = REQUIRED_HEADERS.filter((header) => !headers.includes(header));
+
+  if (missingHeaders.length > 0) {
+    const row = createRow(1, '', '', undefined, [
+      `Missing required column${missingHeaders.length > 1 ? 's' : ''}: ${missingHeaders.join(', ')}`,
+    ]);
+    return toParseResult([row]);
+  }
+
+  const recipientIndex = headers.indexOf('recipient');
+  const amountIndex = headers.indexOf('amount');
+  const signedTransactionXdrIndex = headers.indexOf('signedTransactionXdr');
+  const rows = records.slice(1).reduce<BulkPayoutRow[]>((accumulator, record, index) => {
+    if (record.every((cell) => cell.trim() === '')) {
+      return accumulator;
+    }
+
+    const lineNumber = index + 2;
+    const recipient = record[recipientIndex]?.trim() ?? '';
+    const amount = normalizeAmount(record[amountIndex] ?? '');
+    const signedTransactionXdr =
+      signedTransactionXdrIndex === -1 ? undefined : record[signedTransactionXdrIndex]?.trim();
+    accumulator.push(
+      createRow(
+        lineNumber,
+        recipient,
+        amount,
+        signedTransactionXdr,
+        validateRow(recipient, amount)
+      )
+    );
+    return accumulator;
+  }, []);
+
+  return toParseResult(rows);
+}
+
+export async function executeBulkPayoutBatch(
+  rows: BulkPayoutRow[],
+  submitPayout: PayoutSubmitter
+): Promise<BulkPayoutExecutionSummary> {
+  const results: BulkPayoutExecution[] = [];
+
+  for (const row of rows) {
+    try {
+      await submitPayout({
+        recipient: row.recipient,
+        amount: row.amount,
+        signedTransactionXdr: row.signedTransactionXdr,
+        idempotencyKey: `bulk-payout-${row.id}`,
+      });
+      results.push({ row, status: 'success' });
+    } catch (error) {
+      results.push({
+        row,
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'Payout execution failed',
+      });
+    }
+  }
+
+  const successful = results.filter((result) => result.status === 'success').length;
+  return {
+    total: rows.length,
+    successful,
+    failed: rows.length - successful,
+    results,
+  };
+}
+
+export function createRelayerPayoutSubmitter(
+  options: RelayerPayoutSubmitterOptions
+): PayoutSubmitter {
+  const baseUrl = options.baseUrl.replace(/\/$/, '');
+  const fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
+
+  return async (submission: PayoutSubmission) => {
+    const token = await options.getAuthToken();
+    const response = await fetchImpl(`${baseUrl}/relay/execute`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'Idempotency-Key': submission.idempotencyKey,
+      },
+      body: JSON.stringify(options.buildRelayRequest(submission)),
+    });
+
+    const body = (await readJsonResponse(response)) as {
+      success?: boolean;
+      error?: { message?: string };
+      message?: string;
+    };
+
+    if (!response.ok || body.success === false) {
+      throw new Error(
+        body.error?.message ?? body.message ?? `Payout relay request failed (${response.status})`
+      );
+    }
+  };
+}
+
+function parseCsvRecords(csv: string): string[][] {
+  const records: string[][] = [];
+  let record: string[] = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let index = 0; index < csv.length; index += 1) {
+    const char = csv[index];
+    const nextChar = csv[index + 1];
+
+    if (char === '"') {
+      if (inQuotes && nextChar === '"') {
+        field += '"';
+        index += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      record.push(field);
+      field = '';
+      continue;
+    }
+
+    if ((char === '\n' || char === '\r') && !inQuotes) {
+      if (char === '\r' && nextChar === '\n') {
+        index += 1;
+      }
+      record.push(field);
+      records.push(record);
+      record = [];
+      field = '';
+      continue;
+    }
+
+    field += char;
+  }
+
+  if (field.length > 0 || record.length > 0) {
+    record.push(field);
+    records.push(record);
+  }
+
+  return records.filter((row) => row.some((cell) => cell.trim() !== ''));
+}
+
+function createRow(
+  lineNumber: number,
+  recipient: string,
+  amount: string,
+  signedTransactionXdr: string | undefined,
+  errors: string[]
+): BulkPayoutRow {
+  return {
+    id: `${lineNumber}-${recipient}-${amount}`,
+    lineNumber,
+    recipient,
+    amount,
+    signedTransactionXdr,
+    status: 'pending',
+    errors,
+  };
+}
+
+function validateRow(recipient: string, amount: string): string[] {
+  const errors: string[] = [];
+
+  if (!recipient) {
+    errors.push('Recipient is required');
+  } else if (!isValidEd25519PublicKey(recipient)) {
+    errors.push('Recipient must be a valid Stellar G... public key');
+  }
+
+  if (!amount) {
+    errors.push('Amount is required');
+  } else if (!/^\d+(?:\.\d{1,7})?$/.test(amount)) {
+    errors.push('Amount must be a positive decimal with up to 7 fractional digits');
+  } else {
+    const stroops = decimalToStroops(amount);
+    if (stroops <= 0n) {
+      errors.push('Amount must be greater than zero');
+    } else if (stroops > MAX_STROOPS) {
+      errors.push('Amount exceeds the Stellar maximum asset amount');
+    }
+  }
+
+  return errors;
+}
+
+function normalizeHeader(value: string): string {
+  return value.trim().toLowerCase().replace(/[\s_-]+/g, '');
+}
+
+function normalizeAmount(value: string): string {
+  return value.trim();
+}
+
+function toParseResult(rows: BulkPayoutRow[]): BulkPayoutParseResult {
+  const validRows = rows.filter((row) => row.errors.length === 0);
+  const invalidRows = rows.filter((row) => row.errors.length > 0);
+
+  return {
+    rows,
+    validRows,
+    invalidRows,
+    totalAmount: formatStroops(
+      validRows.reduce((total, row) => total + decimalToStroops(row.amount), 0n)
+    ),
+  };
+}
+
+function decimalToStroops(amount: string): bigint {
+  const [whole, fractional = ''] = amount.split('.');
+  return BigInt(whole) * 10_000_000n + BigInt(fractional.padEnd(7, '0'));
+}
+
+function formatStroops(stroops: bigint): string {
+  const whole = stroops / 10_000_000n;
+  const fractional = (stroops % 10_000_000n).toString().padStart(7, '0').replace(/0+$/, '');
+  return fractional ? `${whole}.${fractional}` : whole.toString();
+}
+
+function isValidEd25519PublicKey(value: string): boolean {
+  if (!/^G[A-Z2-7]{55}$/.test(value)) {
+    return false;
+  }
+
+  const decoded = decodeBase32(value);
+  if (!decoded || decoded.length !== 35) {
+    return false;
+  }
+
+  const payload = decoded.slice(0, 33);
+  const checksum = decoded[33] | (decoded[34] << 8);
+  return payload[0] === STRKEY_ED25519_PUBLIC_KEY_VERSION_BYTE && crc16Xmodem(payload) === checksum;
+}
+
+function decodeBase32(value: string): Uint8Array | null {
+  const bytes: number[] = [];
+  let buffer = 0;
+  let bits = 0;
+
+  for (const char of value) {
+    const digit = STRKEY_BASE32_ALPHABET.indexOf(char);
+    if (digit === -1) {
+      return null;
+    }
+
+    buffer = (buffer << 5) | digit;
+    bits += 5;
+
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((buffer >> bits) & 0xff);
+    }
+  }
+
+  return new Uint8Array(bytes);
+}
+
+function crc16Xmodem(bytes: Uint8Array): number {
+  let crc = 0;
+
+  for (const byte of bytes) {
+    crc ^= byte << 8;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = crc & 0x8000 ? (crc << 1) ^ 0x1021 : crc << 1;
+      crc &= 0xffff;
+    }
+  }
+
+  return crc;
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}

--- a/package.json
+++ b/package.json
@@ -66,6 +66,18 @@
     ],
     "packages/account-abstraction/src/**/*.{ts,tsx,js,jsx}": [
       "pnpm --dir packages/account-abstraction exec eslint --fix"
+    ],
+    "apps/extension-wallet/src/**/*.{ts,tsx,js,jsx}": [
+      "pnpm --dir apps/extension-wallet exec eslint --fix"
+    ],
+    "apps/web-dashboard/src/**/*.{ts,tsx,js,jsx}": [
+      "pnpm --dir apps/web-dashboard exec eslint --fix"
+    ],
+    "apps/mobile-wallet/src/**/*.{ts,tsx,js,jsx}": [
+      "pnpm --dir apps/mobile-wallet exec eslint --fix"
+    ],
+    "services/relayer/src/**/*.{ts,tsx,js,jsx}": [
+      "pnpm --dir services/relayer exec eslint --fix"
     ]
   },
   "pnpm": {


### PR DESCRIPTION
Closes #405 
Closes #416 

# PR Description

Fixes #416 by adding a dashboard bulk payout workflow that imports CSV rows, validates Stellar recipients and payment amounts, previews valid and invalid rows, and executes valid batches through the relayer `/relay/execute` path with per-row idempotency keys. The execution summary now reflects relayer responses so failed rows are reported back to the user.

Fixes #405 by extending root lint-staged coverage so app and relayer source changes run package-local ESLint autofix in addition to the existing Prettier checks.

# Changed

- #416: Added bulk payout CSV parser, Stellar validation, preview page, relayer-backed execution, and failed-row reporting.
- #416: Added dashboard route coverage and focused bulk payout service tests.
- #405: Added lint-staged ESLint entries for `apps/*/src` and `services/relayer/src`.
- #405: Documented staged-file checks in `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk payouts functionality enabling users to import and execute multiple payouts from CSV files.
  * Provides CSV file validation with a preview table showing per-row validity status and error details.
  * Displays execution summary with success/failure counts and a detailed report of failed transactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ancore-org/ancore/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->