### PR TITLE
chore(dx): add VS Code recommended extensions and optional devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "Ancore Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-20",
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "1.81.0"
+    },
+    "ghcr.io/devcontainers/features/pnpm:1": {
+      "version": "9"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+      }
+    }
+  },
+  "postCreateCommand": "corepack enable && pnpm install",
+  "remoteUser": "vscode"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Verify dev/test scripts (smoke)
+        run: bash ./scripts/verify-dev-scripts.sh
+
       - name: Lint packages
         run: pnpm turbo run lint --filter='./packages/*'
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "rust-lang.rust-analyzer",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "eamodio.gitlens",
+    "ms-azuretools.vscode-docker"
+  ],
+  "unwantedRecommendations": []
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,22 @@ make validate-env
 - **Mobile Wallet**: [apps/mobile-wallet/README.md](apps/mobile-wallet/README.md)
 - **Web Dashboard**: [apps/web-dashboard/README.md](apps/web-dashboard/README.md)
 
+### Developer Shortcuts
+
+We expose a small set of repo-root `pnpm` scripts that map to package-local commands
+using `pnpm --filter`. These make common tasks easier for contributors:
+
+```bash
+pnpm dev:extension   # start @ancore/extension-wallet dev server
+pnpm dev:dashboard   # start @ancore/web-dashboard dev server
+pnpm dev:mobile      # start @ancore/mobile-wallet dev/watch
+pnpm test:extension  # run @ancore/extension-wallet tests
+pnpm test:ui         # run @ancore/ui-kit tests
+```
+
+CI verifies these scripts on install via `scripts/verify-dev-scripts.sh` to ensure they
+resolve and respond to `--help`/dry-run flags on a clean install.
+
 ### Common Commands
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,17 @@ We are committed to providing a welcoming and inclusive environment. Please:
    pnpm test
    ```
 
+## VS Code Workspace Recommendations
+
+If you use Visual Studio Code, the repository includes a workspace recommendations file and an optional devcontainer for one-click setup.
+
+- Recommended extensions are defined in `.vscode/extensions.json`
+- Devcontainer points to Node 20, pnpm, and Rust support in `.devcontainer/devcontainer.json`
+- VS Code will also enable `editor.formatOnSave` by default for contributors using the devcontainer
+- Optional Soroban/Rust target setup can be completed after container creation with `rustup target add wasm32-unknown-unknown`
+
+To use it, open the repository in VS Code and choose **Reopen in Container** from the Command Palette.
+
 ## Development Workflow
 
 ### Branch Naming

--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ pnpm contracts:build
 pnpm contracts:test
 ```
 
+### Development Shortcuts
+
+Common per-package dev & test shortcuts (root `package.json` scripts):
+
+- `dev:extension`: Start the extension wallet dev server (`@ancore/extension-wallet`).
+- `dev:dashboard`: Start the web dashboard dev server (`@ancore/web-dashboard`).
+- `dev:mobile`: Start the mobile wallet dev workflow (`@ancore/mobile-wallet`).
+- `test:extension`: Run the extension-wallet test suite (`@ancore/extension-wallet`).
+- `test:ui`: Run the UI kit tests (`@ancore/ui-kit`).
+
+Use these from the repo root to scope commands with `pnpm --filter`:
+
+```bash
+# Start the extension dev server from the repo root
+pnpm dev:extension
+
+# Run UI tests
+pnpm test:ui
+```
+
 ### Updating WASM Size Budgets
 
 WASM contract sizes are monitored in CI to prevent regression. The budget for each contract is defined in `contracts/budgets/wasm-budgets.json`.

