### PR TITLE
fix: Add permission bitmask helper

### DIFF
--- a/apps/extension-wallet/src/components/PermissionSelector.tsx
+++ b/apps/extension-wallet/src/components/PermissionSelector.tsx
@@ -1,37 +1,41 @@
 import React from 'react';
+import { SessionPermission } from '@ancore/types';
+import {
+  ALL_SESSION_PERMISSIONS,
+  formatPermissionLabel,
+  hasPermission,
+  togglePermission,
+} from '@ancore/account-abstraction';
 
 interface PermissionSelectorProps {
-  selectedPermissions: string[];
-  onChange: (permissions: string[]) => void;
+  /** Selected permission bitmask. */
+  value: number;
+  onChange: (bitmask: number) => void;
   className?: string;
 }
 
-const availablePermissions = ['Read', 'Write', 'Execute', 'Admin'];
+const PERMISSION_OPTIONS: { label: string; value: SessionPermission }[] =
+  ALL_SESSION_PERMISSIONS.map((permission) => ({
+    value: permission,
+    label: formatPermissionLabel(permission),
+  }));
 
 export const PermissionSelector: React.FC<PermissionSelectorProps> = ({
-  selectedPermissions,
+  value,
   onChange,
   className,
 }) => {
-  const togglePermission = (permission: string) => {
-    if (selectedPermissions.includes(permission)) {
-      onChange(selectedPermissions.filter((p) => p !== permission));
-    } else {
-      onChange([...selectedPermissions, permission]);
-    }
-  };
-
   return (
     <div className={className}>
-      {availablePermissions.map((permission) => (
+      {PERMISSION_OPTIONS.map(({ label, value: permission }) => (
         <label key={permission} className="block mb-2">
           <input
             type="checkbox"
-            checked={selectedPermissions.includes(permission)}
-            onChange={() => togglePermission(permission)}
+            checked={hasPermission(value, permission)}
+            onChange={() => onChange(togglePermission(value, permission))}
             className="mr-2"
           />
-          {permission}
+          {label}
         </label>
       ))}
     </div>

--- a/contracts/account/README.md
+++ b/contracts/account/README.md
@@ -105,6 +105,20 @@ fn get_session_key(env: Env, public_key: BytesN<32>) -> Option<SessionKey>
 
 Manage session keys for the account.
 
+#### Session permission bits
+
+Session key permissions are stored on-chain as `Vec<u32>`. Each value is a permission index; SDK/UI code may combine selections into a bitmask using `1 << index`.
+
+| Index | Bit flag | Name | Description |
+| ----- | -------- | ---- | ----------- |
+| `0` | `1 << 0` (`0b001`) | `SEND_PAYMENT` | Authorize payment operations |
+| `1` | `1 << 1` (`0b010`) | `MANAGE_DATA` | Authorize manage-data operations |
+| `2` | `1 << 2` (`0b100`) | `INVOKE_CONTRACT` | Authorize arbitrary contract invocations |
+
+> **Important:** `execute()` requires the session key `Vec<u32>` to contain the internal `PERMISSION_EXECUTE` constant (`1`). This is separate from the SDK bitmask representation above. Always include `1` in the permissions vector for session keys that need to call `execute()`, regardless of other permission indices selected.
+
+Use `@ancore/account-abstraction` helpers (`permissionsToBitmask`, `bitmaskToContractVec`, `permissionsToContractVec`) to keep UI, SDK, and contract representations aligned.
+
 ### Validation Module Boundary
 
 Pluggable validation modules are defined in `contracts/validation-modules/`.

--- a/packages/account-abstraction/src/__tests__/permissions.test.ts
+++ b/packages/account-abstraction/src/__tests__/permissions.test.ts
@@ -1,0 +1,108 @@
+import { SessionPermission } from '@ancore/types';
+
+import {
+  PERM_BITS,
+  PERMISSION_EXECUTE,
+  bitmaskToContractVec,
+  bitmaskToPermissions,
+  contractVecToPermissions,
+  permissionsToBitmask,
+  permissionsToContractVec,
+} from '../permissions';
+
+/** Contract-aligned permission vectors used for round-trip tests. */
+export const CONTRACT_PERMISSION_VECTORS = [
+  {
+    name: 'empty',
+    permissions: [] as SessionPermission[],
+    bitmask: 0,
+    contractVec: [] as number[],
+  },
+  {
+    name: 'send payment only',
+    permissions: [SessionPermission.SEND_PAYMENT],
+    bitmask: PERM_BITS[SessionPermission.SEND_PAYMENT],
+    contractVec: [0],
+  },
+  {
+    name: 'manage data only',
+    permissions: [SessionPermission.MANAGE_DATA],
+    bitmask: PERM_BITS[SessionPermission.MANAGE_DATA],
+    contractVec: [1],
+  },
+  {
+    name: 'invoke contract only',
+    permissions: [SessionPermission.INVOKE_CONTRACT],
+    bitmask: PERM_BITS[SessionPermission.INVOKE_CONTRACT],
+    contractVec: [2],
+  },
+  {
+    name: 'send payment and invoke contract',
+    permissions: [SessionPermission.SEND_PAYMENT, SessionPermission.INVOKE_CONTRACT],
+    bitmask:
+      PERM_BITS[SessionPermission.SEND_PAYMENT] |
+      PERM_BITS[SessionPermission.INVOKE_CONTRACT],
+    contractVec: [0, 2],
+  },
+  {
+    name: 'all permissions',
+    permissions: [
+      SessionPermission.SEND_PAYMENT,
+      SessionPermission.MANAGE_DATA,
+      SessionPermission.INVOKE_CONTRACT,
+    ],
+    bitmask:
+      PERM_BITS[SessionPermission.SEND_PAYMENT] |
+      PERM_BITS[SessionPermission.MANAGE_DATA] |
+      PERM_BITS[SessionPermission.INVOKE_CONTRACT],
+    contractVec: [0, 1, 2],
+  },
+] as const;
+
+describe('permissions', () => {
+  describe('permissionsToBitmask', () => {
+    it.each(CONTRACT_PERMISSION_VECTORS)(
+      'encodes $name permissions',
+      ({ permissions, bitmask }) => {
+        expect(permissionsToBitmask([...permissions])).toBe(bitmask);
+      }
+    );
+  });
+
+  describe('bitmaskToPermissions', () => {
+    it.each(CONTRACT_PERMISSION_VECTORS)(
+      'decodes $name permissions',
+      ({ permissions, bitmask }) => {
+        expect(bitmaskToPermissions(bitmask)).toEqual([...permissions]);
+      }
+    );
+  });
+
+  describe('contract round-trip', () => {
+    it.each(CONTRACT_PERMISSION_VECTORS)(
+      'maps $name to contract Vec<u32>',
+      ({ permissions, contractVec }) => {
+        expect(permissionsToContractVec([...permissions])).toEqual(contractVec);
+      }
+    );
+
+    it.each(CONTRACT_PERMISSION_VECTORS)(
+      'maps $name bitmask to contract Vec<u32>',
+      ({ bitmask, contractVec }) => {
+        expect(bitmaskToContractVec(bitmask)).toEqual(contractVec);
+      }
+    );
+
+    it.each(CONTRACT_PERMISSION_VECTORS)(
+      'round-trips $name contract Vec<u32> through bitmask helpers',
+      ({ permissions, bitmask, contractVec }) => {
+        expect(contractVecToPermissions(contractVec)).toEqual([...permissions]);
+        expect(permissionsToBitmask(contractVecToPermissions(contractVec))).toBe(bitmask);
+      }
+    );
+  });
+
+  it('documents PERMISSION_EXECUTE for session-key execute authorization', () => {
+    expect(PERMISSION_EXECUTE).toBe(1);
+  });
+});

--- a/packages/account-abstraction/src/add-session-key.ts
+++ b/packages/account-abstraction/src/add-session-key.ts
@@ -1,44 +1,59 @@
 /* eslint-disable no-redeclare */
 
+import type { SessionPermission } from '@ancore/types';
+
 import type {
   AccountContractReadOptions,
   AccountContractWriteResult,
   InvocationArgs,
 } from './account-contract';
 import { AccountContract } from './account-contract';
+import { permissionsToContractVec } from './permissions';
 
 function getContract(contract: AccountContract | string): AccountContract {
   return typeof contract === 'string' ? new AccountContract(contract) : contract;
 }
 
+function resolveSessionKeyPermissions(
+  permissions: SessionPermission[] | number[]
+): number[] {
+  return permissionsToContractVec(permissions as SessionPermission[]);
+}
+
 export function addSessionKey(
   contract: AccountContract | string,
   publicKey: string | Uint8Array,
-  permissions: number[],
+  permissions: SessionPermission[] | number[],
   expiresAt: number
 ): InvocationArgs;
 export function addSessionKey(
   contract: AccountContract | string,
   publicKey: string | Uint8Array,
-  permissions: number[],
+  permissions: SessionPermission[] | number[],
   expiresAt: number,
   options: AccountContractReadOptions
 ): Promise<AccountContractWriteResult>;
 export function addSessionKey(
   contract: AccountContract | string,
   publicKey: string | Uint8Array,
-  permissions: number[],
+  permissions: SessionPermission[] | number[],
   expiresAt: number,
   options?: AccountContractReadOptions
 ): InvocationArgs | Promise<AccountContractWriteResult> {
+  const contractPermissions = resolveSessionKeyPermissions(permissions);
+
   if (options) {
     const resolvedContract = getContract(contract);
-    const invocation = resolvedContract.addSessionKey(publicKey, permissions, expiresAt);
+    const invocation = resolvedContract.addSessionKey(
+      publicKey,
+      contractPermissions,
+      expiresAt
+    );
     return Promise.resolve({
       invocation,
       operation: resolvedContract.buildInvokeOperation(invocation),
     });
   }
 
-  return getContract(contract).addSessionKey(publicKey, permissions, expiresAt);
+  return getContract(contract).addSessionKey(publicKey, contractPermissions, expiresAt);
 }

--- a/packages/account-abstraction/src/index.ts
+++ b/packages/account-abstraction/src/index.ts
@@ -63,6 +63,19 @@ export {
 } from './permission-formatter';
 
 export {
+  ALL_SESSION_PERMISSIONS,
+  PERM_BITS,
+  PERMISSION_EXECUTE,
+  bitmaskToContractVec,
+  bitmaskToPermissions,
+  contractVecToPermissions,
+  hasPermission,
+  permissionsToBitmask,
+  permissionsToContractVec,
+  togglePermission,
+} from './permissions';
+
+export {
   NonceDriftKind,
   NONCE_DRIFT_RETRY_GUIDANCE,
   isValidNonce,

--- a/packages/account-abstraction/src/permissions.ts
+++ b/packages/account-abstraction/src/permissions.ts
@@ -1,0 +1,83 @@
+import { SessionPermission } from '@ancore/types';
+
+/**
+ * Bit flags for each {@link SessionPermission} used in UI/SDK bitmask state.
+ * Bit position matches the contract permission index (0, 1, 2).
+ */
+export const PERM_BITS: Readonly<Record<SessionPermission, number>> = {
+  [SessionPermission.SEND_PAYMENT]: 1 << SessionPermission.SEND_PAYMENT,
+  [SessionPermission.MANAGE_DATA]: 1 << SessionPermission.MANAGE_DATA,
+  [SessionPermission.INVOKE_CONTRACT]: 1 << SessionPermission.INVOKE_CONTRACT,
+};
+
+/**
+ * Contract-internal constant required in `Vec<u32>` for session keys that call `execute()`.
+ * Distinct from the SDK bitmask representation above.
+ */
+export const PERMISSION_EXECUTE = 1;
+
+/** All session permissions in contract index order. */
+export const ALL_SESSION_PERMISSIONS: readonly SessionPermission[] = [
+  SessionPermission.SEND_PAYMENT,
+  SessionPermission.MANAGE_DATA,
+  SessionPermission.INVOKE_CONTRACT,
+];
+
+const SESSION_PERMISSION_VALUES = new Set<number>(
+  ALL_SESSION_PERMISSIONS.map((permission) => permission as number)
+);
+
+/**
+ * Combine session permissions into a single bitmask for UI state.
+ */
+export function permissionsToBitmask(perms: SessionPermission[]): number {
+  return perms.reduce((mask, permission) => mask | PERM_BITS[permission], 0);
+}
+
+/**
+ * Expand a permission bitmask back into session permission enum values.
+ */
+export function bitmaskToPermissions(bitmask: number): SessionPermission[] {
+  return ALL_SESSION_PERMISSIONS.filter(
+    (permission) => (bitmask & PERM_BITS[permission]) !== 0
+  );
+}
+
+/**
+ * Convert session permissions to the contract `Vec<u32>` representation.
+ * Values are the permission indices (0, 1, 2), sorted and deduplicated.
+ */
+export function permissionsToContractVec(perms: SessionPermission[]): number[] {
+  return [...new Set(perms.map((permission) => permission as number))].sort(
+    (left, right) => left - right
+  );
+}
+
+/**
+ * Parse contract `Vec<u32>` permission values into session permissions.
+ * Unknown values are omitted.
+ */
+export function contractVecToPermissions(vec: number[]): SessionPermission[] {
+  return vec.filter((value): value is SessionPermission =>
+    SESSION_PERMISSION_VALUES.has(value)
+  );
+}
+
+/**
+ * Convert a UI bitmask to the contract `Vec<u32>` representation.
+ */
+export function bitmaskToContractVec(bitmask: number): number[] {
+  return permissionsToContractVec(bitmaskToPermissions(bitmask));
+}
+
+/** Returns true when the bitmask includes the given permission. */
+export function hasPermission(bitmask: number, permission: SessionPermission): boolean {
+  return (bitmask & PERM_BITS[permission]) !== 0;
+}
+
+/** Toggle a permission bit in the bitmask. */
+export function togglePermission(bitmask: number, permission: SessionPermission): number {
+  return hasPermission(bitmask, permission)
+    ? bitmask & ~PERM_BITS[permission]
+    : bitmask | PERM_BITS[permission];
+}


### PR DESCRIPTION
## 📌 Summary
Adds shared session-permission bitmask helpers in `@ancore/account-abstraction`, wires them into the add-session-key flow, updates the extension `PermissionSelector` to use the helpers, and documents the permission bit table in the account contract README.

## 🎯 Purpose / Motivation
Session key permissions must stay consistent across the extension UI, SDK, and on-chain `Vec<u32>` format. Previously, permission bit logic was duplicated (or placeholder values like `Read`/`Write`/`Execute`/`Admin` existed in the extension), which risked mismatches with contract expectations.

## 🛠️ Changes Made
- **#593:** Added `packages/account-abstraction/src/permissions.ts` with:
  - `PERM_BITS`, `permissionsToBitmask`, `bitmaskToPermissions`
  - Contract conversion helpers: `permissionsToContractVec`, `bitmaskToContractVec`, `contractVecToPermissions`
  - UI helpers: `hasPermission`, `togglePermission`
- Exported all helpers from `@ancore/account-abstraction`
- Updated `add-session-key.ts` to normalize permissions through `permissionsToContractVec`
- Rewrote `PermissionSelector` to use `SessionPermission` labels and bitmask state via shared helpers
- Added round-trip tests aligned with contract permission vectors
- Documented the permission index / bit-flag table in `contracts/account/README.md`

## 🧪 How to Test
1. Run account-abstraction tests:
   ```bash
   pnpm --filter @ancore/account-abstraction test
   ```
   Expected: `permissions.test.ts` passes for empty, single, and combined permission cases.
2. Build the extension and verify the permission selector renders Send Payment / Manage Data / Invoke Contract checkboxes (when wired into a screen).
3. Confirm add-session-key invocations encode `Vec<u32>` values matching selected permissions (e.g. Send Payment + Invoke Contract → `[0, 2]`).

## 📸 Screenshots (if applicable)
N/A — component API change only; `PermissionSelector` is not yet mounted in a screen.

## ⚠️ Breaking Changes
- `PermissionSelector` props changed from `selectedPermissions: string[]` to `value: number` (bitmask) and `onChange: (bitmask: number) => void`.
- None for SDK consumers using existing `number[]` contract permission vectors.

## 🔗 Related Issues
Closes ancore-org/ancore#593

## ✅ Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission utility functions for converting between different permission formats and checking permission states.

* **Documentation**
  * Added session permission bits documentation clarifying on-chain permission representation and requirements.

* **Refactor**
  * Updated session key permission handling to support flexible input formats and improved internal permission processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ancore-org/ancore/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->