### PR TITLE
feat: resolve #675 #588 #671 #581 — metrics, revoke tests, simulation…

### DIFF
--- a/apps/extension-wallet/src/hooks/useSendTransaction.ts
+++ b/apps/extension-wallet/src/hooks/useSendTransaction.ts
@@ -19,6 +19,7 @@ import {
   type SchedulerClient,
 } from '@/services/scheduler-client';
 import { resolveHandle as defaultResolveHandle } from '@/services/handle-resolver';
+import type { SimulationState } from '@/screens/Send/SimulationPreview';
 
 export type SendStep = 'form' | 'review' | 'confirm' | 'status' | 'scheduled';
 export type TxStatus = 'idle' | 'pending' | 'confirmed' | 'failed';
@@ -45,6 +46,11 @@ export interface SendTransactionDraft extends SendFormValues {
   resolvedHandle?: ResolvedHandle;
 }
 
+export interface SimulationResult {
+  simulatedFee: string;
+  outcome: string;
+}
+
 export interface SendService {
   estimateFee: (input: SendFormValues) => Promise<FeeEstimate>;
   authenticatePassword: (password: string) => Promise<boolean>;
@@ -52,6 +58,7 @@ export interface SendService {
   signTransaction: (tx: SendTransactionDraft) => Promise<string>;
   submitTransaction: (signedPayload: string) => Promise<{ txId: string }>;
   fetchTransactionStatus: (txId: string) => Promise<TxStatus>;
+  simulateTransaction?: (tx: SendTransactionDraft) => Promise<SimulationResult>;
   createScheduledTransfer?: (
     tx: SendTransactionDraft,
     schedule: ScheduleConfig
@@ -187,6 +194,7 @@ export function useSendTransaction(options: UseSendTransactionOptions = {}) {
   const [schedule, setSchedule] = useState<ScheduleConfig | undefined>();
   const [errors, setErrors] = useState<ValidationErrors>({});
   const [submitting, setSubmitting] = useState(false);
+  const [simulation, setSimulation] = useState<SimulationState | undefined>();
 
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -271,6 +279,36 @@ export function useSendTransaction(options: UseSendTransactionOptions = {}) {
           resolvedHandle,
         });
         setStep('review');
+
+        // Run simulation in the background after entering review
+        if (service.simulateTransaction) {
+          const draft: SendTransactionDraft = {
+            ...resolvedValues,
+            fee: estimatedFee,
+            total,
+            truncatedNote,
+            recipientInput,
+            resolvedHandle,
+          };
+          setSimulation({ status: 'loading' });
+          service
+            .simulateTransaction(draft)
+            .then((result) => {
+              setSimulation({
+                status: 'success',
+                simulatedFee: result.simulatedFee,
+                outcome: result.outcome,
+              });
+            })
+            .catch((err: unknown) => {
+              const message =
+                err instanceof Error ? err.message : 'Simulation failed';
+              setSimulation({ status: 'error', message });
+            });
+        } else {
+          setSimulation(undefined);
+        }
+
         return true;
       } catch (error) {
         console.error('Simulation failed:', error);
@@ -375,6 +413,7 @@ export function useSendTransaction(options: UseSendTransactionOptions = {}) {
     schedule,
     errors,
     submitting,
+    simulation,
     setStep,
     setErrors,
     goToReview,

--- a/apps/extension-wallet/src/screens/Send/ReviewScreen.tsx
+++ b/apps/extension-wallet/src/screens/Send/ReviewScreen.tsx
@@ -4,11 +4,14 @@ import type { SendTransactionDraft } from '@/hooks/useSendTransaction';
 import { TransferNotePreview } from '@/components/TransferNotePreview';
 import { ShieldCheck, ArrowRight, Wallet, Globe, Info, CalendarClock } from 'lucide-react';
 import type { ScheduleConfig, TransferTiming } from '@/screens/Send/ScheduleControls';
+import { SimulationPreview, type SimulationState } from './SimulationPreview';
 
 interface ReviewScreenProps {
   transaction: SendTransactionDraft;
   timing?: TransferTiming;
   schedule?: ScheduleConfig;
+  /** Simulation state — when provided, shows the preview panel above the fee summary. */
+  simulation?: SimulationState;
   onBack: () => void;
   onConfirm: () => void;
 }
@@ -24,6 +27,7 @@ export function ReviewScreen({
   transaction,
   timing,
   schedule,
+  simulation,
   onBack,
   onConfirm,
 }: ReviewScreenProps) {
@@ -139,6 +143,9 @@ export function ReviewScreen({
           </div>
         </div>
 
+        {/* Simulation Preview */}
+        {simulation && <SimulationPreview simulation={simulation} />}
+
         {/* Explicit Confirmation Step */}
         <div
           className={cn(
@@ -191,7 +198,7 @@ export function ReviewScreen({
           </Button>
           <Button
             type="button"
-            disabled={!isConfirmed}
+            disabled={!isConfirmed || simulation?.status === 'loading' || simulation?.status === 'error'}
             className="flex-[2] bg-cyan-400 text-slate-950 font-black uppercase tracking-widest rounded-2xl h-12 shadow-[0_10px_20px_rgba(34,211,238,0.2)] hover:bg-cyan-300 disabled:opacity-50 disabled:grayscale transition-all flex items-center justify-center gap-2 text-[10px]"
             onClick={onConfirm}
           >

--- a/apps/extension-wallet/src/screens/Send/SendScreen.tsx
+++ b/apps/extension-wallet/src/screens/Send/SendScreen.tsx
@@ -71,6 +71,7 @@ export function SendScreen({ balance, assetDecimals, service, pollIntervalMs }: 
         transaction={send.tx}
         timing={send.timing}
         schedule={send.schedule}
+        simulation={send.simulation}
         onBack={() => send.setStep('form')}
         onConfirm={send.requestConfirm}
       />

--- a/apps/extension-wallet/src/screens/Send/SimulationPreview.tsx
+++ b/apps/extension-wallet/src/screens/Send/SimulationPreview.tsx
@@ -1,0 +1,83 @@
+/**
+ * SimulationPreview — shows the simulated transaction result and fee
+ * before the user confirms a send.
+ *
+ * Renders three states:
+ *  - loading  — simulation is in progress
+ *  - error    — simulation failed (shows reason, blocks confirm)
+ *  - success  — shows simulated fee and outcome
+ *
+ * Issue #671
+ */
+
+import { Loader2, CheckCircle2, AlertTriangle } from 'lucide-react';
+
+export type SimulationState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'success'; simulatedFee: string; outcome: string };
+
+interface SimulationPreviewProps {
+  simulation: SimulationState;
+}
+
+export function SimulationPreview({ simulation }: SimulationPreviewProps) {
+  if (simulation.status === 'loading') {
+    return (
+      <div
+        role="status"
+        aria-label="Simulating transaction"
+        data-testid="simulation-loading"
+        className="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-xs text-slate-400"
+      >
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-cyan-400 shrink-0" aria-hidden="true" />
+        <span>Simulating transaction…</span>
+      </div>
+    );
+  }
+
+  if (simulation.status === 'error') {
+    return (
+      <div
+        role="alert"
+        data-testid="simulation-error"
+        className="flex items-start gap-2 rounded-2xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs text-amber-300"
+      >
+        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <div className="space-y-0.5">
+          <span className="block font-black uppercase tracking-widest text-[10px] text-amber-400">
+            Simulation Warning
+          </span>
+          <span className="leading-relaxed">{simulation.message}</span>
+        </div>
+      </div>
+    );
+  }
+
+  // success
+  return (
+    <div
+      data-testid="simulation-success"
+      className="space-y-2 rounded-2xl border border-emerald-500/20 bg-emerald-500/5 px-4 py-3"
+    >
+      <div className="flex items-center gap-1.5">
+        <CheckCircle2 className="h-3.5 w-3.5 text-emerald-400 shrink-0" aria-hidden="true" />
+        <span className="text-[10px] font-black uppercase tracking-widest text-emerald-400">
+          Simulation Passed
+        </span>
+      </div>
+      <div className="flex justify-between text-xs">
+        <span className="text-slate-500 uppercase tracking-widest font-bold text-[10px]">
+          Simulated Fee
+        </span>
+        <span className="font-mono text-slate-300">{simulation.simulatedFee} XLM</span>
+      </div>
+      <div className="flex justify-between text-xs">
+        <span className="text-slate-500 uppercase tracking-widest font-bold text-[10px]">
+          Expected Outcome
+        </span>
+        <span className="font-mono text-emerald-300 capitalize">{simulation.outcome}</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/account-abstraction/jest.config.cjs
+++ b/packages/account-abstraction/jest.config.cjs
@@ -30,5 +30,7 @@ module.exports = {
     },
   },
   testMatch: ['**/__tests__/**/*.test.ts'],
-  testPathIgnorePatterns: ['/node_modules/', 'integration\\.test\\.ts$'],
+  // Only exclude integration tests that require live network access (execute.integration).
+  // revoke-session-key.integration.test.ts uses mocks and runs in CI.
+  testPathIgnorePatterns: ['/node_modules/', 'execute\\.integration\\.test\\.ts$'],
 };

--- a/packages/account-abstraction/src/__tests__/revoke-session-key.integration.test.ts
+++ b/packages/account-abstraction/src/__tests__/revoke-session-key.integration.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Integration tests for revokeSessionKey — cross-module behaviour.
+ *
+ * Covers:
+ *  1. revokeSessionKey composed into TransactionBuilder flows
+ *  2. Error normalization via toCanonicalAccountError
+ *  3. Interaction between revokeSessionKey and the transaction-builder's
+ *     revokeSessionKey method (same contract, consistent op shape)
+ *
+ * Issue #588
+ */
+
+import { Keypair, StrKey } from '@stellar/stellar-sdk';
+import { randomBytes } from 'node:crypto';
+
+import { revokeSessionKey } from '../revoke-session-key';
+import { AccountContract, type AccountContractReadOptions } from '../account-contract';
+import { TransactionBuilder } from '../transaction-builder';
+import {
+  SessionKeyNotFoundError,
+  UnauthorizedError,
+  SessionKeyExpiredError,
+  ContractInvocationError,
+  toCanonicalError as toCanonicalAccountError,
+} from '../errors';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('../account-contract', () => {
+  const mockRevokeSessionKey = jest.fn();
+  const mockBuildInvokeOperation = jest.fn();
+  const MockAccountContract = jest.fn().mockImplementation(() => ({
+    revokeSessionKey: mockRevokeSessionKey,
+    buildInvokeOperation: mockBuildInvokeOperation,
+  }));
+  return {
+    AccountContract: MockAccountContract,
+    __mocks: { mockRevokeSessionKey, mockBuildInvokeOperation, MockAccountContract },
+  };
+});
+
+const { __mocks } = jest.requireMock('../account-contract') as {
+  __mocks: {
+    mockRevokeSessionKey: jest.Mock;
+    mockBuildInvokeOperation: jest.Mock;
+    MockAccountContract: jest.Mock;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CONTRACT_ID = StrKey.encodeContract(randomBytes(32));
+const SESSION_KEY = Keypair.random().publicKey();
+const SOURCE_ACCOUNT = Keypair.random().publicKey();
+
+// ---------------------------------------------------------------------------
+// 1. Composition with TransactionBuilder
+// ---------------------------------------------------------------------------
+
+describe('revokeSessionKey + TransactionBuilder composition', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('revokeSessionKey build result method matches TransactionBuilder revoke op', () => {
+    const invocation = { method: 'revoke_session_key', args: [] };
+    __mocks.mockRevokeSessionKey.mockReturnValue(invocation);
+
+    const result = revokeSessionKey(CONTRACT_ID, { publicKey: SESSION_KEY });
+
+    // TransactionBuilder uses 'revoke_session_key' as the contract method name
+    expect(result.method).toBe('revoke_session_key');
+  });
+
+  it('TransactionBuilder.revokeSessionKey queues a revoke op', () => {
+    const builder = new TransactionBuilder(SOURCE_ACCOUNT, CONTRACT_ID);
+    builder.revokeSessionKey(SESSION_KEY);
+
+    // @ts-expect-error: accessing private ops for assertion
+    const ops = builder['ops'];
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toMatchObject({
+      type: 'sessionKey',
+      op: 'revoke',
+      sessionKey: SESSION_KEY,
+    });
+  });
+
+  it('TransactionBuilder simulate() reflects the queued revoke op count', async () => {
+    const builder = new TransactionBuilder(SOURCE_ACCOUNT, CONTRACT_ID);
+    builder.revokeSessionKey(SESSION_KEY);
+
+    const sim = await builder.simulate();
+    expect(sim.operationCount).toBe(1);
+  });
+
+  it('can chain revokeSessionKey with other builder ops', async () => {
+    const builder = new TransactionBuilder(SOURCE_ACCOUNT, CONTRACT_ID);
+    builder
+      .addSessionKey(Keypair.random().publicKey(), [1], Date.now() + 60_000)
+      .revokeSessionKey(SESSION_KEY);
+
+    const sim = await builder.simulate();
+    expect(sim.operationCount).toBe(2);
+  });
+
+  it('revokeSessionKey write result contains both invocation and operation', async () => {
+    const invocation = { method: 'revoke_session_key', args: [] };
+    const operation = { type: 'invokeHostFunction', source: null };
+    __mocks.mockRevokeSessionKey.mockReturnValue(invocation);
+    __mocks.mockBuildInvokeOperation.mockReturnValue(operation);
+
+    const result = await revokeSessionKey(
+      CONTRACT_ID,
+      { publicKey: SESSION_KEY },
+      {} as AccountContractReadOptions
+    );
+
+    expect(result).toEqual({ invocation, operation });
+    expect(__mocks.mockBuildInvokeOperation).toHaveBeenCalledWith(invocation);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Error normalization paths
+// ---------------------------------------------------------------------------
+
+describe('revokeSessionKey error normalization via toCanonicalAccountError', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('SessionKeyNotFoundError normalizes to SESSION_KEY_NOT_FOUND code', () => {
+    __mocks.mockRevokeSessionKey.mockImplementation(() => {
+      throw new Error('Session key not found');
+    });
+
+    let caught: unknown;
+    try {
+      revokeSessionKey(CONTRACT_ID, { publicKey: SESSION_KEY });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(SessionKeyNotFoundError);
+    const canonical = toCanonicalAccountError(caught);
+    expect(canonical.code).toBe('SESSION_KEY_NOT_FOUND');
+    expect(canonical.name).toBe('SessionKeyNotFoundError');
+  });
+
+  it('UnauthorizedError normalizes to UNAUTHORIZED code', () => {
+    __mocks.mockRevokeSessionKey.mockImplementation(() => {
+      throw new Error('Auth failure: unauthorized');
+    });
+
+    let caught: unknown;
+    try {
+      revokeSessionKey(CONTRACT_ID, { publicKey: SESSION_KEY });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(UnauthorizedError);
+    const canonical = toCanonicalAccountError(caught);
+    expect(canonical.code).toBe('UNAUTHORIZED');
+  });
+
+  it('SessionKeyExpiredError normalizes to SESSION_KEY_EXPIRED code', () => {
+    __mocks.mockRevokeSessionKey.mockImplementation(() => {
+      throw new Error('Error(Contract, #6)');
+    });
+
+    let caught: unknown;
+    try {
+      revokeSessionKey(CONTRACT_ID, { publicKey: SESSION_KEY });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(SessionKeyExpiredError);
+    const canonical = toCanonicalAccountError(caught);
+    expect(canonical.code).toBe('SESSION_KEY_EXPIRED');
+  });
+
+  it('ContractInvocationError normalizes to CONTRACT_INVOCATION code', () => {
+    __mocks.mockRevokeSessionKey.mockImplementation(() => {
+      throw new Error('host invocation failed');
+    });
+
+    let caught: unknown;
+    try {
+      revokeSessionKey(CONTRACT_ID, { publicKey: SESSION_KEY });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(ContractInvocationError);
+    const canonical = toCanonicalAccountError(caught);
+    expect(canonical.code).toBe('CONTRACT_INVOCATION');
+  });
+
+  it('non-Error throwable normalizes gracefully', () => {
+    __mocks.mockRevokeSessionKey.mockImplementation(() => {
+      throw { weird: 'object' };
+    });
+
+    let caught: unknown;
+    try {
+      revokeSessionKey(CONTRACT_ID, { publicKey: SESSION_KEY });
+    } catch (e) {
+      caught = e;
+    }
+
+    const canonical = toCanonicalAccountError(caught);
+    expect(canonical.code).toBe('CONTRACT_INVOCATION');
+  });
+
+  it('write path errors also normalize correctly', async () => {
+    __mocks.mockRevokeSessionKey.mockImplementation(() => {
+      throw new Error('Session key not found');
+    });
+
+    let caught: unknown;
+    try {
+      await revokeSessionKey(
+        CONTRACT_ID,
+        { publicKey: SESSION_KEY },
+        {} as AccountContractReadOptions
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(SessionKeyNotFoundError);
+    const canonical = toCanonicalAccountError(caught);
+    expect(canonical.code).toBe('SESSION_KEY_NOT_FOUND');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Cross-module: AccountContract instance reuse
+// ---------------------------------------------------------------------------
+
+describe('revokeSessionKey with AccountContract instance (cross-module)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reuses the provided AccountContract instance without constructing a new one', () => {
+    const invocation = { method: 'revoke_session_key', args: [] };
+    __mocks.mockRevokeSessionKey.mockReturnValue(invocation);
+
+    const contract = new AccountContract(CONTRACT_ID);
+    __mocks.MockAccountContract.mockClear(); // clear constructor call from above
+
+    revokeSessionKey(contract, { publicKey: SESSION_KEY });
+
+    // Constructor should NOT have been called again
+    expect(__mocks.MockAccountContract).not.toHaveBeenCalled();
+    expect(__mocks.mockRevokeSessionKey).toHaveBeenCalledWith(SESSION_KEY);
+  });
+
+  it('accepts Uint8Array key in cross-module flow', () => {
+    const key = new Uint8Array(32).fill(1);
+    const invocation = { method: 'revoke_session_key', args: [] };
+    __mocks.mockRevokeSessionKey.mockReturnValue(invocation);
+
+    const contract = new AccountContract(CONTRACT_ID);
+    const result = revokeSessionKey(contract, { publicKey: key });
+
+    expect(__mocks.mockRevokeSessionKey).toHaveBeenCalledWith(key);
+    expect(result).toBe(invocation);
+  });
+});

--- a/services/indexer/src/error.rs
+++ b/services/indexer/src/error.rs
@@ -1,10 +1,37 @@
-use axum::{
+﻿use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
     Json,
 };
-use serde_json::json;
+use serde::Serialize;
+use serde_json::Value;
 use thiserror::Error;
+
+/// Structured error envelope returned by all API routes.
+///
+/// Shape: `{ "code": "...", "message": "...", "details"?: ... }`
+///
+/// Issue #581
+#[derive(Debug, Serialize)]
+pub struct ErrorEnvelope {
+    /// Machine-readable error code (e.g. `"INVALID_CURSOR"`, `"NOT_FOUND"`).
+    pub code: &'static str,
+    /// Human-readable description of the error.
+    pub message: String,
+    /// Optional structured details (validation context, field names, etc.).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+}
+
+/// Canonical error codes used across all indexer API routes.
+pub mod codes {
+    pub const INVALID_CURSOR: &str = "INVALID_CURSOR";
+    pub const INVALID_FILTER: &str = "INVALID_FILTER";
+    pub const NOT_FOUND: &str = "NOT_FOUND";
+    pub const QUERY_TIMEOUT: &str = "QUERY_TIMEOUT";
+    pub const DATABASE_ERROR: &str = "DATABASE_ERROR";
+    pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
+}
 
 #[derive(Error, Debug)]
 pub enum ApiError {
@@ -29,33 +56,66 @@ pub enum ApiError {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        let (status, error_type, message) = match self {
-            ApiError::InvalidCursor(msg) => (StatusCode::BAD_REQUEST, "invalid_cursor", msg),
-            ApiError::InvalidFilter(msg) => (StatusCode::BAD_REQUEST, "invalid_filter", msg),
-            ApiError::NotFound => (StatusCode::NOT_FOUND, "not_found", "Resource not found".to_string()),
-            ApiError::QueryTimeout(msg) => (StatusCode::GATEWAY_TIMEOUT, "query_timeout", msg),
-            ApiError::Database(err) => {
-                if matches!(err, sqlx::Error::PoolTimedOut) {
-                    (StatusCode::GATEWAY_TIMEOUT, "query_timeout", "Database pool timed out".to_string())
-                } else if err.as_database_error().and_then(|db_err| db_err.code()).map(|c| c == "57014").unwrap_or(false) {
-                    (StatusCode::GATEWAY_TIMEOUT, "query_timeout", "Database query timed out".to_string())
-                } else {
-                    tracing::error!("Database error: {:?}", err);
-                    (StatusCode::INTERNAL_SERVER_ERROR, "internal_error", "Database error".to_string())
+        let (status, code, message, details): (StatusCode, &'static str, String, Option<Value>) =
+            match self {
+                ApiError::InvalidCursor(msg) => {
+                    (StatusCode::BAD_REQUEST, codes::INVALID_CURSOR, msg, None)
                 }
-            }
-            ApiError::Internal(err) => {
-                tracing::error!("Internal error: {:?}", err);
-                (StatusCode::INTERNAL_SERVER_ERROR, "internal_error", "Internal server error".to_string())
-            }
-        };
+                ApiError::InvalidFilter(msg) => {
+                    (StatusCode::BAD_REQUEST, codes::INVALID_FILTER, msg, None)
+                }
+                ApiError::NotFound => (
+                    StatusCode::NOT_FOUND,
+                    codes::NOT_FOUND,
+                    "Resource not found".to_string(),
+                    None,
+                ),
+                ApiError::QueryTimeout(msg) => {
+                    (StatusCode::GATEWAY_TIMEOUT, codes::QUERY_TIMEOUT, msg, None)
+                }
+                ApiError::Database(err) => {
+                    if matches!(err, sqlx::Error::PoolTimedOut) {
+                        (
+                            StatusCode::GATEWAY_TIMEOUT,
+                            codes::QUERY_TIMEOUT,
+                            "Database pool timed out".to_string(),
+                            None,
+                        )
+                    } else if err
+                        .as_database_error()
+                        .and_then(|db_err| db_err.code())
+                        .map(|c| c == "57014")
+                        .unwrap_or(false)
+                    {
+                        (
+                            StatusCode::GATEWAY_TIMEOUT,
+                            codes::QUERY_TIMEOUT,
+                            "Database query timed out".to_string(),
+                            None,
+                        )
+                    } else {
+                        tracing::error!("Database error: {:?}", err);
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            codes::DATABASE_ERROR,
+                            "Database error".to_string(),
+                            None,
+                        )
+                    }
+                }
+                ApiError::Internal(err) => {
+                    tracing::error!("Internal error: {:?}", err);
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        codes::INTERNAL_ERROR,
+                        "Internal server error".to_string(),
+                        None,
+                    )
+                }
+            };
 
-        let body = json!({
-            "error": error_type,
-            "detail": message
-        });
-
-        (status, Json(body)).into_response()
+        let envelope = ErrorEnvelope { code, message, details };
+        (status, Json(envelope)).into_response()
     }
 }
 

--- a/services/relayer/src/handlers/executeRelay.ts
+++ b/services/relayer/src/handlers/executeRelay.ts
@@ -39,6 +39,10 @@ export function createExecuteRelayHandler(relayService: RelayServiceContract) {
         },
         'relay_execute_failed'
       );
+      // Expose typed error code to the metrics middleware for relay_errors_total
+      if (response.error?.code) {
+        res.locals.relayErrorCode = response.error.code;
+      }
     }
 
     res.status(response.success ? 200 : 422).json(response);

--- a/services/relayer/src/metrics/index.test.ts
+++ b/services/relayer/src/metrics/index.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for Prometheus metrics — relay_request_duration_seconds and relay_errors_total.
+ * Issue #675
+ */
+
+import { relayLatency, relayErrors, renderPrometheusMetrics } from './index';
+
+beforeEach(() => {
+  relayLatency.reset();
+  relayErrors.reset();
+});
+
+describe('RelayLatencyHistogram', () => {
+  it('increments count on observe', () => {
+    relayLatency.observe(0.05);
+    const snap = relayLatency.snapshot();
+    expect(snap.count).toBe(1);
+  });
+
+  it('accumulates sum', () => {
+    relayLatency.observe(0.1);
+    relayLatency.observe(0.2);
+    const snap = relayLatency.snapshot();
+    expect(snap.sum).toBeCloseTo(0.3);
+  });
+
+  it('places observation in correct bucket', () => {
+    relayLatency.observe(0.05); // should land in ≤0.05 bucket
+    const snap = relayLatency.snapshot();
+    const bucket = snap.buckets.find((b) => b.le === 0.05);
+    expect(bucket?.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('+Inf bucket always equals total count', () => {
+    relayLatency.observe(0.001);
+    relayLatency.observe(100); // beyond all finite buckets
+    const snap = relayLatency.snapshot();
+    const inf = snap.buckets.find((b) => b.le === '+Inf');
+    expect(inf?.count).toBe(snap.count);
+  });
+
+  it('buckets are cumulative', () => {
+    relayLatency.observe(0.005);
+    relayLatency.observe(0.1);
+    const snap = relayLatency.snapshot();
+    let prev = 0;
+    for (const b of snap.buckets) {
+      expect(b.count).toBeGreaterThanOrEqual(prev);
+      prev = b.count;
+    }
+  });
+
+  it('reset clears all state', () => {
+    relayLatency.observe(1);
+    relayLatency.reset();
+    const snap = relayLatency.snapshot();
+    expect(snap.count).toBe(0);
+    expect(snap.sum).toBe(0);
+  });
+});
+
+describe('RelayErrorCounter', () => {
+  it('increments a new error code', () => {
+    relayErrors.increment('INVALID_SIGNATURE');
+    expect(relayErrors.snapshot()['INVALID_SIGNATURE']).toBe(1);
+  });
+
+  it('accumulates multiple increments for the same code', () => {
+    relayErrors.increment('NONCE_REPLAY');
+    relayErrors.increment('NONCE_REPLAY');
+    expect(relayErrors.snapshot()['NONCE_REPLAY']).toBe(2);
+  });
+
+  it('tracks multiple distinct error codes independently', () => {
+    relayErrors.increment('INVALID_SIGNATURE');
+    relayErrors.increment('SESSION_KEY_EXPIRED');
+    const snap = relayErrors.snapshot();
+    expect(snap['INVALID_SIGNATURE']).toBe(1);
+    expect(snap['SESSION_KEY_EXPIRED']).toBe(1);
+  });
+
+  it('reset clears all counts', () => {
+    relayErrors.increment('INTERNAL_ERROR');
+    relayErrors.reset();
+    expect(relayErrors.snapshot()).toEqual({});
+  });
+});
+
+describe('renderPrometheusMetrics', () => {
+  it('includes histogram HELP and TYPE lines', () => {
+    const output = renderPrometheusMetrics();
+    expect(output).toContain('# HELP relay_request_duration_seconds');
+    expect(output).toContain('# TYPE relay_request_duration_seconds histogram');
+  });
+
+  it('includes counter HELP and TYPE lines', () => {
+    const output = renderPrometheusMetrics();
+    expect(output).toContain('# HELP relay_errors_total');
+    expect(output).toContain('# TYPE relay_errors_total counter');
+  });
+
+  it('renders histogram bucket lines', () => {
+    relayLatency.observe(0.05);
+    const output = renderPrometheusMetrics();
+    expect(output).toMatch(/relay_request_duration_seconds_bucket\{le="0\.05"\}/);
+    expect(output).toContain('relay_request_duration_seconds_bucket{le="+Inf"}');
+  });
+
+  it('renders _sum and _count lines', () => {
+    relayLatency.observe(0.2);
+    const output = renderPrometheusMetrics();
+    expect(output).toContain('relay_request_duration_seconds_sum');
+    expect(output).toContain('relay_request_duration_seconds_count 1');
+  });
+
+  it('renders error counter with label', () => {
+    relayErrors.increment('GAS_LIMIT_EXCEEDED');
+    const output = renderPrometheusMetrics();
+    expect(output).toContain('relay_errors_total{code="GAS_LIMIT_EXCEEDED"} 1');
+  });
+
+  it('emits zero-value counter line when no errors recorded', () => {
+    const output = renderPrometheusMetrics();
+    expect(output).toContain('relay_errors_total{code=""} 0');
+  });
+
+  it('output ends with a newline', () => {
+    const output = renderPrometheusMetrics();
+    expect(output.endsWith('\n')).toBe(true);
+  });
+});

--- a/services/relayer/src/metrics/index.ts
+++ b/services/relayer/src/metrics/index.ts
@@ -1,0 +1,144 @@
+/**
+ * Prometheus metrics for the Relayer service.
+ *
+ * Exposes:
+ *  - relay_request_duration_seconds  — histogram of /relay/* handler latency
+ *  - relay_errors_total              — counter of relay errors by error code
+ *
+ * Issue #675
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface HistogramBucket {
+  le: number | '+Inf';
+  count: number;
+}
+
+interface HistogramSnapshot {
+  buckets: HistogramBucket[];
+  sum: number;
+  count: number;
+}
+
+interface CounterSnapshot {
+  [label: string]: number;
+}
+
+// ---------------------------------------------------------------------------
+// Histogram — relay_request_duration_seconds
+// ---------------------------------------------------------------------------
+
+/** Upper bounds in seconds for latency buckets (Prometheus convention). */
+const LATENCY_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
+
+class RelayLatencyHistogram {
+  private readonly buckets: Map<number, number> = new Map(
+    LATENCY_BUCKETS.map((le) => [le, 0])
+  );
+  private infCount = 0;
+  private sum = 0;
+  private count = 0;
+
+  observe(durationSeconds: number): void {
+    this.sum += durationSeconds;
+    this.count += 1;
+
+    let recorded = false;
+    for (const le of LATENCY_BUCKETS) {
+      if (durationSeconds <= le) {
+        this.buckets.set(le, (this.buckets.get(le) ?? 0) + 1);
+        if (!recorded) recorded = true;
+      }
+    }
+    // +Inf bucket always increments
+    this.infCount += 1;
+  }
+
+  snapshot(): HistogramSnapshot {
+    // Cumulative counts (Prometheus histogram semantics)
+    let cumulative = 0;
+    const buckets: HistogramBucket[] = [];
+    for (const le of LATENCY_BUCKETS) {
+      cumulative += this.buckets.get(le) ?? 0;
+      buckets.push({ le, count: cumulative });
+    }
+    buckets.push({ le: '+Inf', count: this.infCount });
+    return { buckets, sum: this.sum, count: this.count };
+  }
+
+  reset(): void {
+    for (const le of LATENCY_BUCKETS) this.buckets.set(le, 0);
+    this.infCount = 0;
+    this.sum = 0;
+    this.count = 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Counter — relay_errors_total
+// ---------------------------------------------------------------------------
+
+class RelayErrorCounter {
+  private readonly counts: Map<string, number> = new Map();
+
+  increment(errorCode: string): void {
+    this.counts.set(errorCode, (this.counts.get(errorCode) ?? 0) + 1);
+  }
+
+  snapshot(): CounterSnapshot {
+    return Object.fromEntries(this.counts);
+  }
+
+  reset(): void {
+    this.counts.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton registry
+// ---------------------------------------------------------------------------
+
+export const relayLatency = new RelayLatencyHistogram();
+export const relayErrors = new RelayErrorCounter();
+
+// ---------------------------------------------------------------------------
+// Prometheus text format serialiser
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialises the current metric state to Prometheus text exposition format.
+ * Suitable for serving on GET /metrics.
+ */
+export function renderPrometheusMetrics(): string {
+  const lines: string[] = [];
+
+  // ── relay_request_duration_seconds ──────────────────────────────────────
+  lines.push('# HELP relay_request_duration_seconds Histogram of /relay/* handler latency in seconds');
+  lines.push('# TYPE relay_request_duration_seconds histogram');
+  const latencySnap = relayLatency.snapshot();
+  for (const bucket of latencySnap.buckets) {
+    lines.push(
+      `relay_request_duration_seconds_bucket{le="${bucket.le}"} ${bucket.count}`
+    );
+  }
+  lines.push(`relay_request_duration_seconds_sum ${latencySnap.sum}`);
+  lines.push(`relay_request_duration_seconds_count ${latencySnap.count}`);
+
+  // ── relay_errors_total ───────────────────────────────────────────────────
+  lines.push('# HELP relay_errors_total Counter of relay errors by error code');
+  lines.push('# TYPE relay_errors_total counter');
+  const errorSnap = relayErrors.snapshot();
+  for (const [code, count] of Object.entries(errorSnap)) {
+    lines.push(`relay_errors_total{code="${code}"} ${count}`);
+  }
+  // Emit a zero-value line when no errors have been recorded so the metric
+  // always appears in the output (avoids "no data" gaps in dashboards).
+  if (Object.keys(errorSnap).length === 0) {
+    lines.push('relay_errors_total{code=""} 0');
+  }
+
+  return lines.join('\n') + '\n';
+}

--- a/services/relayer/src/middleware/metricsCollector.ts
+++ b/services/relayer/src/middleware/metricsCollector.ts
@@ -1,0 +1,48 @@
+/**
+ * Metrics Collector Middleware
+ *
+ * Records per-request latency into the relay_request_duration_seconds histogram
+ * and increments relay_errors_total for any non-2xx response on /relay/* routes.
+ *
+ * Must be registered after createRequestLoggerMiddleware() so that req.startTime
+ * is already set.
+ *
+ * Issue #675
+ */
+
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+import { relayLatency, relayErrors } from '../metrics';
+
+const RELAY_PATH_PREFIX = '/relay/';
+
+/**
+ * Returns a middleware that instruments /relay/* routes with Prometheus metrics.
+ */
+export function createMetricsCollectorMiddleware(): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // Only instrument relay routes
+    if (!req.path.startsWith(RELAY_PATH_PREFIX)) {
+      next();
+      return;
+    }
+
+    res.on('finish', () => {
+      const startMs = req.startTime ?? Date.now();
+      const durationSeconds = (Date.now() - startMs) / 1000;
+
+      relayLatency.observe(durationSeconds);
+
+      // Count errors: 4xx and 5xx responses
+      if (res.statusCode >= 400) {
+        // Use the error code from the response body if available via res.locals,
+        // otherwise fall back to the HTTP status code string.
+        const errorCode: string =
+          (res.locals.relayErrorCode as string | undefined) ??
+          `HTTP_${res.statusCode}`;
+        relayErrors.increment(errorCode);
+      }
+    });
+
+    next();
+  };
+}

--- a/services/relayer/src/server.ts
+++ b/services/relayer/src/server.ts
@@ -7,6 +7,8 @@ import { createAuthMiddleware } from './middleware/auth';
 import { createIdempotencyMiddleware } from './middleware/idempotency';
 import { createPayloadGuardMiddleware } from './middleware/payloadGuard';
 import { createRequestLoggerMiddleware } from './middleware/requestLogger';
+import { createMetricsCollectorMiddleware } from './middleware/metricsCollector';
+import { renderPrometheusMetrics } from './metrics';
 import { validateBody } from './validation/middleware';
 import { createExecuteRelayHandler } from './handlers/executeRelay';
 import { createValidateRelayHandler } from './handlers/validateRelay';
@@ -89,6 +91,10 @@ export function createApp(
   // Registered after CORS and payload guard, before auth and body parsing.
   app.use(createRequestLoggerMiddleware());
 
+  // Metrics collector: records /relay/* latency histogram and error counter.
+  // Registered after request logger so req.startTime is already set.
+  app.use(createMetricsCollectorMiddleware());
+
   app.use(express.json());
 
   const useMockSubmission =
@@ -147,6 +153,10 @@ export function createApp(
   app.post('/relay/execute', auth, relayLimiter, validate, idempotency, executeHandler);
   app.post('/relay/validate', auth, relayLimiter, validate, validateHandler);
   app.get('/relay/status', statusLimiter, (_req, res) => res.json(relayService.health()));
+  app.get('/metrics', (_req, res) => {
+    res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+    res.send(renderPrometheusMetrics());
+  });
 
   app.post(
     '/api/v1/scheduled-transfers',


### PR DESCRIPTION
closes #675 
closes #588 
closes #671 
closes #581 

#675 [RELAYER] Expose Prometheus metrics for request latency and errors
- Add relay_request_duration_seconds histogram and relay_errors_total counter
- Add metricsCollector middleware to instrument /relay/* routes
- Expose GET /metrics endpoint in Prometheus text format
- Add unit tests for histogram, counter, and serialization

#588 [ACCOUNT-ABSTRACTION] Add revokeSessionKey builder method tests
- Add revoke-session-key.integration.test.ts covering cross-module composition with TransactionBuilder, error normalization via toCanonicalAccountError, and AccountContract instance reuse
- Update jest.config.cjs to run mock-based integration tests in CI (only exclude execute.integration.test.ts which requires live testnet)

#671 [EXTENSION] Add transaction simulation preview on send confirm step
- Add SimulationPreview component with loading/error/success states
- Integrate simulation prop into ReviewScreen above fee summary
- Wire simulation state through useSendTransaction hook and SendScreen

#581 [INDEXER] Add API error envelope with error codes
- Replace ad-hoc {error, detail} JSON with structured ErrorEnvelope
- Add codes module with INVALID_CURSOR, INVALID_FILTER, NOT_FOUND, QUERY_TIMEOUT, DATABASE_ERROR, INTERNAL_ERROR constants
- Migrate all ApiError variants to emit {code, message, details?} shape


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transaction simulation now displays in send flow with real-time loading, success, and error states
  * Added metrics endpoint for monitoring service health and performance
  
* **Improvements**
  * Standardized error response format across services for better clarity and consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ancore-org/ancore/pull/726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->