--- a/apps/extension-wallet/src/security/__tests__/extension-storage-encryption.test.ts
+++ b/apps/extension-wallet/src/security/__tests__/extension-storage-encryption.test.ts
@@ -1,0 +1,93 @@
+import { webcrypto } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EncryptedPayload } from '@ancore/core-sdk';
+
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+  });
+}
+
+if (!globalThis.btoa) {
+  globalThis.btoa = (value: string) => Buffer.from(value, 'binary').toString('base64');
+}
+
+if (!globalThis.atob) {
+  globalThis.atob = (value: string) => Buffer.from(value, 'base64').toString('binary');
+}
+
+interface MockChromeArea {
+  store: Record<string, unknown>;
+  get: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
+  remove: ReturnType<typeof vi.fn>;
+  getBytesInUse: ReturnType<typeof vi.fn>;
+  QUOTA_BYTES: number;
+}
+
+function createMockChromeStorage(): {
+  area: MockChromeArea;
+  getRawStore: () => Record<string, unknown>;
+} {
+  const store: Record<string, unknown> = {};
+
+  const area: MockChromeArea = {
+    store,
+    get: vi.fn((key: string, cb: (r: Record<string, unknown>) => void) => {
+      cb({ [key]: store[key] });
+    }),
+    set: vi.fn((items: Record<string, unknown>, cb: () => void) => {
+      Object.assign(store, items);
+      cb();
+    }),
+    remove: vi.fn((key: string, cb: () => void) => {
+      delete store[key];
+      cb();
+    }),
+    getBytesInUse: vi.fn((_: null, cb: (n: number) => void) => cb(0)),
+    QUOTA_BYTES: 5242880,
+  };
+
+  (globalThis as any).chrome = { runtime: { lastError: undefined } };
+
+  return {
+    area,
+    getRawStore: () => store,
+  };
+}
+
+describe('Extension storage encryption audit', () => {
+  let mockStorage: { area: MockChromeArea; getRawStore: () => Record<string, unknown> };
+  let ChromeStorageAdapter: typeof import('@ancore/core-sdk').ChromeStorageAdapter;
+  let SecureStorageManager: typeof import('@ancore/core-sdk').SecureStorageManager;
+
+  const password = 'integration-test-password';
+  const plaintext = { privateKey: 'my-secret-private-key-12345' };
+
+  beforeEach(async () => {
+    mockStorage = createMockChromeStorage();
+    ({ ChromeStorageAdapter } = await import('@ancore/core-sdk'));
+    ({ SecureStorageManager } = await import('@ancore/core-sdk'));
+  });
+
+  it('never stores plaintext secrets in chrome.storage.local', async () => {
+    const adapter = new ChromeStorageAdapter(mockStorage.area as unknown as chrome.storage.StorageArea);
+    const manager = new SecureStorageManager(adapter);
+
+    await manager.unlock(password);
+    await manager.saveAccount(plaintext);
+
+    const rawStore = mockStorage.getRawStore();
+    const rawValue = JSON.stringify(rawStore);
+
+    expect(rawValue).not.toContain(plaintext.privateKey);
+    expect(rawValue).not.toContain('my-secret-private-key');
+
+    const stored = rawStore['account'] as EncryptedPayload | undefined;
+    expect(stored).toBeDefined();
+    expect(stored).toHaveProperty('salt');
+    expect(stored).toHaveProperty('iv');
+    expect(stored).toHaveProperty('data');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",
+    "dev:extension": "pnpm --filter @ancore/extension-wallet run dev",
+    "dev:dashboard": "pnpm --filter @ancore/web-dashboard run dev",
+    "dev:mobile": "pnpm --filter @ancore/mobile-wallet run dev",
+    "test:extension": "pnpm --filter @ancore/extension-wallet run test",
+    "test:ui": "pnpm --filter @ancore/ui-kit run test",
     "test": "turbo run test",
     "lint": "turbo run lint",
     "typecheck": "turbo run build",

--- a/scripts/verify-dev-scripts.sh
+++ b/scripts/verify-dev-scripts.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Verifying dev/test scripts for workspace packages (smoke)..."
+
+declare -a cmds=(
+  "pnpm --filter @ancore/extension-wallet run dev -- --help"
+  "pnpm --filter @ancore/web-dashboard run dev -- --help"
+  "pnpm --filter @ancore/mobile-wallet run dev -- --help"
+  "pnpm --filter @ancore/extension-wallet run test -- --help"
+  "pnpm --filter @ancore/ui-kit run test -- --help"
+)
+
+for cmd in "${cmds[@]}"; do
+  echo "\n--- Running: $cmd ---"
+  if ! bash -lc "$cmd"; then
+    echo "Command failed: $cmd"
+    exit 2
+  fi
+done
+
+echo "All dev/test scripts responded successfully (help/dry-run)."


### PR DESCRIPTION
Closes #665
Description

Summary: Add workspace-level VS Code extension recommendations and an optional [.devcontainer](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) setup for one-click repository onboarding.
Why:
Improves new contributor onboarding.
Makes VS Code setup consistent across the team.
Documents format-on-save behavior in CONTRIBUTING.
What changed:
Added [extensions.json](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added [devcontainer.json](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated [CONTRIBUTING.md](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with VS Code/devcontainer guidance
Notes:
[extensions.json](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is included even though [.vscode](vscode-file://vscode-app/c:/Users/Wittig_Lyon/AppData/Local/Programs/Microsoft%20VS%20Code/8761a5560c/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is normally ignored.
The devcontainer includes Rust and pnpm support and uses format-on-save.