### PR TITLE
feat: session-key panel, relayer simulation error mapping, inactivity helper & execute integration test

### DIFF
--- a/apps/extension-wallet/src/security/inactivity-detector.ts
+++ b/apps/extension-wallet/src/security/inactivity-detector.ts
@@ -18,6 +18,18 @@ const ACTIVITY_EVENTS: (keyof WindowEventMap)[] = [
   'click',
 ];
 
+/**
+ * Convert a configured auto-lock timeout in minutes into the millisecond
+ * value expected by {@link InactivityDetector}.
+ *
+ * `0` (and any non-positive value) is preserved as `0`, matching the
+ * detector's "never lock" sentinel.
+ */
+export function minutesToInactivityMs(minutes: number): number {
+  if (!Number.isFinite(minutes) || minutes <= 0) return 0;
+  return Math.floor(minutes * 60 * 1000);
+}
+
 export class InactivityDetector {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private readonly onInactive: () => void;

--- a/apps/extension-wallet/src/security/lock-manager.ts
+++ b/apps/extension-wallet/src/security/lock-manager.ts
@@ -6,7 +6,7 @@
  */
 
 import { SecureStorageManager } from '@ancore/core-sdk';
-import { InactivityDetector } from './inactivity-detector';
+import { InactivityDetector, minutesToInactivityMs } from './inactivity-detector';
 
 type StorageManagerInstance = InstanceType<typeof SecureStorageManager>;
 
@@ -32,7 +32,10 @@ export class LockManager {
     this.onLock = options.onLock;
     this.onUnlock = options.onUnlock;
 
-    this.detector = new InactivityDetector(() => this.lock(), options.autoLockMinutes * 60 * 1000);
+    this.detector = new InactivityDetector(
+      () => this.lock(),
+      minutesToInactivityMs(options.autoLockMinutes)
+    );
   }
 
   get isLocked(): boolean {
@@ -71,7 +74,7 @@ export class LockManager {
    * Update the auto-lock timeout (e.g. when user changes settings).
    */
   setAutoLockMinutes(minutes: number): void {
-    this.detector.setTimeoutMs(minutes * 60 * 1000);
+    this.detector.setTimeoutMs(minutesToInactivityMs(minutes));
   }
 
   /**

--- a/apps/web-dashboard/package.json
+++ b/apps/web-dashboard/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@ancore/core-sdk": "workspace:*",
     "@ancore/types": "workspace:*",
     "@ancore/ui-kit": "workspace:*",
     "zod": "^3.22.4",

--- a/apps/web-dashboard/src/widgets/SessionKeysPanel.tsx
+++ b/apps/web-dashboard/src/widgets/SessionKeysPanel.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Badge, Card, CardContent, CardHeader, CardTitle, Skeleton } from '@ancore/ui-kit';
+import { AlertCircle, Key } from 'lucide-react';
+import { isSessionKeyActive } from '@ancore/core-sdk';
+
+export interface SessionKeySummary {
+  publicKey: string;
+  /** Unix timestamp in seconds. `0` indicates a revoked key. */
+  expiresAt: number;
+  label?: string;
+}
+
+export interface SessionKeysPanelProps {
+  keys?: SessionKeySummary[];
+  isLoading?: boolean;
+  error?: Error | null;
+  /** Override "now" (ms) for deterministic rendering / testnet mocks. */
+  nowMs?: number;
+  className?: string;
+}
+
+function truncatePublicKey(pk: string): string {
+  if (pk.length <= 14) return pk;
+  return `${pk.slice(0, 8)}…${pk.slice(-4)}`;
+}
+
+/**
+ * Read-only panel listing session keys with an active/expired badge.
+ *
+ * Uses {@link isSessionKeyActive} from `@ancore/core-sdk` to derive the badge
+ * so the UI stays in sync with the on-chain semantics implemented by the
+ * account contract. The `nowMs` prop makes the component deterministic for
+ * tests and for testnet mocks.
+ */
+export const SessionKeysPanel: React.FC<SessionKeysPanelProps> = ({
+  keys,
+  isLoading,
+  error,
+  nowMs,
+  className = '',
+}) => {
+  return (
+    <Card className={`overflow-hidden ${className}`}>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">Session Keys</CardTitle>
+        <Key className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div data-testid="session-keys-loading" className="space-y-2">
+            <Skeleton className="h-6 w-full" />
+            <Skeleton className="h-6 w-3/4" />
+          </div>
+        ) : error ? (
+          <div
+            className="flex items-center space-x-2 text-destructive"
+            data-testid="session-keys-error"
+          >
+            <AlertCircle className="h-4 w-4" />
+            <span className="text-xs font-medium">Unable to load session keys</span>
+          </div>
+        ) : !keys || keys.length === 0 ? (
+          <p className="text-xs text-muted-foreground" data-testid="session-keys-empty">
+            No session keys.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border" data-testid="session-keys-list">
+            {keys.map((key) => {
+              const active = isSessionKeyActive(
+                { expiresAt: key.expiresAt, publicKey: key.publicKey },
+                nowMs !== undefined ? { nowMs } : undefined
+              );
+              return (
+                <li
+                  key={key.publicKey}
+                  className="flex items-center justify-between py-2"
+                  data-testid="session-key-row"
+                >
+                  <span className="font-mono text-xs text-foreground">
+                    {key.label ?? truncatePublicKey(key.publicKey)}
+                  </span>
+                  <Badge variant={active ? 'default' : 'destructive'}>
+                    {active ? 'Active' : 'Expired'}
+                  </Badge>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SessionKeysPanel;

--- a/contracts/account/src/lib.rs
+++ b/contracts/account/src/lib.rs
@@ -120,6 +120,18 @@ pub enum DataKey {
     Version,
 }
 
+/// Caller authorization path for [`AncoreAccount::execute`].
+///
+/// `Owner` requires the registered owner address signature; `SessionKey`
+/// carries the public key the caller claims to be acting on behalf of, which
+/// must match a stored, unexpired session key with `PERMISSION_EXECUTE`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CallerIdentity {
+    Owner,
+    SessionKey(BytesN<32>),
+}
+
 const DAY_IN_LEDGERS: u32 = 17280; // 24 hours * 60 min * 60 sec / 5 sec per ledger
 const INSTANCE_BUMP_AMOUNT: u32 = 30 * DAY_IN_LEDGERS; // 30 days
 const INSTANCE_BUMP_THRESHOLD: u32 = 15 * DAY_IN_LEDGERS; // 15 days
@@ -1140,6 +1152,95 @@ mod test {
             &Some(sig),
             &Some(payload),
         );
+    }
+
+    /// Integration test for execute() via a session-key signature.
+    ///
+    /// Covers the three acceptance criteria from issue #680:
+    /// 1. Happy path: session key signs the canonical payload and the contract accepts,
+    ///    bumping the nonce in the snapshot.
+    /// 2. Wrong signature: the contract returns `InvalidSignature` and the nonce is not
+    ///    advanced.
+    /// 3. Expired key: advancing the ledger past `expires_at` causes execute to return
+    ///    `SessionKeyExpired` and the nonce is not advanced.
+    #[test]
+    fn test_execute_session_key_end_to_end() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, AncoreAccount);
+        let client = AncoreAccountClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        init(&env, &client, &owner);
+        env.mock_all_auths();
+
+        env.ledger().set_timestamp(1_000);
+
+        let mut csprng = OsRng;
+        let signing_key = SigningKey::generate(&mut csprng);
+        let session_pk = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+
+        let expires_at = env.ledger().timestamp() + 10_000;
+        let mut permissions = Vec::new(&env);
+        permissions.push_back(PERMISSION_EXECUTE);
+        client.add_session_key(&session_pk, &expires_at, &permissions);
+
+        let callee_id = env.register_contract(None, AncoreAccount);
+        let function = soroban_sdk::symbol_short!("get_nonce");
+        let args = Vec::new(&env);
+
+        // 1. Happy path — session key signs the canonical payload for nonce=0.
+        let (sig, payload) = sign_payload(&env, &signing_key, &callee_id, &function, &args, 0);
+        let result = client.execute(
+            &CallerIdentity::SessionKey(session_pk.clone()),
+            &callee_id,
+            &function,
+            &args,
+            &0u64,
+            &Some(session_pk.clone()),
+            &Some(sig),
+            &Some(payload),
+        );
+        let nonce_result: u64 = soroban_sdk::FromVal::from_val(&env, &result);
+        assert_eq!(nonce_result, 0);
+        // Snapshot side-effect: the account's nonce has been incremented.
+        assert_eq!(client.get_nonce(), 1);
+
+        // 2. Wrong signature — tamper one byte; the contract must reject and the nonce
+        //    must not advance.
+        let (good_sig, good_payload) =
+            sign_payload(&env, &signing_key, &callee_id, &function, &args, 1);
+        let mut tampered = good_sig.to_array();
+        tampered[0] ^= 0xFF;
+        let bad_sig = BytesN::from_array(&env, &tampered);
+        let bad_result = client.try_execute(
+            &CallerIdentity::SessionKey(session_pk.clone()),
+            &callee_id,
+            &function,
+            &args,
+            &1u64,
+            &Some(session_pk.clone()),
+            &Some(bad_sig),
+            &Some(good_payload),
+        );
+        assert_eq!(bad_result, Err(Ok(ContractError::InvalidSignature)));
+        assert_eq!(client.get_nonce(), 1);
+
+        // 3. Expired key — advance the ledger past `expires_at`; execute must return
+        //    SessionKeyExpired before invoking the callee, leaving the nonce unchanged.
+        env.ledger().set_timestamp(expires_at + 1);
+        let (sig2, payload2) = sign_payload(&env, &signing_key, &callee_id, &function, &args, 1);
+        let expired_result = client.try_execute(
+            &CallerIdentity::SessionKey(session_pk.clone()),
+            &callee_id,
+            &function,
+            &args,
+            &1u64,
+            &Some(session_pk),
+            &Some(sig2),
+            &Some(payload2),
+        );
+        assert_eq!(expired_result, Err(Ok(ContractError::SessionKeyExpired)));
+        assert_eq!(client.get_nonce(), 1);
     }
 
     #[test]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ importers:
         version: 30.4.1
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -238,6 +238,9 @@ importers:
 
   apps/web-dashboard:
     dependencies:
+      '@ancore/core-sdk':
+        specifier: workspace:*
+        version: link:../../packages/core-sdk
       '@ancore/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -359,10 +362,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -411,7 +414,7 @@ importers:
         version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -469,7 +472,7 @@ importers:
         version: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -503,10 +506,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -540,10 +543,10 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.4.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
@@ -716,7 +719,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.41)(typescript@5.9.3)
@@ -765,7 +768,7 @@ importers:
         version: 6.3.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -14378,7 +14381,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -14394,12 +14397,12 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
       '@jest/transform': 29.7.0
-      '@jest/types': 30.4.1
+      '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.29.7)
       esbuild: 0.21.5
-      jest-util: 30.4.1
+      jest-util: 29.7.0
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@30.4.1)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.21.5)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -14415,10 +14418,10 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
       '@jest/transform': 29.7.0
-      '@jest/types': 30.4.1
+      '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.29.7)
       esbuild: 0.21.5
-      jest-util: 30.4.1
+      jest-util: 29.7.0
 
   ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3):
     dependencies:

