### PR TITLE
fix: Add retry policy presets (aggressive/conservative)

### DIFF
--- a/packages/stellar/README.md
+++ b/packages/stellar/README.md
@@ -1,0 +1,68 @@
+# @ancore/stellar
+
+Stellar and Soroban network utilities for Ancore, including `StellarClient` and resilient retry helpers for Horizon and RPC calls.
+
+## Retry policy presets
+
+Network calls can hit rate limits (HTTP 429) or transient failures. `@ancore/stellar` ships two presets tuned for different call sites:
+
+| Preset    | Use case                           | Attempts | Base delay |
+| --------- | ---------------------------------- | -------- | ---------- |
+| `wallet`  | User-facing wallet flows (default) | 3        | 200 ms     |
+| `indexer` | Background/indexer workloads       | 5        | 500 ms     |
+
+`StellarClient` uses the conservative `wallet` preset by default. Indexer-style services can opt into the more aggressive preset when they need extra tolerance under rate limits.
+
+## Usage
+
+### Default wallet preset
+
+```typescript
+import { StellarClient } from '@ancore/stellar';
+
+const client = new StellarClient({ network: 'testnet' });
+```
+
+### Indexer preset
+
+```typescript
+const indexerClient = new StellarClient({
+  network: 'mainnet',
+  retryPreset: 'indexer',
+});
+```
+
+### Override preset values
+
+Pass `retryOptions` to merge over the selected preset. This is useful when an app needs tighter control during rate limiting without defining a full policy from scratch.
+
+```typescript
+const client = new StellarClient({
+  network: 'testnet',
+  retryPreset: 'wallet',
+  retryOptions: {
+    maxRetries: 4,
+    baseDelayMs: 300,
+  },
+});
+```
+
+`retryOptions` always wins over the preset for any field you provide.
+
+### Direct retry helper usage
+
+Presets are also exported for non-client call sites:
+
+```typescript
+import { RETRY_PRESETS, retryOptionsFromPreset, withRetry } from '@ancore/stellar';
+
+await withRetry(() => fetchFromHorizon(), retryOptionsFromPreset(RETRY_PRESETS.indexer));
+```
+
+When all attempts are exhausted, `withRetry` throws `RetryExhaustedError` with the last underlying error attached as `lastError`.
+
+## Installation
+
+```bash
+npm install @ancore/stellar
+```

--- a/packages/stellar/src/__tests__/client.test.ts
+++ b/packages/stellar/src/__tests__/client.test.ts
@@ -11,6 +11,7 @@ import {
   TransactionError,
 } from '../errors';
 import * as retryModule from '../retry';
