### PR TITLE
fix: handle Horizon rate limit retries

### DIFF
--- a/packages/stellar/src/__tests__/client.test.ts
+++ b/packages/stellar/src/__tests__/client.test.ts
@@ -388,6 +388,53 @@ describe('StellarClient', () => {
       expect(horizon.loadAccount).toHaveBeenCalledTimes(2);
     });
 
+    it('should retry Horizon 429 responses and eventually succeed', async () => {
+      const client = new StellarClient({
+        network: 'testnet',
+        retryOptions: { maxRetries: 1, baseDelayMs: 0 },
+      });
+      const horizon = getHorizonMock(client);
+      const rateLimitError = Object.assign(new Error('Rate limited'), {
+        response: { status: 429 },
+      });
+      horizon.loadAccount
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce(mockAccountResponse);
+
+      await expect(client.getAccount('GABC123')).resolves.toEqual(mockAccountResponse);
+      expect(horizon.loadAccount).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not retry permanent Horizon 400 responses', async () => {
+      const client = new StellarClient({
+        network: 'testnet',
+        retryOptions: { maxRetries: 2, baseDelayMs: 0 },
+      });
+      const horizon = getHorizonMock(client);
+      const badRequestError = Object.assign(new Error('Bad request'), {
+        response: { status: 400 },
+      });
+      horizon.loadAccount.mockRejectedValue(badRequestError);
+
+      await expect(client.getAccount('GABC123')).rejects.toThrow(NetworkError);
+      expect(horizon.loadAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it('should surface RetryExhaustedError after persistent Horizon 429 responses', async () => {
+      const client = new StellarClient({
+        network: 'testnet',
+        retryOptions: { maxRetries: 1, baseDelayMs: 0 },
+      });
+      const horizon = getHorizonMock(client);
+      const rateLimitError = Object.assign(new Error('Rate limited'), {
+        response: { status: 429 },
+      });
+      horizon.loadAccount.mockRejectedValue(rateLimitError);
+
+      await expect(client.getAccount('GABC123')).rejects.toThrow(RetryExhaustedError);
+      expect(horizon.loadAccount).toHaveBeenCalledTimes(2);
+    });
+
     it('should unwrap RetryExhaustedError to the last NetworkError', async () => {
       const client = new StellarClient({
         network: 'testnet',
@@ -461,6 +508,26 @@ describe('StellarClient', () => {
       const horizon = getHorizonMock(client);
       horizon.submitTransaction
         .mockRejectedValueOnce(new Error('timeout'))
+        .mockResolvedValueOnce(mockSubmitResponse);
+
+      await expect(client.submitTransaction(mockTransaction)).resolves.toEqual(mockSubmitResponse);
+      expect(horizon.submitTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry Horizon 429 submission responses and eventually succeed', async () => {
+      const client = new StellarClient({
+        network: 'testnet',
+        retryOptions: { maxRetries: 1, baseDelayMs: 0 },
+      });
+      const horizon = getHorizonMock(client);
+      const rateLimitError = Object.assign(new Error('Rate limited'), {
+        response: {
+          status: 429,
+          data: { title: 'Rate Limit Exceeded' },
+        },
+      });
+      horizon.submitTransaction
+        .mockRejectedValueOnce(rateLimitError)
         .mockResolvedValueOnce(mockSubmitResponse);
 
       await expect(client.submitTransaction(mockTransaction)).resolves.toEqual(mockSubmitResponse);

--- a/packages/stellar/src/client.ts
+++ b/packages/stellar/src/client.ts
@@ -157,20 +157,32 @@ export class StellarClient {
     return Math.max(this.rpcServers.length, maxRetries + 1);
   }
 
-  private getErrorStatusCode(error: Error): number | undefined {
+  private getErrorStatusCode(error: unknown): number | undefined {
     if (error instanceof NetworkError) {
       return error.statusCode;
     }
 
-    if ('statusCode' in error && typeof error.statusCode === 'number') {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'statusCode' in error &&
+      typeof error.statusCode === 'number'
+    ) {
       return error.statusCode;
     }
 
-    if ('status' in error && typeof error.status === 'number') {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'status' in error &&
+      typeof error.status === 'number'
+    ) {
       return error.status;
     }
 
     if (
+      error &&
+      typeof error === 'object' &&
       'response' in error &&
       error.response &&
       typeof error.response === 'object' &&
@@ -183,18 +195,89 @@ export class StellarClient {
     return undefined;
   }
 
-  private isRetryableRpcError(error: Error): boolean {
-    if (error instanceof StellarError && !(error instanceof NetworkError)) {
-      return false;
+  private isRetryableStatusCode(statusCode: number): boolean {
+    return statusCode === 429 || statusCode >= 500;
+  }
+
+  private isRetryableNetworkError(error: Error): boolean {
+    if (error instanceof NetworkError && error.retryable !== undefined) {
+      return error.retryable;
     }
 
     const statusCode = this.getErrorStatusCode(error);
 
     if (statusCode !== undefined) {
-      return statusCode === 429 || statusCode >= 500;
+      return this.isRetryableStatusCode(statusCode);
     }
 
     return true;
+  }
+
+  private createHorizonNetworkError(message: string, error: unknown): NetworkError {
+    const statusCode = this.getErrorStatusCode(error);
+    const retryable = statusCode === undefined ? true : this.isRetryableStatusCode(statusCode);
+    const rateLimitMessage = statusCode === 429 ? `${message}: rate limited by Horizon` : message;
+
+    return new NetworkError(rateLimitMessage, {
+      cause: error instanceof Error ? error : undefined,
+      statusCode,
+      retryable,
+    });
+  }
+
+  private isRateLimitedNetworkError(error: Error): boolean {
+    return error instanceof NetworkError && error.statusCode === 429;
+  }
+
+  private isRetryableHorizonError(error: Error): boolean {
+    if (error instanceof StellarError && !(error instanceof NetworkError)) {
+      return false;
+    }
+
+    return this.isRetryableNetworkError(error);
+  }
+
+  private getHorizonResponseData(error: unknown): unknown {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'response' in error &&
+      error.response &&
+      typeof error.response === 'object' &&
+      'data' in error.response
+    ) {
+      return error.response.data;
+    }
+
+    return undefined;
+  }
+
+  private getTransactionResultCode(error: unknown): string | undefined {
+    const data = this.getHorizonResponseData(error);
+
+    if (!data || typeof data !== 'object' || !('extras' in data)) {
+      return undefined;
+    }
+
+    const { extras } = data;
+    if (!extras || typeof extras !== 'object' || !('result_codes' in extras)) {
+      return undefined;
+    }
+
+    const { result_codes: resultCodes } = extras;
+    if (!resultCodes || typeof resultCodes !== 'object' || !('transaction' in resultCodes)) {
+      return undefined;
+    }
+
+    return typeof resultCodes.transaction === 'string' ? resultCodes.transaction : undefined;
+  }
+
+  private isRetryableRpcError(error: Error): boolean {
+    if (error instanceof StellarError && !(error instanceof NetworkError)) {
+      return false;
+    }
+
+    return this.isRetryableNetworkError(error);
   }
 
   private async executeRpcWithFailover<T>(
@@ -268,22 +351,27 @@ export class StellarClient {
             const account = await this.horizonServer.loadAccount(publicKey);
             return account;
           } catch (error) {
-            if (error instanceof Error && error.message.includes('Not Found')) {
+            const statusCode = this.getErrorStatusCode(error);
+            if (
+              statusCode === 404 ||
+              (error instanceof Error && error.message.includes('Not Found'))
+            ) {
               throw new AccountNotFoundError(publicKey);
             }
-            throw new NetworkError('Failed to load account', {
-              cause: error instanceof Error ? error : undefined,
-            });
+            throw this.createHorizonNetworkError('Failed to load account', error);
           }
         },
         {
           ...this.retryOptions,
-          isRetryable: (error) => !(error instanceof AccountNotFoundError),
+          isRetryable: (error) => this.isRetryableHorizonError(error),
         }
       );
     } catch (error: unknown) {
       // If retry exhausted, throw the last error if it's one of our custom errors
       if (error instanceof RetryExhaustedError && error.lastError) {
+        if (this.isRateLimitedNetworkError(error.lastError)) {
+          throw error;
+        }
         if (
           error.lastError instanceof AccountNotFoundError ||
           error.lastError instanceof NetworkError
@@ -321,26 +409,30 @@ export class StellarClient {
   ): Promise<AccountActivityPage<Horizon.HorizonApi.OperationResponseType>> {
     const { cursor = null, limit = 20, order = 'desc' } = request;
 
-    return withRetry(async () => {
-      try {
-        const builder = this.horizonServer
-          .operations()
-          .forAccount(publicKey)
-          .limit(limit)
-          .order(order);
+    return withRetry(
+      async () => {
+        try {
+          const builder = this.horizonServer
+            .operations()
+            .forAccount(publicKey)
+            .limit(limit)
+            .order(order);
 
-        const page = cursor ? await builder.cursor(cursor).call() : await builder.call();
-        // Cast via unknown to avoid overlap errors between Horizon response types
-        const records = page.records as unknown as Horizon.HorizonApi.OperationResponseType[];
-        const nextCursor = this.getNextCursor(records);
+          const page = cursor ? await builder.cursor(cursor).call() : await builder.call();
+          // Cast via unknown to avoid overlap errors between Horizon response types
+          const records = page.records as unknown as Horizon.HorizonApi.OperationResponseType[];
+          const nextCursor = this.getNextCursor(records);
 
-        return { records, nextCursor };
-      } catch (error) {
-        throw new NetworkError('Failed to fetch account activity page', {
-          cause: error instanceof Error ? error : undefined,
-        });
+          return { records, nextCursor };
+        } catch (error) {
+          throw this.createHorizonNetworkError('Failed to fetch account activity page', error);
+        }
+      },
+      {
+        ...this.retryOptions,
+        isRetryable: (error) => this.isRetryableHorizonError(error),
       }
-    }, this.retryOptions);
+    );
   }
 
   /**
@@ -439,33 +531,31 @@ export class StellarClient {
     transaction: Transaction
   ): Promise<Horizon.HorizonApi.SubmitTransactionResponse> {
     try {
-      return await withRetry(async () => {
-        try {
-          const response = await this.horizonServer.submitTransaction(transaction);
-          return response;
-        } catch (error) {
-          if (
-            error &&
-            typeof error === 'object' &&
-            'response' in error &&
-            error.response &&
-            typeof error.response === 'object' &&
-            'data' in error.response
-          ) {
-            const data = error.response.data as {
-              extras?: { result_codes?: { transaction?: string } };
-            };
-            throw new TransactionError('Transaction submission failed', {
-              resultCode: data?.extras?.result_codes?.transaction,
-            });
+      return await withRetry(
+        async () => {
+          try {
+            const response = await this.horizonServer.submitTransaction(transaction);
+            return response;
+          } catch (error) {
+            const resultCode = this.getTransactionResultCode(error);
+            if (resultCode) {
+              throw new TransactionError('Transaction submission failed', {
+                resultCode,
+              });
+            }
+            throw this.createHorizonNetworkError('Failed to submit transaction', error);
           }
-          throw new NetworkError('Failed to submit transaction', {
-            cause: error instanceof Error ? error : undefined,
-          });
+        },
+        {
+          ...this.retryOptions,
+          isRetryable: (error) => this.isRetryableHorizonError(error),
         }
-      }, this.retryOptions);
+      );
     } catch (error: unknown) {
       if (error instanceof RetryExhaustedError && error.lastError) {
+        if (this.isRateLimitedNetworkError(error.lastError)) {
+          throw error;
+        }
         if (
           error.lastError instanceof TransactionError ||
           error.lastError instanceof NetworkError

--- a/packages/stellar/src/errors.ts
+++ b/packages/stellar/src/errors.ts
@@ -19,12 +19,17 @@ export class StellarError extends Error {
 export class NetworkError extends StellarError {
   public readonly cause?: Error;
   public readonly statusCode?: number;
+  public readonly retryable?: boolean;
 
-  constructor(message: string, options?: { cause?: Error; statusCode?: number }) {
+  constructor(
+    message: string,
+    options?: { cause?: Error; statusCode?: number; retryable?: boolean }
+  ) {
     super(message);
     this.name = 'NetworkError';
     this.cause = options?.cause;
     this.statusCode = options?.statusCode;
+    this.retryable = options?.retryable;
   }
 }
 


### PR DESCRIPTION
## Summary
- Preserves Horizon HTTP status codes on NetworkError.
- Retries Horizon 429/5xx responses while avoiding retries for permanent 400 responses.
- Surfaces persistent Horizon 429 responses as RetryExhaustedError.
- Avoids treating non-transaction Horizon response data as TransactionError.
- Adds focused StellarClient coverage for account loading and transaction submission 429 behavior.

Closes #602

## Verification
- pnpm --dir packages/stellar exec jest src/__tests__/client.test.ts --runInBand --coverage=false
- pnpm --dir packages/stellar exec eslint src/client.ts src/errors.ts src/__tests__/client.test.ts
- pnpm exec prettier --check packages/stellar/src/client.ts packages/stellar/src/errors.ts packages/stellar/src/__tests__/client.test.ts
- pnpm --dir packages/types run build
- pnpm --dir packages/stellar run build
- git diff --check

Note: the full packages/stellar test command currently fails in src/__tests__/fee-stats.test.ts on an unrelated pre-existing expectation that does not exercise these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limited requests with automatic retry logic for transient failures
  * Enhanced error classification to distinguish between temporary network issues and permanent errors
  * Better error reporting for transaction submission and account query failures

* **Tests**
  * Expanded test coverage for rate-limiting scenarios and error handling edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ancore-org/ancore/pull/707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->