--- a/services/relayer/src/services/mapSimulationError.ts
+++ b/services/relayer/src/services/mapSimulationError.ts
@@ -1,0 +1,48 @@
+import type { RelayError } from '../types';
+
+/**
+ * Map Soroban simulation failures to typed relay errors.
+ *
+ * Returns `null` when the input does not look like a simulation error so the
+ * caller can fall back to {@link mapSubmissionError} or another classifier.
+ *
+ * Known mappings:
+ *  - Soroban host function / contract simulation failures → `SIMULATION_FAILED`
+ *  - Resource budget exhaustion (fee/CPU/memory) → `GAS_LIMIT_EXCEEDED`
+ */
+export function mapSimulationError(error: unknown): RelayError | null {
+  const message = extractMessage(error);
+  if (!message) return null;
+
+  const haystack = message.toLowerCase();
+
+  if (
+    haystack.includes('resource') ||
+    haystack.includes('budget exceeded') ||
+    haystack.includes('out of gas')
+  ) {
+    return { code: 'GAS_LIMIT_EXCEEDED', message };
+  }
+
+  if (
+    haystack.includes('simulation') ||
+    haystack.includes('simulate') ||
+    haystack.includes('host_function_failed') ||
+    haystack.includes('invokehostfunction') ||
+    haystack.includes('insufficient balance')
+  ) {
+    return { code: 'SIMULATION_FAILED', message };
+  }
+
+  return null;
+}
+
+function extractMessage(error: unknown): string | null {
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === 'object' && 'message' in error) {
+    const m = (error as { message?: unknown }).message;
+    if (typeof m === 'string') return m;
+  }
+  return null;
+}