+import type { RetryOptions } from '../retry';
 
 type MockRpcServer = {
   getHealth: jest.Mock<Promise<unknown>, []>;
@@ -180,6 +181,23 @@ describe('StellarClient', () => {
       expect(client.getNetworkPassphrase()).toBe(customPassphrase);
     });
 
+    it('should use the wallet retry preset by default', () => {
+      const client = new StellarClient({ network: 'testnet' });
+      const retryOptions = (client as unknown as { retryOptions: RetryOptions }).retryOptions;
+
+      expect(retryOptions).toEqual(retryModule.resolveRetryOptions('wallet'));
+    });
+
+    it('should allow selecting the indexer retry preset', () => {
+      const client = new StellarClient({
+        network: 'testnet',
+        retryPreset: 'indexer',
+      });
+      const retryOptions = (client as unknown as { retryOptions: RetryOptions }).retryOptions;
+
+      expect(retryOptions).toEqual(retryModule.resolveRetryOptions('indexer'));
+    });
+
     it('should allow custom retry options', () => {
       const client = new StellarClient({
         network: 'testnet',
@@ -188,8 +206,28 @@ describe('StellarClient', () => {
           baseDelayMs: 500,
         },
       });
+      const retryOptions = (client as unknown as { retryOptions: RetryOptions }).retryOptions;
 
-      expect(client.getNetwork()).toBe('testnet');
+      expect(retryOptions).toEqual({
+        maxRetries: 5,
+        baseDelayMs: 500,
+        exponential: true,
+      });
+    });
+
+    it('should merge custom retry options over the selected preset', () => {
+      const client = new StellarClient({
+        network: 'testnet',
+        retryPreset: 'indexer',
+        retryOptions: { baseDelayMs: 100 },
+      });
+      const retryOptions = (client as unknown as { retryOptions: RetryOptions }).retryOptions;
+
+      expect(retryOptions).toEqual({
+        maxRetries: 4,
+        baseDelayMs: 100,
+        exponential: true,
+      });
     });
 
     it('should allow custom asset metadata cache TTL', async () => {

--- a/packages/stellar/src/__tests__/retry.test.ts
+++ b/packages/stellar/src/__tests__/retry.test.ts
@@ -2,7 +2,13 @@
  * Tests for retry logic
  */
 
-import { withRetry, calculateDelay } from '../retry';
+import {
+  withRetry,
+  calculateDelay,
+  RETRY_PRESETS,
+  resolveRetryOptions,
+  retryOptionsFromPreset,
+} from '../retry';
 import {
   RetryExhaustedError,
   NetworkError,
@@ -531,6 +537,84 @@ describe('retry', () => {
           expect(exhaustedError.lastError).toBeInstanceOf(NetworkError);
           expect((exhaustedError.lastError as NetworkError).statusCode).toBe(502);
         }
+      });
+    });
+  });
+
+  describe('RETRY_PRESETS', () => {
+    it('should expose wallet and indexer presets', () => {
+      expect(RETRY_PRESETS.wallet).toEqual({ maxAttempts: 3, baseDelayMs: 200 });
+      expect(RETRY_PRESETS.indexer).toEqual({ maxAttempts: 5, baseDelayMs: 500 });
+    });
+
+    it('should convert presets into retry options', () => {
+      expect(retryOptionsFromPreset(RETRY_PRESETS.wallet)).toEqual({
+        maxRetries: 2,
+        baseDelayMs: 200,
+        exponential: true,
+      });
+      expect(retryOptionsFromPreset(RETRY_PRESETS.indexer)).toEqual({
+        maxRetries: 4,
+        baseDelayMs: 500,
+        exponential: true,
+      });
+    });
+
+    it('should merge preset defaults with overrides', () => {
+      expect(resolveRetryOptions('wallet', { maxRetries: 1 })).toEqual({
+        maxRetries: 1,
+        baseDelayMs: 200,
+        exponential: true,
+      });
+    });
+
+    describe('429 handling with mocked fetch', () => {
+      const originalFetch = global.fetch;
+
+      beforeEach(() => {
+        global.fetch = jest.fn();
+      });
+
+      afterEach(() => {
+        global.fetch = originalFetch;
+      });
+
+      const fetchHorizonAccount = async () => {
+        const response = await fetch('https://horizon-testnet.stellar.org/accounts/GABC123');
+        if (!response.ok) {
+          throw new NetworkError('Horizon request failed', { statusCode: response.status });
+        }
+        return response.json();
+      };
+
+      it('should retry on 429 and succeed using the wallet preset', async () => {
+        (global.fetch as jest.Mock)
+          .mockResolvedValueOnce({ ok: false, status: 429 })
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ id: 'GABC123' }),
+          });
+
+        const result = await withRetry(fetchHorizonAccount, {
+          ...retryOptionsFromPreset(RETRY_PRESETS.wallet),
+          baseDelayMs: 0,
+        });
+
+        expect(result).toEqual({ id: 'GABC123' });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('should throw RetryExhaustedError when 429 persists through wallet preset', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 429 });
+
+        await expect(
+          withRetry(fetchHorizonAccount, {
+            ...retryOptionsFromPreset(RETRY_PRESETS.wallet),
+            baseDelayMs: 0,
+          })
+        ).rejects.toBeInstanceOf(RetryExhaustedError);
+
+        expect(global.fetch).toHaveBeenCalledTimes(RETRY_PRESETS.wallet.maxAttempts);
       });
     });
   });

--- a/packages/stellar/src/client.ts
+++ b/packages/stellar/src/client.ts
@@ -12,7 +12,7 @@ import {
   TransactionError,
   RetryExhaustedError,
 } from './errors';
