### PR TITLE
test(security): add extension storage encryption audit test (chrome.s…

### DIFF
--- a/apps/extension-wallet/src/security/__tests__/extension-storage-encryption.test.ts
+++ b/apps/extension-wallet/src/security/__tests__/extension-storage-encryption.test.ts
@@ -1,0 +1,93 @@
+import { webcrypto } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EncryptedPayload } from '@ancore/core-sdk';
+
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+  });
+}
+
+if (!globalThis.btoa) {
+  globalThis.btoa = (value: string) => Buffer.from(value, 'binary').toString('base64');
+}
+
+if (!globalThis.atob) {
+  globalThis.atob = (value: string) => Buffer.from(value, 'base64').toString('binary');
+}
+
+interface MockChromeArea {
+  store: Record<string, unknown>;
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+  getBytesInUse: ReturnType<typeof vi.fn>;
+  QUOTA_BYTES: number;
+}
+
+function createMockChromeStorage(): {
+  area: MockChromeArea;
+  getRawStore: () => Record<string, unknown>;
+} {
+  const store: Record<string, unknown> = {};
+
+  const area: MockChromeArea = {
+    store,
+    get: vi.fn((key: string, cb: (r: Record<string, unknown>) => void) => {
+      cb({ [key]: store[key] });
+    }),
+    set: vi.fn((items: Record<string, unknown>, cb: () => void) => {
+      Object.assign(store, items);
+      cb();
+    }),
+    remove: vi.fn((key: string, cb: () => void) => {
+      delete store[key];
+      cb();
+    }),
+    getBytesInUse: vi.fn((_: null, cb: (n: number) => void) => cb(0)),
+    QUOTA_BYTES: 5242880,
+  };
+
+  (globalThis as any).chrome = { runtime: { lastError: undefined } };
+
+  return {
+    area,
+    getRawStore: () => store,
+  };
+}
+
+describe('Extension storage encryption audit', () => {
+  let mockStorage: { area: MockChromeArea; getRawStore: () => Record<string, unknown> };
+  let ChromeStorageAdapter: typeof import('@ancore/core-sdk').ChromeStorageAdapter;
+  let SecureStorageManager: typeof import('@ancore/core-sdk').SecureStorageManager;
+
+  const password = 'integration-test-password';
+  const plaintext = { privateKey: 'my-secret-private-key-12345' };
+
+  beforeEach(async () => {
+    mockStorage = createMockChromeStorage();
+    ({ ChromeStorageAdapter } = await import('@ancore/core-sdk'));
+    ({ SecureStorageManager } = await import('@ancore/core-sdk'));
+  });
+
+  it('never stores plaintext secrets in chrome.storage.local', async () => {
+    const adapter = new ChromeStorageAdapter(mockStorage.area as unknown as chrome.storage.StorageArea);
+    const manager = new SecureStorageManager(adapter);
+
+    await manager.unlock(password);
+    await manager.saveAccount(plaintext);
+
+    const rawStore = mockStorage.getRawStore();
+    const rawValue = JSON.stringify(rawStore);
+
+    expect(rawValue).not.toContain(plaintext.privateKey);
+    expect(rawValue).not.toContain('my-secret-private-key');
+
+    const stored = rawStore['account'] as EncryptedPayload | undefined;
+    expect(stored).toBeDefined();
+    expect(stored).toHaveProperty('salt');
+    expect(stored).toHaveProperty('iv');
+    expect(stored).toHaveProperty('data');
+  });
+});


### PR DESCRIPTION
Closes #662

PR Description

Summary: Add an integration-style test that mocks [chrome.storage.local](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and asserts [SecureStorageManager](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) never writes plaintext secrets to extension storage. This validates that account/session secrets are encrypted before persistence in extension environments.
Why: Threat mitigation / audit — prevents accidental plaintext secrets being persisted to [chrome.storage.local](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
What I changed:
Added [extension-storage-encryption.test.ts](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which:
Mocks [chrome.storage.local](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (using [vi.fn](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
Uses [ChromeStorageAdapter](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) + [SecureStorageManager](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from @ancore/core-sdk.
Saves an account and asserts raw storage JSON does not contain plaintext (e.g., mnemonic/privateKey) and that the stored value has [salt](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [iv](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [data](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Testing notes:
The test uses Node [webcrypto](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) polyfill and defines [btoa](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[atob](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for the test environment (consistent with other tests).
To run locally:
Install deps and run the extension-wallet test suite:
Acceptance criteria:
Test passes in CI.
The test documents the threat mitigated (in file header comments).
Risk: Low — only adds a test file; no production code changes.PR Description

Summary: Add an integration-style test that mocks [chrome.storage.local](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and asserts [SecureStorageManager](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) never writes plaintext secrets to extension storage. This validates that account/session secrets are encrypted before persistence in extension environments.
Why: Threat mitigation / audit — prevents accidental plaintext secrets being persisted to [chrome.storage.local](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
What I changed:
Added [extension-storage-encryption.test.ts](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which:
Mocks [chrome.storage.local](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (using [vi.fn](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
Uses [ChromeStorageAdapter](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) + [SecureStorageManager](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) from @ancore/core-sdk.
Saves an account and asserts raw storage JSON does not contain plaintext (e.g., mnemonic/privateKey) and that the stored value has [salt](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [iv](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and [data](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Testing notes:
The test uses Node [webcrypto](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) polyfill and defines [btoa](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/[atob](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for the test environment (consistent with other tests).
To run locally:
Install deps and run the extension-wallet test suite:
Acceptance criteria:
Test passes in CI.
The test documents the threat mitigated (in file header comments).
Risk: Low — only adds a test file; no production code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test suite for extension storage encryption validation to ensure sensitive values remain encrypted in storage and are never stored as plaintext.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->