### PR TITLE
Statements export (CSV/PDF) for personal and business records

### DIFF
--- a/apps/web-dashboard/src/components/transactions/TransactionTable.tsx
+++ b/apps/web-dashboard/src/components/transactions/TransactionTable.tsx
@@ -11,6 +11,7 @@ import type { Transaction, TransactionSortKey, TransactionTableState } from './t
 
 interface TransactionTableProps {
   transactions: Transaction[];
+  onExportStatement?: () => void;
 }
 
 const DATE_FILTER_LABELS: Record<TransactionTableState['date'], string> = {
@@ -57,7 +58,7 @@ function formatDate(value: string): string {
   }).format(new Date(value));
 }
 
-export function TransactionTable({ transactions }: TransactionTableProps) {
+export function TransactionTable({ onExportStatement, transactions }: TransactionTableProps) {
   const [searchParams, setSearchParams] = useSearchParams();
   const state = useMemo(() => parseTransactionTableState(searchParams), [searchParams]);
 
@@ -85,11 +86,22 @@ export function TransactionTable({ transactions }: TransactionTableProps) {
 
   return (
     <section className="space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-semibold">Transactions</h1>
-        <p className="text-sm text-slate-600">
-          Filter and sort transaction history without losing the current view.
-        </p>
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold">Transactions</h1>
+          <p className="text-sm text-slate-600">
+            Filter and sort transaction history without losing the current view.
+          </p>
+        </div>
+        {onExportStatement ? (
+          <button
+            className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
+            onClick={onExportStatement}
+            type="button"
+          >
+            Export statement
+          </button>
+        ) : null}
       </header>
 
       <div className="grid gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 md:grid-cols-3">

--- a/apps/web-dashboard/src/features/statements/StatementExportModal.stories.tsx
+++ b/apps/web-dashboard/src/features/statements/StatementExportModal.stories.tsx
@@ -1,0 +1,42 @@
+import { StatementExportModal } from './StatementExportModal';
+import { StatementExportService } from './statement-export';
+
+class MockStatementExportService extends StatementExportService {
+  async fetchRows() {
+    return {
+      rows: [
+        {
+          id: 'row-1',
+          timestamp: '2026-04-24T10:00:00.000Z',
+          counterparty: 'Acme Treasury',
+          amount: '142.50',
+          asset: 'USDC',
+          status: 'completed' as const,
+          memoOrReference: 'Invoice 1042',
+        },
+      ],
+    };
+  }
+}
+
+const meta = {
+  title: 'Statements/StatementExportModal',
+  component: StatementExportModal,
+  args: {
+    accountId: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
+    isOpen: true,
+    onClose: () => undefined,
+    service: new MockStatementExportService(),
+    pdfEnabled: true,
+  },
+};
+
+export default meta;
+
+export const Default = {};
+
+export const PdfDisabled = {
+  args: {
+    pdfEnabled: false,
+  },
+};

--- a/apps/web-dashboard/src/features/statements/StatementExportModal.tsx
+++ b/apps/web-dashboard/src/features/statements/StatementExportModal.tsx
@@ -1,0 +1,212 @@
+import { useMemo, useState } from 'react';
+import type { StatementExportFilters, StatementExportFormat, StatementRow } from '@ancore/types';
+
+import {
+  downloadStatementExport,
+  StatementExportError,
+  StatementExportService,
+} from './statement-export';
+
+interface StatementExportModalProps {
+  accountId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  service?: StatementExportService;
+  pdfEnabled?: boolean;
+}
+
+const today = new Date().toISOString().slice(0, 10);
+const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+export function StatementExportModal({
+  accountId,
+  isOpen,
+  onClose,
+  service = new StatementExportService(),
+  pdfEnabled = import.meta.env.VITE_STATEMENT_PDF_EXPORT === 'true',
+}: StatementExportModalProps) {
+  const [from, setFrom] = useState(thirtyDaysAgo);
+  const [to, setTo] = useState(today);
+  const [format, setFormat] = useState<StatementExportFormat>('csv');
+  const [isLoading, setIsLoading] = useState(false);
+  const [previewRows, setPreviewRows] = useState<StatementRow[]>([]);
+  const [hasLoadedPreview, setHasLoadedPreview] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const filters = useMemo<StatementExportFilters>(
+    () => ({
+      accountId,
+      from: `${from}T00:00:00.000Z`,
+      to: `${to}T23:59:59.999Z`,
+    }),
+    [accountId, from, to]
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  async function previewStatement() {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const page = await service.fetchRows(filters);
+      setPreviewRows(page.rows.slice(0, 5));
+      setHasLoadedPreview(true);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Unable to preview statement rows.');
+      setPreviewRows([]);
+      setHasLoadedPreview(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function exportStatement() {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await service.export(filters, format);
+      downloadStatementExport(result);
+    } catch (caught) {
+      setError(
+        caught instanceof StatementExportError
+          ? caught.message
+          : 'Unable to export statement. Try again or narrow the date range.'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div
+      aria-labelledby="statement-export-title"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/50 p-4"
+      role="dialog"
+    >
+      <div className="w-full max-w-2xl rounded-2xl bg-white p-6 shadow-xl">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900" id="statement-export-title">
+              Export statement
+            </h2>
+            <p className="mt-1 text-sm text-slate-600">
+              Generate CSV records from indexer-backed account activity.
+            </p>
+          </div>
+          <button
+            className="rounded-lg px-3 py-2 text-sm text-slate-600"
+            onClick={onClose}
+            type="button"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="mt-6 grid gap-4 md:grid-cols-2">
+          <label className="space-y-2 text-sm font-medium text-slate-700">
+            Account
+            <input
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-xs"
+              readOnly
+              value={accountId}
+            />
+          </label>
+          <label className="space-y-2 text-sm font-medium text-slate-700">
+            Format
+            <select
+              aria-label="Statement export format"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2"
+              onChange={(event) => setFormat(event.target.value as StatementExportFormat)}
+              value={format}
+            >
+              <option value="csv">CSV</option>
+              {pdfEnabled ? <option value="pdf">PDF</option> : null}
+            </select>
+          </label>
+          <label className="space-y-2 text-sm font-medium text-slate-700">
+            From
+            <input
+              className="w-full rounded-lg border border-slate-300 px-3 py-2"
+              onChange={(event) => setFrom(event.target.value)}
+              type="date"
+              value={from}
+            />
+          </label>
+          <label className="space-y-2 text-sm font-medium text-slate-700">
+            To
+            <input
+              className="w-full rounded-lg border border-slate-300 px-3 py-2"
+              onChange={(event) => setTo(event.target.value)}
+              type="date"
+              value={to}
+            />
+          </label>
+        </div>
+
+        {error ? (
+          <div
+            className="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+            role="alert"
+          >
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-6 rounded-xl border border-slate-200">
+          <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+            <p className="text-sm font-medium text-slate-700">Preview</p>
+            <button
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 disabled:opacity-60"
+              disabled={isLoading}
+              onClick={previewStatement}
+              type="button"
+            >
+              {isLoading ? 'Loading…' : 'Load preview'}
+            </button>
+          </div>
+          <div className="p-4">
+            {isLoading ? <p className="text-sm text-slate-500">Fetching statement rows…</p> : null}
+            {!isLoading && previewRows.length === 0 ? (
+              <p className="text-sm text-slate-500">
+                {hasLoadedPreview
+                  ? 'No statement activity found for the selected range.'
+                  : 'No statement rows loaded for this range yet.'}
+              </p>
+            ) : null}
+            {previewRows.length > 0 ? (
+              <ul className="space-y-2 text-sm text-slate-700">
+                {previewRows.map((row) => (
+                  <li className="rounded-lg bg-slate-50 p-3" key={row.id}>
+                    <span className="font-medium">{row.timestamp}</span> · {row.counterparty} ·{' '}
+                    {row.amount} {row.asset} · {row.status}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            className="rounded-lg px-4 py-2 text-sm font-medium text-slate-600"
+            onClick={onClose}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+            disabled={isLoading}
+            onClick={exportStatement}
+            type="button"
+          >
+            {isLoading ? 'Exporting…' : 'Export statement'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-dashboard/src/features/statements/__tests__/statement-export.test.ts
+++ b/apps/web-dashboard/src/features/statements/__tests__/statement-export.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { STATEMENT_COLUMNS } from '@ancore/types';
+
+import { fetchStatementRows, toStatementCsv } from '../statement-export';
+
+const row = {
+  id: 'row-1',
+  timestamp: '2026-04-24T10:00:00.000Z',
+  counterparty: 'Acme Treasury',
+  amount: '142.50',
+  asset: 'USDC',
+  status: 'completed' as const,
+  memoOrReference: 'Invoice 1042',
+};
+
+describe('statement export schema', () => {
+  it('locks statement column order and CSV headers', () => {
+    expect(STATEMENT_COLUMNS.map((column) => column.key)).toEqual([
+      'timestamp',
+      'counterparty',
+      'amount',
+      'asset',
+      'status',
+      'memoOrReference',
+    ]);
+    expect(toStatementCsv([row]).split('\n')[0]).toBe(
+      'Timestamp,Counterparty,Amount,Asset,Status,Memo/Reference'
+    );
+  });
+
+  it('escapes CSV cells without changing column order', () => {
+    const csv = toStatementCsv([{ ...row, memoOrReference: 'Invoice, "special"' }]);
+
+    expect(csv).toContain('"Invoice, ""special"""');
+    expect(csv.split('\n')[1]).toBe(
+      '2026-04-24T10:00:00.000Z,Acme Treasury,142.50,USDC,completed,"Invoice, ""special"""'
+    );
+  });
+});
+
+describe('fetchStatementRows', () => {
+  it('applies account and date filters to bounded indexer fetches', async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        rows: [
+          {
+            id: 'row-1',
+            amount: '142.50',
+            asset: 'USDC',
+            counterparty: 'Acme Treasury',
+            timestamp: row.timestamp,
+            status: 'completed',
+            memo_or_reference: 'Invoice 1042',
+          },
+        ],
+        next_cursor: null,
+      })
+    );
+
+    const rows = await fetchStatementRows(
+      {
+        accountId: 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
+        from: '2026-04-01T00:00:00.000Z',
+        to: '2026-04-30T23:59:59.999Z',
+      },
+      fetcher as unknown as typeof fetch
+    );
+
+    const requestedUrl = new URL(fetcher.mock.calls[0][0]);
+    expect(requestedUrl.pathname).toContain(
+      '/api/v1/accounts/GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890/statements/rows'
+    );
+    expect(requestedUrl.searchParams.get('from_date')).toBe('2026-04-01T00:00:00.000Z');
+    expect(requestedUrl.searchParams.get('to_date')).toBe('2026-04-30T23:59:59.999Z');
+    expect(requestedUrl.searchParams.get('limit')).toBe('100');
+    expect(rows[0]).toMatchObject(row);
+  });
+});

--- a/apps/web-dashboard/src/features/statements/statement-export.ts
+++ b/apps/web-dashboard/src/features/statements/statement-export.ts
@@ -1,0 +1,241 @@
+import {
+  STATEMENT_COLUMNS,
+  type StatementExportFilters,
+  type StatementExportFormat,
+  type StatementExportResult,
+  type StatementRow,
+  type StatementRowsPage,
+} from '@ancore/types';
+
+const DEFAULT_PAGE_LIMIT = 100;
+const MAX_EXPORT_ROWS = 5_000;
+const INDEXER_BASE_URL = import.meta.env.VITE_INDEXER_BASE_URL ?? '';
+
+interface IndexerStatementRow {
+  id: string;
+  timestamp: string;
+  counterparty?: string | null;
+  amount?: string | null;
+  asset?: string | null;
+  status?: string | null;
+  memo_or_reference?: string | null;
+  memoOrReference?: string | null;
+}
+
+interface IndexerStatementRowsResponse {
+  rows: IndexerStatementRow[];
+  next_cursor?: string | null;
+}
+
+export class StatementExportError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StatementExportError';
+  }
+}
+
+function assertFilters(filters: StatementExportFilters) {
+  if (!filters.accountId.trim()) {
+    throw new StatementExportError('Choose an account before exporting a statement.');
+  }
+
+  const fromTime = Date.parse(filters.from);
+  const toTime = Date.parse(filters.to);
+  if (Number.isNaN(fromTime) || Number.isNaN(toTime)) {
+    throw new StatementExportError('Choose a valid statement date range.');
+  }
+  if (fromTime > toTime) {
+    throw new StatementExportError('Statement start date must be before the end date.');
+  }
+}
+
+function normalizeStatus(value: string | undefined): StatementRow['status'] {
+  if (value === 'completed' || value === 'pending' || value === 'failed') {
+    return value;
+  }
+  return 'unknown';
+}
+
+function indexerRowToStatementRow(row: IndexerStatementRow): StatementRow {
+  return {
+    id: row.id,
+    timestamp: row.timestamp,
+    counterparty: row.counterparty ?? '—',
+    amount: row.amount ?? '0',
+    asset: row.asset ?? 'XLM',
+    status: normalizeStatus(row.status ?? undefined),
+    memoOrReference: row.memoOrReference ?? row.memo_or_reference ?? '',
+  };
+}
+
+function buildStatementRowsUrl(filters: StatementExportFilters, cursor?: string): string {
+  const url = new URL(
+    `/api/v1/accounts/${encodeURIComponent(filters.accountId)}/statements/rows`,
+    INDEXER_BASE_URL || window.location.origin
+  );
+  url.searchParams.set('from_date', new Date(filters.from).toISOString());
+  url.searchParams.set('to_date', new Date(filters.to).toISOString());
+  url.searchParams.set('limit', String(DEFAULT_PAGE_LIMIT));
+  if (cursor) {
+    url.searchParams.set('cursor_after', cursor);
+  }
+  return url.toString();
+}
+
+function escapeCsvCell(value: string): string {
+  if (/[,"\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function toStatementCsv(rows: StatementRow[]): string {
+  const header = STATEMENT_COLUMNS.map((column) => escapeCsvCell(column.header)).join(',');
+  const body = rows.map((row) =>
+    STATEMENT_COLUMNS.map((column) => escapeCsvCell(String(row[column.key]))).join(',')
+  );
+  return [header, ...body].join('\n');
+}
+
+function escapePdfText(value: string): string {
+  return value.replace(/([\\()])/g, '\\$1').replace(/[\n\r]/g, ' ');
+}
+
+function wrapPdfLine(value: string, maxLength = 96): string[] {
+  if (value.length <= maxLength) {
+    return [value];
+  }
+
+  const lines: string[] = [];
+  for (let index = 0; index < value.length; index += maxLength) {
+    lines.push(value.slice(index, index + maxLength));
+  }
+  return lines;
+}
+
+function toStatementPdf(rows: StatementRow[], filters: StatementExportFilters): string {
+  const range = `${new Date(filters.from).toLocaleDateString()} - ${new Date(filters.to).toLocaleDateString()}`;
+  const lines = [
+    'Account statement',
+    `Account: ${filters.accountId}`,
+    `Date range: ${range}`,
+    '',
+    STATEMENT_COLUMNS.map((column) => column.header).join(' | '),
+    ...rows.flatMap((row) =>
+      wrapPdfLine(STATEMENT_COLUMNS.map((column) => String(row[column.key])).join(' | '))
+    ),
+  ];
+
+  if (rows.length === 0) {
+    lines.push('No statement activity found.');
+  }
+
+  const content = [
+    'BT',
+    '/F1 10 Tf',
+    '40 760 Td',
+    '14 TL',
+    ...lines.map((line, index) => `${index === 0 ? '' : 'T* '}(${escapePdfText(line)}) Tj`),
+    'ET',
+  ].join('\n');
+
+  const objects = [
+    '1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj',
+    '2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj',
+    '3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj',
+    '4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj',
+    `5 0 obj << /Length ${content.length} >> stream\n${content}\nendstream endobj`,
+  ];
+
+  let pdf = '%PDF-1.4\n';
+  const offsets = [0];
+  for (const object of objects) {
+    offsets.push(pdf.length);
+    pdf += `${object}\n`;
+  }
+  const xrefOffset = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n`;
+  pdf += '0000000000 65535 f \n';
+  pdf += offsets
+    .slice(1)
+    .map((offset) => `${String(offset).padStart(10, '0')} 00000 n `)
+    .join('\n');
+  pdf += `\ntrailer << /Root 1 0 R /Size ${objects.length + 1} >>\nstartxref\n${xrefOffset}\n%%EOF`;
+  return pdf;
+}
+
+function buildFilename(filters: StatementExportFilters, format: StatementExportFormat) {
+  const from = filters.from.slice(0, 10);
+  const to = filters.to.slice(0, 10);
+  return `statement-${filters.accountId.slice(0, 8)}-${from}-${to}.${format === 'csv' ? 'csv' : 'pdf'}`;
+}
+
+export async function fetchStatementRows(
+  filters: StatementExportFilters,
+  fetcher: typeof fetch = fetch
+): Promise<StatementRow[]> {
+  assertFilters(filters);
+
+  const rows: StatementRow[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const response = await fetcher(buildStatementRowsUrl(filters, cursor));
+    if (!response.ok) {
+      throw new StatementExportError('Unable to fetch statement rows from the indexer.');
+    }
+
+    const page = (await response.json()) as IndexerStatementRowsResponse;
+    rows.push(...page.rows.map(indexerRowToStatementRow));
+    cursor = page.next_cursor ?? undefined;
+
+    if (rows.length > MAX_EXPORT_ROWS) {
+      throw new StatementExportError(
+        'Narrow the date range before exporting more than 5,000 rows.'
+      );
+    }
+  } while (cursor);
+
+  return rows;
+}
+
+export class StatementExportService {
+  async fetchRows(filters: StatementExportFilters): Promise<StatementRowsPage> {
+    const rows = await fetchStatementRows(filters);
+    return { rows };
+  }
+
+  async export(
+    filters: StatementExportFilters,
+    format: StatementExportFormat
+  ): Promise<StatementExportResult> {
+    const rows = await fetchStatementRows(filters);
+
+    if (format === 'pdf') {
+      const pdf = toStatementPdf(rows, filters);
+      return {
+        filename: buildFilename(filters, format),
+        mimeType: 'application/pdf',
+        blob: new Blob([pdf], { type: 'application/pdf' }),
+      };
+    }
+
+    const csv = toStatementCsv(rows);
+    return {
+      filename: buildFilename(filters, format),
+      mimeType: 'text/csv;charset=utf-8',
+      blob: new Blob([csv], { type: 'text/csv;charset=utf-8' }),
+    };
+  }
+}
+
+export function downloadStatementExport(result: StatementExportResult) {
+  const url = URL.createObjectURL(result.blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = result.filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/apps/web-dashboard/src/pages/transactions.tsx
+++ b/apps/web-dashboard/src/pages/transactions.tsx
@@ -1,5 +1,10 @@
+import { useState } from 'react';
+
 import { TransactionTable } from '../components/transactions/TransactionTable';
+import { StatementExportModal } from '../features/statements/StatementExportModal';
 import type { Transaction } from '../components/transactions/transaction-types';
+
+const STATEMENT_ACCOUNT_ID = 'GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
 
 const DASHBOARD_TRANSACTIONS: Transaction[] = [
   {
@@ -50,5 +55,19 @@ const DASHBOARD_TRANSACTIONS: Transaction[] = [
 ];
 
 export function TransactionsPage() {
-  return <TransactionTable transactions={DASHBOARD_TRANSACTIONS} />;
+  const [isStatementExportOpen, setIsStatementExportOpen] = useState(false);
+
+  return (
+    <>
+      <TransactionTable
+        onExportStatement={() => setIsStatementExportOpen(true)}
+        transactions={DASHBOARD_TRANSACTIONS}
+      />
+      <StatementExportModal
+        accountId={STATEMENT_ACCOUNT_ID}
+        isOpen={isStatementExportOpen}
+        onClose={() => setIsStatementExportOpen(false)}
+      />
+    </>
+  );
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,3 +36,4 @@ export * from './schemas';
 export * from './payment-request';
 export * from './contacts';
 export * from './scheduled-transfer';
+export * from './statement';

--- a/packages/types/src/statement.ts
+++ b/packages/types/src/statement.ts
@@ -1,0 +1,39 @@
+export const STATEMENT_COLUMNS = [
+  { key: 'timestamp', header: 'Timestamp' },
+  { key: 'counterparty', header: 'Counterparty' },
+  { key: 'amount', header: 'Amount' },
+  { key: 'asset', header: 'Asset' },
+  { key: 'status', header: 'Status' },
+  { key: 'memoOrReference', header: 'Memo/Reference' },
+] as const;
+
+export type StatementColumnKey = (typeof STATEMENT_COLUMNS)[number]['key'];
+export type StatementStatus = 'completed' | 'pending' | 'failed' | 'unknown';
+export type StatementExportFormat = 'csv' | 'pdf';
+
+export interface StatementRow {
+  id: string;
+  timestamp: string;
+  counterparty: string;
+  amount: string;
+  asset: string;
+  status: StatementStatus;
+  memoOrReference: string;
+}
+
+export interface StatementExportFilters {
+  accountId: string;
+  from: string;
+  to: string;
+}
+
+export interface StatementRowsPage {
+  rows: StatementRow[];
+  nextCursor?: string;
+}
+
+export interface StatementExportResult {
+  filename: string;
+  mimeType: string;
+  blob: Blob;
+}

--- a/services/indexer/src/api/mod.rs
+++ b/services/indexer/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub mod account_activity;
 pub mod health;
 pub mod metrics;
+pub mod statements;

--- a/services/indexer/src/api/statements.rs
+++ b/services/indexer/src/api/statements.rs
@@ -1,0 +1,131 @@
+use axum::{
+    extract::{Path, Query, State},
+    response::Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+use crate::error::{ApiError, Result};
+use crate::repositories::account_activity::{ActivityFilter, CursorPage};
+
+#[derive(Debug, Deserialize)]
+pub struct StatementRowsQuery {
+    cursor_after: Option<String>,
+    limit: Option<u32>,
+    from_date: String,
+    to_date: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StatementRow {
+    id: String,
+    timestamp: DateTime<Utc>,
+    counterparty: String,
+    amount: String,
+    asset: String,
+    status: String,
+    memo_or_reference: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StatementRowsResponse {
+    rows: Vec<StatementRow>,
+    next_cursor: Option<String>,
+}
+
+fn validate_account_id(id: &str) -> Result<()> {
+    if id.is_empty() {
+        return Err(ApiError::InvalidFilter(
+            "account_id cannot be empty".to_string(),
+        ));
+    }
+    if id.len() != 56 || !id.starts_with('G') {
+        return Err(ApiError::InvalidFilter(
+            "account_id must be a valid Stellar public key (56 characters starting with G)"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn parse_iso_datetime(s: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|_| {
+            ApiError::InvalidFilter(format!(
+                "Invalid datetime format: {}, expected ISO 8601 (RFC3339)",
+                s
+            ))
+        })
+}
+
+fn metadata_string(metadata: Option<&serde_json::Value>, key: &str) -> Option<String> {
+    metadata
+        .and_then(|value| value.get(key))
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string)
+}
+
+pub async fn rows_handler(
+    State(db): State<PgPool>,
+    Path(account_id): Path<String>,
+    Query(params): Query<StatementRowsQuery>,
+) -> Result<Json<StatementRowsResponse>> {
+    validate_account_id(&account_id)?;
+
+    let from_date = parse_iso_datetime(&params.from_date)?;
+    let to_date = parse_iso_datetime(&params.to_date)?;
+    if from_date > to_date {
+        return Err(ApiError::InvalidFilter(
+            "from_date must be <= to_date".to_string(),
+        ));
+    }
+
+    let filter = ActivityFilter {
+        from_date: Some(from_date),
+        to_date: Some(to_date),
+        ..Default::default()
+    };
+    let page = CursorPage {
+        after: params.cursor_after,
+        before: None,
+        limit: params.limit,
+    };
+
+    let result = crate::repositories::account_activity::get_account_activity(
+        &db,
+        &account_id,
+        &filter,
+        &page,
+    )
+    .await?;
+
+    let rows = result
+        .items
+        .into_iter()
+        .map(|activity| {
+            let status = metadata_string(activity.metadata.as_ref(), "status")
+                .unwrap_or_else(|| "unknown".to_string());
+            let memo_or_reference = metadata_string(activity.metadata.as_ref(), "memoOrReference")
+                .or_else(|| metadata_string(activity.metadata.as_ref(), "memo"))
+                .or_else(|| metadata_string(activity.metadata.as_ref(), "reference"))
+                .unwrap_or_else(|| activity.tx_hash.clone());
+
+            StatementRow {
+                id: activity.id.to_string(),
+                timestamp: activity.created_at,
+                counterparty: activity.counterparty.unwrap_or_else(|| "—".to_string()),
+                amount: activity.amount.unwrap_or_else(|| "0".to_string()),
+                asset: activity.asset.unwrap_or_else(|| "XLM".to_string()),
+                status,
+                memo_or_reference,
+            }
+        })
+        .collect();
+
+    Ok(Json(StatementRowsResponse {
+        rows,
+        next_cursor: result.next_cursor,
+    }))
+}

--- a/services/indexer/src/main.rs
+++ b/services/indexer/src/main.rs
@@ -17,6 +17,7 @@ mod repositories;
 use api::account_activity;
 use api::health;
 use api::metrics;
+use api::statements;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -88,6 +89,10 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/api/v1/accounts/:account_id/activity/types",
             get(account_activity::list_types_handler),
+        )
+        .route(
+            "/api/v1/accounts/:account_id/statements/rows",
+            get(statements::rows_handler),
         )
         .route("/health", get(health::health_handler))
         .route("/metrics", get(metrics::metrics_handler))


### PR DESCRIPTION
Changes:
- Add statement export flow
- Merge pull request #4 from chiscookeke11/codex/add-statements-export-…

        
closes #417 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now export account statements from the transactions table in CSV or PDF formats
  * Added date range filtering and preview functionality to review statement rows before exporting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ancore-org/ancore/pull/700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->