### PR TITLE
fix: Add copy-to-clipboard feedback toast on address copy

### DIFF
--- a/apps/extension-wallet/src/components/AccountHeader.tsx
+++ b/apps/extension-wallet/src/components/AccountHeader.tsx
@@ -1,20 +1,15 @@
 import { Copy, Check, Globe } from 'lucide-react';
 import { Button } from '@ancore/ui-kit';
 import { Badge, Tooltip } from '@ancore/ui-kit';
+import { useCopyWithFeedback } from '@/hooks/useCopyWithFeedback';
 
 interface AccountHeaderProps {
   address: string;
   network: string;
-  onCopyAddress: () => void;
-  copied?: boolean;
 }
 
-export function AccountHeader({
-  address,
-  network,
-  onCopyAddress,
-  copied = false,
-}: AccountHeaderProps) {
+export function AccountHeader({ address, network }: AccountHeaderProps) {
+  const { copy, copied } = useCopyWithFeedback();
   return (
     <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-card to-card/80 border border-border/50 shadow-lg p-6">
       {/* Background decorative elements */}
@@ -63,7 +58,7 @@ export function AccountHeader({
             <Button
               variant="outline"
               size="icon"
-              onClick={onCopyAddress}
+              onClick={() => void copy(address)}
               className="shrink-0 rounded-full border-border/50 hover:border-primary/50 hover:bg-primary/5 transition-all duration-300 hover:scale-105"
               aria-label={copied ? 'Address copied' : 'Copy address'}
             >

--- a/apps/extension-wallet/src/components/__tests__/AccountHeader.test.tsx
+++ b/apps/extension-wallet/src/components/__tests__/AccountHeader.test.tsx
@@ -4,10 +4,20 @@ import { describe, it, expect, vi } from 'vitest';
 import { AccountHeader } from '../AccountHeader';
 import userEvent from '@testing-library/user-event';
 
+const copyMock = vi.fn();
+
+vi.mock('@/hooks/useCopyWithFeedback', () => ({
+  useCopyWithFeedback: () => ({ copy: copyMock, copied: false }),
+}));
+
 // Mock UI kit components since we are testing the logic in AccountHeader
 vi.mock('@ancore/ui-kit', () => ({
   Badge: ({ children }: any) => <span data-testid="badge">{children}</span>,
-  Button: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+  Button: ({ children, onClick, ...props }: any) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
   // We need the Tooltip to render its content to test it
   Tooltip: ({ children, content }: any) => (
     <div data-testid="tooltip-wrapper">
@@ -28,12 +38,24 @@ describe('AccountHeader', () => {
   const defaultProps = {
     address: 'GDXYZ...',
     network: 'Testnet',
-    onCopyAddress: vi.fn(),
   };
+
+  beforeEach(() => {
+    copyMock.mockClear();
+  });
 
   it('renders the address', () => {
     render(<AccountHeader {...defaultProps} />);
     expect(screen.getByText('GDXYZ...')).toBeInTheDocument();
+  });
+
+  it('calls copy feedback hook when copy button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<AccountHeader {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /copy address/i }));
+
+    expect(copyMock).toHaveBeenCalledWith('GDXYZ...');
   });
 
   describe('Network Badge Tooltip', () => {

--- a/apps/extension-wallet/src/hooks/__tests__/useCopyWithFeedback.test.ts
+++ b/apps/extension-wallet/src/hooks/__tests__/useCopyWithFeedback.test.ts
@@ -1,0 +1,116 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationProvider } from '@ancore/ui-kit';
+import React from 'react';
+import {
+  useCopyWithFeedback,
+  COPY_ERROR_TOAST,
+  COPY_SUCCESS_ANNOUNCEMENT,
+  COPY_SUCCESS_TOAST,
+} from '../useCopyWithFeedback';
+
+const { showSuccess, showError, emitAddressCopied, announceToScreenReader } = vi.hoisted(() => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  emitAddressCopied: vi.fn(),
+  announceToScreenReader: vi.fn(),
+}));
+
+vi.mock('@ancore/ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@ancore/ui-kit')>();
+  return {
+    ...actual,
+    useToast: () => ({ showSuccess, showError, toast: vi.fn() }),
+  };
+});
+
+vi.mock('@/telemetry', () => ({
+  getTelemetry: () => ({
+    emitAddressCopied,
+    isEnabled: () => true,
+  }),
+}));
+
+vi.mock('@/utils/accessibility', () => ({
+  announceToScreenReader,
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(NotificationProvider, null, children);
+}
+
+describe('useCopyWithFeedback', () => {
+  beforeEach(() => {
+    showSuccess.mockClear();
+    showError.mockClear();
+    emitAddressCopied.mockClear();
+    announceToScreenReader.mockClear();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('copies text, shows success toast, announces, and emits telemetry', async () => {
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText');
+    const { result } = renderHook(() => useCopyWithFeedback(), { wrapper });
+
+    await act(async () => {
+      await result.current.copy('GABC123');
+    });
+
+    expect(writeText).toHaveBeenCalledWith('GABC123');
+    expect(showSuccess).toHaveBeenCalledWith(COPY_SUCCESS_TOAST);
+    expect(announceToScreenReader).toHaveBeenCalledWith(COPY_SUCCESS_ANNOUNCEMENT);
+    expect(emitAddressCopied).toHaveBeenCalledTimes(1);
+    expect(result.current.copied).toBe(true);
+  });
+
+  it('shows error toast and assertive announcement when clipboard is denied', async () => {
+    vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(new Error('denied'));
+    const { result } = renderHook(() => useCopyWithFeedback(), { wrapper });
+
+    await act(async () => {
+      await result.current.copy('GABC123');
+    });
+
+    expect(showError).toHaveBeenCalledWith(COPY_ERROR_TOAST);
+    expect(announceToScreenReader).toHaveBeenCalledWith(COPY_ERROR_TOAST, 'assertive');
+    expect(emitAddressCopied).not.toHaveBeenCalled();
+    expect(result.current.copied).toBe(false);
+  });
+
+  it('debounces rapid copy attempts', async () => {
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCopyWithFeedback(), { wrapper });
+
+    await act(async () => {
+      await result.current.copy('GABC123');
+      await result.current.copy('GABC123');
+    });
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets copied state after a delay', async () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useCopyWithFeedback(), { wrapper });
+
+      await act(async () => {
+        await result.current.copy('GABC123');
+      });
+
+      expect(result.current.copied).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+
+      expect(result.current.copied).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/extension-wallet/src/hooks/useCopyWithFeedback.ts
+++ b/apps/extension-wallet/src/hooks/useCopyWithFeedback.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useToast } from '@ancore/ui-kit';
+import { getTelemetry } from '@/telemetry';
+import { announceToScreenReader } from '@/utils/accessibility';
+
+const COPY_DEBOUNCE_MS = 1000;
+const COPIED_ICON_MS = 2000;
+
+export const COPY_SUCCESS_TOAST = 'Address copied';
+export const COPY_ERROR_TOAST = 'Could not copy address';
+export const COPY_SUCCESS_ANNOUNCEMENT = 'Address copied to clipboard';
+
+export function useCopyWithFeedback() {
+  const { showSuccess, showError } = useToast();
+  const [copied, setCopied] = useState(false);
+  const lastCopyAtRef = useRef(0);
+  const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimeoutRef.current) {
+        clearTimeout(copiedTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const copy = useCallback(
+    async (text: string) => {
+      const now = Date.now();
+      if (now - lastCopyAtRef.current < COPY_DEBOUNCE_MS) {
+        return;
+      }
+      lastCopyAtRef.current = now;
+
+      try {
+        await navigator.clipboard.writeText(text);
+        showSuccess(COPY_SUCCESS_TOAST);
+        announceToScreenReader(COPY_SUCCESS_ANNOUNCEMENT);
+        getTelemetry().emitAddressCopied();
+        setCopied(true);
+        if (copiedTimeoutRef.current) {
+          clearTimeout(copiedTimeoutRef.current);
+        }
+        copiedTimeoutRef.current = setTimeout(() => setCopied(false), COPIED_ICON_MS);
+      } catch {
+        showError(COPY_ERROR_TOAST);
+        announceToScreenReader(COPY_ERROR_TOAST, 'assertive');
+      }
+    },
+    [showSuccess, showError]
+  );
+
+  return { copy, copied };
+}

--- a/apps/extension-wallet/src/screens/ReceiveScreen.tsx
+++ b/apps/extension-wallet/src/screens/ReceiveScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from '@ancore/ui-kit';
 import { ArrowLeft, Printer } from 'lucide-react';
 import { PaymentQRCode } from '@/components/PaymentQRCode';
+import { useCopyWithFeedback } from '@/hooks/useCopyWithFeedback';
 import type { StellarNetwork } from '@/utils/explorer-links';
 
 export interface ReceiveScreenAccount {
@@ -63,6 +64,8 @@ export function ReceiveScreen({
   onBack,
   className,
 }: ReceiveScreenProps) {
+  const { copy, copied } = useCopyWithFeedback();
+
   const handlePrint = React.useCallback(() => {
     window.print();
   }, []);
@@ -108,7 +111,14 @@ export function ReceiveScreen({
               {account.name}
             </p>
           )}
-          <AddressDisplay address={account.publicKey} copyable truncate={8} label="Your address" />
+          <AddressDisplay
+            address={account.publicKey}
+            copyable
+            truncate={8}
+            label="Your address"
+            onCopy={() => void copy(account.publicKey)}
+            copied={copied}
+          />
         </div>
 
         {/* Print button */}

--- a/apps/extension-wallet/src/screens/__tests__/ReceiveScreen.test.tsx
+++ b/apps/extension-wallet/src/screens/__tests__/ReceiveScreen.test.tsx
@@ -1,6 +1,8 @@
+import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
+import { NotificationProvider } from '@ancore/ui-kit';
 
 vi.mock('qrcode.react', () => ({
   QRCodeSVG: ({ value, 'aria-label': ariaLabel }: { value: string; 'aria-label'?: string }) => (
@@ -19,56 +21,60 @@ const TESTNET_ACCOUNT = {
   publicKey: 'GTEST9876543210ABCDEFGHIJKLMNOPQRSTUV',
 };
 
+function renderReceive(ui: React.ReactElement) {
+  return render(<NotificationProvider>{ui}</NotificationProvider>);
+}
+
 // ─── Test suite ──────────────────────────────────────────────────────────────
 describe('ReceiveScreen', () => {
   describe('rendering', () => {
     it('renders the screen title', () => {
-      render(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
       expect(screen.getByRole('heading', { name: /receive/i })).toBeInTheDocument();
     });
 
     it('renders the QR code with the correct address value', () => {
-      render(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
       const qr = screen.getByTestId('qr-code-svg');
       expect(qr).toBeInTheDocument();
       expect(qr).toHaveAttribute('data-value', MAINNET_ACCOUNT.publicKey);
     });
 
     it('renders the QR code without a name', () => {
-      render(<ReceiveScreen account={TESTNET_ACCOUNT} network="testnet" />);
+      renderReceive(<ReceiveScreen account={TESTNET_ACCOUNT} network="testnet" />);
       const qr = screen.getByTestId('qr-code-svg');
       expect(qr).toHaveAttribute('data-value', TESTNET_ACCOUNT.publicKey);
     });
 
     it('shows the optional account name', () => {
-      render(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
       expect(screen.getByText('Primary Wallet')).toBeInTheDocument();
     });
 
     it('does not render the account name when not provided', () => {
-      render(<ReceiveScreen account={TESTNET_ACCOUNT} network="testnet" />);
+      renderReceive(<ReceiveScreen account={TESTNET_ACCOUNT} network="testnet" />);
       expect(screen.queryByText('Primary Wallet')).not.toBeInTheDocument();
     });
 
     it('renders the address display label', () => {
-      render(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
       expect(screen.getByText('Your address')).toBeInTheDocument();
     });
   });
 
   describe('network indicator', () => {
     it('shows "Mainnet" badge by default', () => {
-      render(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
       expect(screen.getByText('Mainnet')).toBeInTheDocument();
     });
 
     it('shows "Testnet" badge when network is testnet', () => {
-      render(<ReceiveScreen account={TESTNET_ACCOUNT} network="testnet" />);
+      renderReceive(<ReceiveScreen account={TESTNET_ACCOUNT} network="testnet" />);
       expect(screen.getByText('Testnet')).toBeInTheDocument();
     });
 
     it('shows "Futurenet" badge when network is futurenet', () => {
-      render(<ReceiveScreen account={TESTNET_ACCOUNT} network="futurenet" />);
+      renderReceive(<ReceiveScreen account={TESTNET_ACCOUNT} network="futurenet" />);
       expect(screen.getByText('Futurenet')).toBeInTheDocument();
     });
   });
@@ -77,7 +83,7 @@ describe('ReceiveScreen', () => {
     it('calls onBack when the back button is clicked', async () => {
       const user = userEvent.setup();
       const handleBack = vi.fn();
-      render(<ReceiveScreen account={MAINNET_ACCOUNT} onBack={handleBack} />);
+      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} onBack={handleBack} />);
 
       await user.click(screen.getByRole('button', { name: /go back/i }));
 
@@ -91,7 +97,7 @@ describe('ReceiveScreen', () => {
       const writeText = vi.spyOn(navigator.clipboard, 'writeText');
       writeText.mockResolvedValue(undefined);
 
-      render(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
 
       const copyBtn = screen.getByRole('button', { name: /copy address/i });
       await user.click(copyBtn);
@@ -99,25 +105,23 @@ describe('ReceiveScreen', () => {
       expect(writeText).toHaveBeenCalledWith(MAINNET_ACCOUNT.publicKey);
     });
 
-    it('shows a confirmation checkmark after copying', async () => {
+    it('shows success toast after copying', async () => {
       const user = userEvent.setup();
       vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
 
-      render(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
 
       await user.click(screen.getByRole('button', { name: /copy address/i }));
 
       await waitFor(() => {
-        // After copying the button aria-label changes inside AddressDisplay
-        // The icon swaps to a check – verify the button is still in the DOM
-        expect(screen.getByRole('button', { name: /copy address/i })).toBeInTheDocument();
+        expect(screen.getByText('Address copied')).toBeInTheDocument();
       });
     });
   });
 
   describe('print', () => {
     it('renders a print button', () => {
-      render(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
       expect(screen.getByRole('button', { name: /print qr code/i })).toBeInTheDocument();
     });
 
@@ -125,7 +129,7 @@ describe('ReceiveScreen', () => {
       const user = userEvent.setup();
       const printSpy = vi.spyOn(window, 'print').mockImplementation(() => {});
 
-      render(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
       await user.click(screen.getByRole('button', { name: /print qr code/i }));
 
       expect(printSpy).toHaveBeenCalledTimes(1);
@@ -136,18 +140,22 @@ describe('ReceiveScreen', () => {
   describe('QR generation', () => {
     it('encodes exactly the publicKey in the QR code', () => {
       const publicKey = 'GD6SZQJNKL3ZYXPWLUVFXZNXUVXJTQPWMQHZMDMQHLS5VNLQBQNPFLM';
-      render(<ReceiveScreen account={{ publicKey }} />);
+      renderReceive(<ReceiveScreen account={{ publicKey }} />);
       expect(screen.getByTestId('qr-code-svg')).toHaveAttribute('data-value', publicKey);
     });
 
     it('renders a different QR value when account changes', () => {
-      const { rerender } = render(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      const { rerender } = renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
       expect(screen.getByTestId('qr-code-svg')).toHaveAttribute(
         'data-value',
         MAINNET_ACCOUNT.publicKey
       );
 
-      rerender(<ReceiveScreen account={TESTNET_ACCOUNT} />);
+      rerender(
+        <NotificationProvider>
+          <ReceiveScreen account={TESTNET_ACCOUNT} />
+        </NotificationProvider>
+      );
       expect(screen.getByTestId('qr-code-svg')).toHaveAttribute(
         'data-value',
         TESTNET_ACCOUNT.publicKey

--- a/apps/extension-wallet/src/telemetry/__tests__/telemetry-emitter.test.ts
+++ b/apps/extension-wallet/src/telemetry/__tests__/telemetry-emitter.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { initTelemetry } from '../telemetry-emitter';
+import { TelemetryEventType } from '../telemetry-schema';
+
+describe('TelemetryEmitter', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not record address_copied when telemetry is disabled', () => {
+    const emitter = initTelemetry({
+      enabled: false,
+      sessionId: 'test-session',
+      storageKey: 'test_telemetry_events',
+    });
+
+    emitter.emitAddressCopied();
+
+    expect(emitter.getEvents()).toHaveLength(0);
+  });
+
+  it('records address_copied without address payload when enabled', () => {
+    const emitter = initTelemetry({
+      enabled: true,
+      sessionId: 'test-session',
+      storageKey: 'test_telemetry_events',
+    });
+
+    emitter.emitAddressCopied();
+
+    const events = emitter.getEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe(TelemetryEventType.ADDRESS_COPIED);
+    expect(JSON.stringify(events[0])).not.toMatch(/G[A-Z0-9]{55}/);
+  });
+});

--- a/apps/extension-wallet/src/telemetry/telemetry-emitter.ts
+++ b/apps/extension-wallet/src/telemetry/telemetry-emitter.ts
@@ -117,6 +117,12 @@ class TelemetryEmitter {
     });
   }
 
+  emitAddressCopied(): void {
+    this.emit({
+      type: TelemetryEventType.ADDRESS_COPIED,
+    });
+  }
+
   getEvents(): AnyTelemetryEvent[] {
     return [...this.events];
   }

--- a/apps/extension-wallet/src/telemetry/telemetry-schema.ts
+++ b/apps/extension-wallet/src/telemetry/telemetry-schema.ts
@@ -12,6 +12,7 @@ export enum TelemetryEventType {
   EXECUTE_FAILURE = 'wallet_execute_failure',
   TRANSACTION_INITIATED = 'wallet_tx_initiated',
   TRANSACTION_COMPLETED = 'wallet_tx_completed',
+  ADDRESS_COPIED = 'address_copied',
 }
 
 export interface TelemetryEvent {
@@ -57,10 +58,15 @@ export interface TransactionCompletedEvent extends TelemetryEvent {
   duration: number;
 }
 
+export interface AddressCopiedEvent extends TelemetryEvent {
+  type: TelemetryEventType.ADDRESS_COPIED;
+}
+
 export type AnyTelemetryEvent =
   | LockFailureEvent
   | AuthFailureEvent
   | SendFailureEvent
   | ExecuteFailureEvent
   | TransactionInitiatedEvent
-  | TransactionCompletedEvent;
+  | TransactionCompletedEvent
+  | AddressCopiedEvent;

--- a/packages/ui-kit/src/components/address-display.tsx
+++ b/packages/ui-kit/src/components/address-display.tsx
@@ -19,6 +19,14 @@ export interface AddressDisplayProps extends React.HTMLAttributes<HTMLDivElement
    * Optional label for the address
    */
   label?: string;
+  /**
+   * Custom copy handler (e.g. toast + telemetry). When set, internal clipboard logic is skipped.
+   */
+  onCopy?: () => void | Promise<void>;
+  /**
+   * Controlled copied state when using onCopy
+   */
+  copied?: boolean;
 }
 
 /**
@@ -26,8 +34,12 @@ export interface AddressDisplayProps extends React.HTMLAttributes<HTMLDivElement
  * Features truncation, copy-to-clipboard functionality, and responsive design
  */
 const AddressDisplay = React.forwardRef<HTMLDivElement, AddressDisplayProps>(
-  ({ address, copyable = true, truncate = 6, label, className, ...props }, ref) => {
-    const [copied, setCopied] = React.useState(false);
+  (
+    { address, copyable = true, truncate = 6, label, onCopy, copied: copiedProp, className, ...props },
+    ref
+  ) => {
+    const [internalCopied, setInternalCopied] = React.useState(false);
+    const copied = copiedProp ?? internalCopied;
 
     const displayAddress = React.useMemo(() => {
       if (truncate && address.length > truncate * 2) {
@@ -37,14 +49,18 @@ const AddressDisplay = React.forwardRef<HTMLDivElement, AddressDisplayProps>(
     }, [address, truncate]);
 
     const handleCopy = React.useCallback(async () => {
+      if (onCopy) {
+        await onCopy();
+        return;
+      }
       try {
         await navigator.clipboard.writeText(address);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        setInternalCopied(true);
+        setTimeout(() => setInternalCopied(false), 2000);
       } catch (err) {
         console.error('Failed to copy address:', err);
       }
-    }, [address]);
+    }, [address, onCopy]);
 
     return (
       <div ref={ref} className={cn('space-y-1', className)} {...props}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,13 +222,13 @@ importers:
         version: 5.0.0(eslint@9.39.4(jiti@1.21.7))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-environment-jsdom:
         specifier: ^30.3.0
         version: 30.4.1
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -356,10 +356,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -405,10 +405,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -463,10 +463,10 @@ importers:
         version: 3.23.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.41)
+        version: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -500,10 +500,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -537,10 +537,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)
+        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -689,6 +689,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.22.2
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.76
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -710,7 +713,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.41)(typescript@5.9.3)
@@ -753,13 +756,13 @@ importers:
         version: 6.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.41)
+        version: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
       supertest:
         specifier: ^6.3.4
         version: 6.3.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -8379,6 +8382,41 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 25.9.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0)':
     dependencies:
       '@jest/environment': 30.4.1
@@ -10863,13 +10901,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.9.1):
+  create-jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -12210,25 +12248,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.41):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
@@ -12248,16 +12267,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.9.1):
+  jest-cli@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.9.1)
+      create-jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -12325,6 +12344,37 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
       ts-node: 10.9.2(@types/node@20.19.41)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.9.1
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -12589,18 +12639,6 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.41):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.41)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
@@ -12613,12 +12651,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.9.1):
+  jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.9.1)
+      jest-cli: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -14337,28 +14375,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.9
-      jest: 29.7.0(@types/node@25.9.1)
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.8.1
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.29.7
-      '@jest/transform': 29.7.0
-      '@jest/types': 30.4.1
-      babel-jest: 29.7.0(@babel/core@7.29.7)
-      esbuild: 0.21.5
-      jest-util: 30.4.1
-
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -14376,14 +14393,15 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 30.4.1
       babel-jest: 29.7.0(@babel/core@7.29.7)
+      esbuild: 0.21.5
       jest-util: 30.4.1
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@20.19.41)
+      jest: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -14396,6 +14414,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 30.4.1
       babel-jest: 29.7.0(@babel/core@7.29.7)
+      esbuild: 0.21.5
       jest-util: 30.4.1
 
   ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3):
@@ -14415,6 +14434,25 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.9.1
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   tslib@1.14.1: {}
 


### PR DESCRIPTION
## Summary
Adds accessible copy-to-clipboard feedback (toast, screen-reader announcement, and telemetry) for address copy actions in the extension wallet.

## Purpose / Motivation
Users had no consistent confirmation when copying their Stellar address from Account Header or Receive flows. This change provides immediate visual and assistive-technology feedback while respecting privacy (no address in telemetry payloads) and telemetry opt-in.

## Changes Made
- Added `useCopyWithFeedback` hook with success/error toasts, `aria-live` announcements, 1s debounce, and `address_copied` telemetry (opt-in only).
- Wired `AccountHeader` and `ReceiveScreen` to the shared hook.
- Extended `AddressDisplay` with optional controlled `onCopy` / `copied` props for Receive integration.
- Added unit tests for the hook and telemetry emitter.

## How to Test
1. Build extension wallet: `pnpm --filter @ancore/extension-wallet test`
2. Open extension popup → navigate to Receive (or any view using Account Header).
3. Click **Copy address** — expect a green “Address copied” toast and checkmark on the button.
4. Rapid-click copy within 1s — only one clipboard write and one toast should occur.
5. Deny clipboard permission (browser/site settings) — expect “Could not copy address” error toast.
6. With telemetry disabled (`initTelemetry({ enabled: false })`), copy again — no `address_copied` event in stored telemetry.
7. **Manual a11y:** With a screen reader (NVDA/VoiceOver), copy an address and confirm “Address copied to clipboard” is announced.

## Screenshots (if applicable)
N/A — toast is transient; verify in running extension.

## Breaking Changes
- `AccountHeader` no longer accepts `onCopyAddress` / `copied` props; copy is handled internally via `useCopyWithFeedback`.

## Related Issues
Closes ancore-org/ancore#604

## Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [ ] Documentation updated (if needed)