--- a/services/relayer/src/services/relayService.ts
+++ b/services/relayer/src/services/relayService.ts
@@ -12,6 +12,7 @@ import type {
   HealthResponse,
   DependencyStatus,
 } from '../types';
+import { mapSimulationError } from './mapSimulationError';
 import { mapSubmissionError } from './mapSubmissionError';
 
 const MOCK_GAS_USED = 21_000;
@@ -115,7 +116,7 @@ export class RelayService implements RelayServiceContract {
     } catch (error) {
       return {
         success: false,
-        error: mapSubmissionError(error),
+        error: mapSimulationError(error) ?? mapSubmissionError(error),
         gasUsed: 0,
       };
     }

--- a/services/relayer/tests/unit/mapSimulationError.test.ts
+++ b/services/relayer/tests/unit/mapSimulationError.test.ts
@@ -1,0 +1,44 @@
+import { mapSimulationError } from '../../src/services/mapSimulationError';
+
+describe('mapSimulationError', () => {
+  it('maps host function simulation failures to SIMULATION_FAILED', () => {
+    const result = mapSimulationError(new Error('host_function_failed: trap'));
+    expect(result).toEqual({
+      code: 'SIMULATION_FAILED',
+      message: 'host_function_failed: trap',
+    });
+  });
+
+  it('maps insufficient-balance simulation errors to SIMULATION_FAILED', () => {
+    const result = mapSimulationError(new Error('Insufficient balance for invocation'));
+    expect(result).toEqual({
+      code: 'SIMULATION_FAILED',
+      message: 'Insufficient balance for invocation',
+    });
+  });
+
+  it('maps resource budget exhaustion to GAS_LIMIT_EXCEEDED', () => {
+    const result = mapSimulationError(new Error('Resource budget exceeded'));
+    expect(result).toEqual({
+      code: 'GAS_LIMIT_EXCEEDED',
+      message: 'Resource budget exceeded',
+    });
+  });
+
+  it('returns null for errors that are not simulation-shaped', () => {
+    expect(mapSimulationError(new Error('Horizon unreachable'))).toBeNull();
+    expect(mapSimulationError(undefined)).toBeNull();
+    expect(mapSimulationError({})).toBeNull();
+  });
+
+  it('extracts messages from plain strings and message-bearing objects', () => {
+    expect(mapSimulationError('simulation failed: trap')).toEqual({
+      code: 'SIMULATION_FAILED',
+      message: 'simulation failed: trap',
+    });
+    expect(mapSimulationError({ message: 'simulate panic' })).toEqual({
+      code: 'SIMULATION_FAILED',
+      message: 'simulate panic',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Small focused additions across four scopes, one per assigned issue:

- **#686 [DASHBOARD]** — `apps/web-dashboard/src/widgets/SessionKeysPanel.tsx`: new widget listing session keys with an Active / Expired badge driven by `isSessionKeyActive` from `@ancore/core-sdk`. Loading, error, and empty states are covered; the optional `nowMs` prop makes it deterministic for tests and testnet mocks. Declared `@ancore/core-sdk` as a workspace dependency (web-dashboard already imports it from existing hooks, but the declaration was missing).
- **#680 [CONTRACTS]** — `contracts/account/src/lib.rs`: added `test_execute_session_key_end_to_end` in the inner `mod test`, covering all three acceptance scenarios — happy path (session key signs the canonical payload, contract accepts, nonce snapshot advances), wrong-signature rejection (`InvalidSignature`, nonce unchanged), and expired key rejection (`SessionKeyExpired`, nonce unchanged). Uses the existing `sign_payload` helper.
- **#677 [EXTENSION]** — `apps/extension-wallet/src/security/inactivity-detector.ts` + `lock-manager.ts`: extracted a small `minutesToInactivityMs(minutes)` helper next to `InactivityDetector` and routed both constructor and `setAutoLockMinutes` through it, so the auto-lock minutes→ms conversion has a single, testable implementation. `Never` (`0`) is preserved as the existing "never lock" sentinel. (The 1 / 5 / 15 / 30 / Never options and the settings field already exist in `SecuritySettings.tsx`; this PR just tightens the wiring.)
- **#674 [RELAYER]** — `services/relayer/src/services/mapSimulationError.ts`: classify Soroban simulation failures into stable relay codes — host-function / insufficient-balance shapes → `SIMULATION_FAILED`; resource-budget / out-of-gas → `GAS_LIMIT_EXCEEDED`. Returns `null` for non-simulation errors so the existing `mapSubmissionError` keeps handling network / transaction errors unchanged. Wired into `executeRelay`'s catch as the first-pass classifier (`mapSimulationError(error) ?? mapSubmissionError(error)`). Covered by `tests/unit/mapSimulationError.test.ts` with fixture errors per the issue's acceptance criteria.

### Build fix (required for #680)

`contracts/account/src/lib.rs` did not compile on `main`: the public `execute()` signature takes a `CallerIdentity` parameter, but the enum was never defined. Added the minimal definition (`Owner` / `SessionKey(BytesN<32>)`) next to `DataKey`. Without this the lib doesn't compile, so the existing session-key tests and my new test can't be exercised.

## Test plan

- [x] `cargo check -p ancore-account` — clean (1 pre-existing unused-import warning)
- [x] `pnpm --filter @ancore/relayer jest tests/unit/mapSimulationError.test.ts` — 5/5 passing
- [x] `pnpm --filter @ancore/extension-wallet vitest run src/security/__tests__/lock-manager.test.ts` — 9/9 passing
- [x] `pnpm --filter @ancore/relayer tsc --noEmit` — clean for the new file and `relayService.ts`

## Out of scope (pre-existing)

- `cargo test -p ancore-account` does **not** run, even with the `CallerIdentity` fix above, because the crate has further pre-existing breakage independent of this PR: duplicate `test_add_session_key` / `test_add_session_key_emits_event` / `test_has_session_key_present` / `test_has_session_key_absent` / `test_add_session_key_nonzero_expiry_succeeds` definitions inside `mod test`, plus a stale `AccountContract` → `AncoreAccount` rename through the second `#[cfg(test)] mod tests` block (17 stale references) and a missing `#[contract] struct MockContract;` declaration. The new test follows the established `sign_payload` pattern from `test_execute_cross_contract_invocation` and `test_execute_session_key_expired` and will run once those unrelated issues are resolved.
- `apps/web-dashboard` `tsc --noEmit` reports `Cannot find module '@ancore/core-sdk'` for `SessionKeysPanel.tsx` — this is a pre-existing workspace setup issue (core-sdk's `build` script lacks `--dts`, so no type declarations land in `dist`). The same error already hits existing files like `src/services/scheduler-client.ts` on `main`. Runtime resolution works via the vite alias in `apps/web-dashboard/vite.config.ts`.
- Two pre-existing `@ancore/mobile-wallet` test failures (`src/config/__tests__/environment.test.ts`, `src/navigation/__tests__/onboarding.test.tsx`) cause the pre-push hook to fail. Confirmed reproducible on `main` with no local changes; not touched here.

Closes #674
Closes #677
Closes #680
Closes #686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session keys panel to display and manage active/expired session keys in the dashboard.
  * Implemented session key authorization support for account operations.
  * Improved auto-lock timeout configuration for the wallet extension.

* **Bug Fixes**
  * Enhanced error classification for simulation failures to better identify gas limit and insufficient balance issues.

* **Tests**
  * Added comprehensive end-to-end tests for session key authorization workflows.
  * Added unit tests for error handling and classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->