-import { withRetry, type RetryOptions } from './retry';
+import { withRetry, resolveRetryOptions, type RetryOptions, type RetryPresetName } from './retry';
 
 const NETWORK_CONFIG: Record<
   Network,
@@ -57,7 +57,9 @@ export interface AssetMetadataCacheMetrics {
 }
 
 export interface StellarClientConfig extends NetworkConfig {
-  /** Custom retry options for network requests */
+  /** Retry preset tuned for wallet (conservative) or indexer (aggressive) call sites */
+  retryPreset?: RetryPresetName;
+  /** Custom retry options merged over the selected preset */
   retryOptions?: RetryOptions;
   /** Time in milliseconds to cache resolved asset metadata. Set to 0 to disable caching. */
   assetMetadataCacheTtlMs?: number;
@@ -115,11 +117,7 @@ export class StellarClient {
 
     this.rpcServers = this.rpcUrls.map((rpcUrl) => new StellarRpc.Server(rpcUrl));
     this.horizonServer = new Horizon.Server(horizonUrl);
-    this.retryOptions = config.retryOptions ?? {
-      maxRetries: 3,
-      baseDelayMs: 1000,
-      exponential: true,
-    };
+    this.retryOptions = resolveRetryOptions(config.retryPreset ?? 'wallet', config.retryOptions);
     this.assetMetadataCacheTtlMs =
       config.assetMetadataCacheTtlMs ?? DEFAULT_ASSET_METADATA_CACHE_TTL_MS;
   }

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -27,8 +27,14 @@ export {
 export { toCanonicalError as toCanonicalStellarError } from './errors';
 
 // Retry utilities
-export { withRetry, calculateDelay } from './retry';
-export type { RetryOptions } from './retry';
+export {
+  withRetry,
+  calculateDelay,
+  RETRY_PRESETS,
+  retryOptionsFromPreset,
+  resolveRetryOptions,
+} from './retry';
+export type { RetryOptions, RetryPresetConfig, RetryPresetName } from './retry';
 
 // Fee stats
 export { fetchFeeStats, FALLBACK_FEE_STATS } from './fee-stats';

--- a/packages/stellar/src/retry.ts
+++ b/packages/stellar/src/retry.ts
@@ -15,11 +15,50 @@ export interface RetryOptions {
   isRetryable?: (error: Error) => boolean;
 }
 
+export interface RetryPresetConfig {
+  /** Total attempts including the initial request */
+  maxAttempts: number;
+  /** Base delay in milliseconds between retries */
+  baseDelayMs: number;
+  /** Whether to use exponential backoff (default: true) */
+  exponential?: boolean;
+}
+
+/**
+ * Conservative wallet preset (fewer attempts, shorter backoff) and aggressive
+ * indexer preset (more attempts, longer backoff) for rate-limited endpoints.
+ */
+export const RETRY_PRESETS = {
+  wallet: { maxAttempts: 3, baseDelayMs: 200 },
+  indexer: { maxAttempts: 5, baseDelayMs: 500 },
+} as const;
+
+export type RetryPresetName = keyof typeof RETRY_PRESETS;
+
 const DEFAULT_OPTIONS: Required<Omit<RetryOptions, 'isRetryable'>> = {
   maxRetries: 3,
   baseDelayMs: 1000,
   exponential: true,
 };
+
+export function retryOptionsFromPreset(
+  preset: RetryPresetConfig,
+  overrides?: RetryOptions
+): RetryOptions {
+  return {
+    maxRetries: preset.maxAttempts - 1,
+    baseDelayMs: preset.baseDelayMs,
+    exponential: preset.exponential ?? true,
+    ...overrides,
+  };
+}
+
+export function resolveRetryOptions(
+  preset: RetryPresetName = 'wallet',
+  overrides?: RetryOptions
+): RetryOptions {
+  return retryOptionsFromPreset(RETRY_PRESETS[preset], overrides);
+}
 
 /**
  * Sleep for a specified duration

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,13 +222,13 @@ importers:
         version: 5.0.0(eslint@9.39.4(jiti@1.21.7))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^30.3.0
         version: 30.4.1
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -356,10 +356,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -405,10 +405,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -463,10 +463,10 @@ importers:
         version: 3.23.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.41)
+        version: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -500,10 +500,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -537,10 +537,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -689,6 +689,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.22.2
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.76
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -710,7 +713,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.41)(typescript@5.9.3)
@@ -753,13 +756,13 @@ importers:
         version: 6.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.41)
+        version: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
       supertest:
         specifier: ^6.3.4
         version: 6.3.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -8379,6 +8382,41 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 25.9.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0)':
     dependencies:
       '@jest/environment': 30.4.1
@@ -10863,13 +10901,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.9.1):
+  create-jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -12210,25 +12248,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.41):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
@@ -12248,16 +12267,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.9.1):
+  jest-cli@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.9.1)
+      create-jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -12325,6 +12344,37 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
       ts-node: 10.9.2(@types/node@20.19.41)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.9.1
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -12589,18 +12639,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.41):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.41)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
@@ -12613,12 +12651,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.9.1):
+  jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.9.1)
+      jest-cli: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -14337,28 +14375,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.9
-      jest: 29.7.0(@types/node@25.9.1)
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.8.1
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.29.7
-      '@jest/transform': 29.7.0
-      '@jest/types': 30.4.1
-      babel-jest: 29.7.0(@babel/core@7.29.7)
-      esbuild: 0.21.5
-      jest-util: 30.4.1
-
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -14376,14 +14393,15 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 30.4.1
       babel-jest: 29.7.0(@babel/core@7.29.7)
+      esbuild: 0.21.5
       jest-util: 30.4.1
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@20.19.41)
+      jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -14396,6 +14414,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 30.4.1
       babel-jest: 29.7.0(@babel/core@7.29.7)
+      esbuild: 0.21.5
       jest-util: 30.4.1
 
   ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3):
@@ -14415,6 +14434,25 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.9.1
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   tslib@1.14.1: {}
 


### PR DESCRIPTION
## Summary

Add retry policy presets for wallet and indexer call sites, wire `StellarClient` to the conservative wallet preset by default, and document how apps override retry behavior under rate limits.

## Purpose / Motivation

Stellar Horizon and RPC endpoints can return HTTP 429 under load. Wallet flows and background indexers have different latency and resilience needs. Centralized presets make the right defaults easy to adopt while still allowing per-app overrides.

## Changes Made

- Export `RETRY_PRESETS` (`wallet`: 3 attempts / 200 ms, `indexer`: 5 attempts / 500 ms) from `packages/stellar/src/retry.ts`
- Add `retryOptionsFromPreset` and `resolveRetryOptions` helpers to convert presets into `RetryOptions`
- Update `StellarClient` to accept `retryPreset` and default to `wallet`, with `retryOptions` merged on top
- Add tests that simulate HTTP 429 with mocked `fetch`, including success after retry and `RetryExhaustedError` on exhaustion
- Add `packages/stellar/README.md` documenting preset selection and override behavior

## How to Test

1. Run package tests:
   ```bash
   cd packages/stellar
   npm test
   ```
   Expected: all tests pass, including new `RETRY_PRESETS` and client preset coverage.

2. Verify default client preset:
   ```typescript
   import { StellarClient } from '@ancore/stellar';

   const client = new StellarClient({ network: 'testnet' });
   ```
   Expected: client uses wallet preset (`maxRetries: 2`, `baseDelayMs: 200`).

3. Verify indexer override:
   ```typescript
   const indexer = new StellarClient({ network: 'testnet', retryPreset: 'indexer' });
   ```
   Expected: client uses indexer preset (`maxRetries: 4`, `baseDelayMs: 500`).

4. Verify custom override:
   ```typescript
   const client = new StellarClient({
     network: 'testnet',
     retryPreset: 'wallet',
     retryOptions: { maxRetries: 1 },
   });
   ```
   Expected: `maxRetries` is overridden while other wallet preset values remain.

## Breaking Changes

- `StellarClient` default retry behavior changes from `{ maxRetries: 3, baseDelayMs: 1000 }` to the wallet preset `{ maxRetries: 2, baseDelayMs: 200 }`. Apps relying on the old implicit default can pass explicit `retryOptions` to preserve prior behavior.

## Related Issues

Closes ancore-org/ancore#601

## Checklist

- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Documentation updated (if needed)