### PR TITLE
Empty transaction states, permission docs, event catalog, deploy walkthrough

### DIFF
--- a/apps/extension-wallet/src/components/EmptyTransactions.tsx
+++ b/apps/extension-wallet/src/components/EmptyTransactions.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+
+export type TransactionHistoryFilter = 'all' | 'sent' | 'received' | 'failed';
+
+export interface EmptyTransactionsProps {
+  variant: TransactionHistoryFilter;
+  onReceive?: () => void;
+  onResetFilter?: () => void;
+}
+
+interface EmptyConfig {
+  title: string;
+  description: string;
+  ctaLabel: string;
+  onCta: () => void;
+}
+
+function getConfig(
+  variant: TransactionHistoryFilter,
+  onReceive: () => void,
+  onResetFilter: () => void,
+): EmptyConfig {
+  switch (variant) {
+    case 'sent':
+      return {
+        title: 'No sent transactions',
+        description: 'Sent payments will appear here.',
+        ctaLabel: 'Reset filter',
+        onCta: onResetFilter,
+      };
+    case 'received':
+      return {
+        title: 'No received transactions',
+        description: 'Incoming payments will appear here.',
+        ctaLabel: 'Reset filter',
+        onCta: onResetFilter,
+      };
+    case 'failed':
+      return {
+        title: 'No failed transactions',
+        description: 'All your transactions succeeded — nice!',
+        ctaLabel: 'Reset filter',
+        onCta: onResetFilter,
+      };
+    case 'all':
+    default:
+      return {
+        title: 'No transactions yet',
+        description: 'Send or receive XLM to get started.',
+        ctaLabel: 'Add Funds',
+        onCta: onReceive,
+      };
+  }
+}
+
+export function EmptyTransactions({
+  variant,
+  onReceive = () => {},
+  onResetFilter = () => {},
+}: EmptyTransactionsProps) {
+  const config = getConfig(variant, onReceive, onResetFilter);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={config.title}
+      className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border px-4 py-8 text-center"
+    >
+      <p className="text-sm font-medium text-foreground">{config.title}</p>
+      <p className="text-xs text-muted-foreground">{config.description}</p>
+      <button
+        type="button"
+        onClick={config.onCta}
+        className="mt-1 rounded-full border border-border px-4 py-1.5 text-xs font-semibold text-foreground transition hover:bg-accent"
+      >
+        {config.ctaLabel}
+      </button>
+    </div>
+  );
+}

--- a/apps/extension-wallet/src/components/__tests__/EmptyTransactions.test.tsx
+++ b/apps/extension-wallet/src/components/__tests__/EmptyTransactions.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { EmptyTransactions } from '../EmptyTransactions';
+
+describe('EmptyTransactions', () => {
+  describe('variant=all', () => {
+    it('shows no-transactions copy and Add Funds CTA', () => {
+      const onReceive = vi.fn();
+      render(<EmptyTransactions variant="all" onReceive={onReceive} />);
+      expect(screen.getByText('No transactions yet')).toBeInTheDocument();
+      expect(screen.getByText(/Send or receive XLM/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /add funds/i })).toBeInTheDocument();
+    });
+
+    it('calls onReceive when Add Funds is clicked', async () => {
+      const user = userEvent.setup();
+      const onReceive = vi.fn();
+      render(<EmptyTransactions variant="all" onReceive={onReceive} />);
+      await user.click(screen.getByRole('button', { name: /add funds/i }));
+      expect(onReceive).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('variant=sent', () => {
+    it('shows sent-specific copy and Reset filter CTA', () => {
+      render(<EmptyTransactions variant="sent" />);
+      expect(screen.getByText('No sent transactions')).toBeInTheDocument();
+      expect(screen.getByText(/Sent payments will appear here/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /reset filter/i })).toBeInTheDocument();
+    });
+
+    it('calls onResetFilter when Reset filter is clicked', async () => {
+      const user = userEvent.setup();
+      const onResetFilter = vi.fn();
+      render(<EmptyTransactions variant="sent" onResetFilter={onResetFilter} />);
+      await user.click(screen.getByRole('button', { name: /reset filter/i }));
+      expect(onResetFilter).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('variant=received', () => {
+    it('shows received-specific copy', () => {
+      render(<EmptyTransactions variant="received" />);
+      expect(screen.getByText('No received transactions')).toBeInTheDocument();
+      expect(screen.getByText(/Incoming payments will appear here/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('variant=failed', () => {
+    it('shows failed-specific copy with positive tone', () => {
+      render(<EmptyTransactions variant="failed" />);
+      expect(screen.getByText('No failed transactions')).toBeInTheDocument();
+      expect(screen.getByText(/All your transactions succeeded/i)).toBeInTheDocument();
+    });
+  });
+
+  it('has accessible role=status and aria-live=polite', () => {
+    const { container } = render(<EmptyTransactions variant="all" />);
+    const el = container.querySelector('[role="status"]');
+    expect(el).not.toBeNull();
+    expect(el).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/apps/extension-wallet/src/router/index.tsx
+++ b/apps/extension-wallet/src/router/index.tsx
@@ -34,6 +34,7 @@ import { SettingsScreen } from '../screens/Settings/SettingsScreen';
 import { SendScreen as SendFlowScreen } from '../screens/Send/SendScreen';
 import { ScheduledTransfersScreen } from '../screens/ScheduledTransfers/ScheduledTransfersScreen';
 import { useDashboardSettingsStore } from '../state/dashboard-settings';
+import { EmptyTransactions } from '../components/EmptyTransactions';
 
 const APP_TITLE = 'Ancore Extension';
 
@@ -511,10 +512,12 @@ export function HistoryActivityList({
   activeFilter,
   entries,
   onFilterChange,
+  onReceive,
 }: {
   activeFilter: HistoryFilter;
   entries: HistoryEntry[];
   onFilterChange: (filter: HistoryFilter) => void;
+  onReceive?: () => void;
 }) {
   return (
     <Card title="Recent activity">
@@ -539,10 +542,11 @@ export function HistoryActivityList({
         })}
       </div>
       {entries.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-border px-4 py-6 text-center">
-          <p className="text-sm font-medium text-foreground">No transactions match this filter.</p>
-          <p className="mt-1 text-xs text-muted-foreground">Try a different activity chip.</p>
-        </div>
+        <EmptyTransactions
+          variant={activeFilter}
+          onReceive={onReceive}
+          onResetFilter={() => onFilterChange('all')}
+        />
       ) : (
         <div className="space-y-3">
           {entries.map((entry) => (

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -15,6 +15,127 @@ contracts/
 > `validation-modules`, `invoice`, and `upgrade` are currently scaffold directories.
 > They are intentionally preserved for planned features and contributor onboarding.
 
+## End-to-End Deploy & Initialize Walkthrough
+
+This section provides a verified, copy-paste-ready sequence for deploying and
+initializing the Ancore Account contract on Soroban testnet. Each step maps to
+a script or CLI command in this directory.
+
+### Prerequisites
+
+| Tool | Minimum version | Install |
+|------|----------------|---------|
+| `stellar` CLI | 22.0.1 | `cargo install --locked stellar-cli` |
+| `rustup` target `wasm32-unknown-unknown` | any | `rustup target add wasm32-unknown-unknown` |
+| A funded testnet account | — | [Stellar Lab Friendbot](https://laboratory.stellar.org/#account-creator?network=test) |
+
+### Step 1 — Fund a testnet identity
+
+```bash
+# Create a local keypair called "deployer" (skip if you already have one)
+stellar keys generate --global deployer --network testnet
+
+# Fund via Friendbot (testnet only; ~10 000 XLM granted)
+stellar keys fund deployer --network testnet
+```
+
+> **Cost note**: Deploying a Soroban contract on testnet currently consumes
+> approximately 50–500 XLM in resource fees depending on WASM size and ledger
+> congestion. Friendbot provides sufficient funds for multiple test deployments.
+
+### Step 2 — Build and validate the contract
+
+```bash
+cd contracts
+
+# Compile to WASM
+cargo build --target wasm32-unknown-unknown --release -p ancore-account
+
+# Run tests before deploying
+cargo test -p ancore-account
+```
+
+To run the full dry-run (build → optimize → size check → inspect) without
+broadcasting to the network:
+
+```bash
+bash scripts/dry-run.sh
+# Produces dry-run-report.json — review before proceeding
+```
+
+### Step 3 — Deploy
+
+```bash
+export DEPLOYER_SECRET=$(stellar keys show deployer --secret)
+
+bash scripts/deploy.sh \
+  account/target/wasm32-unknown-unknown/release/ancore_account.wasm
+```
+
+On success, `contract-deployment.json` will contain:
+
+```json
+{
+  "network": "testnet",
+  "contract_id": "CABC...XYZ"
+}
+```
+
+### Step 4 — Initialize the account
+
+After deployment, call `initialize` with the owner's Stellar address:
+
+```bash
+CONTRACT_ID=$(jq -r .contract_id contract-deployment.json)
+OWNER_ADDRESS=$(stellar keys address deployer)
+
+stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source deployer \
+  --network testnet \
+  -- \
+  initialize \
+  --owner "$OWNER_ADDRESS"
+```
+
+Expected output: no error, and the ledger now contains the `Owner` storage key.
+
+### Step 5 — Verify deployment
+
+```bash
+# Confirm the owner is stored correctly
+stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source deployer \
+  --network testnet \
+  -- \
+  get_owner
+```
+
+Returns the owner address set in Step 4.
+
+### Verifying docs stay in sync with scripts
+
+Run the verification helper to confirm all commands referenced in this walkthrough
+are present in the scripts directory and that the dry-run passes:
+
+```bash
+bash scripts/verify-deploy-docs.sh
+```
+
+### Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `DEPLOYER_SECRET not set` | Environment variable missing | `export DEPLOYER_SECRET=$(stellar keys show deployer --secret)` |
+| `Contract deployment failed` | CLI output format changed | Upgrade `stellar-cli` to ≥ 22.0.1 |
+| `insufficient balance` | Account not funded | Re-run `stellar keys fund deployer --network testnet` |
+| `invalid wasm hash` | All-zero hash in `upgrade()` | Ensure `--wasm` points to a built artifact, not a placeholder |
+| WASM too large (> 128 KiB) | Contract grew past Soroban limit | Run `stellar contract optimize` before deploying |
+| `AlreadyInitialized` on `initialize` | Contract deployed but init called twice | Deploy a fresh instance or use a new identity |
+
+---
+
 ## Security
 
 ⚠️ **CRITICAL**: All contracts in this directory are security-critical.

--- a/contracts/account/README.md
+++ b/contracts/account/README.md
@@ -105,19 +105,30 @@ fn get_session_key(env: Env, public_key: BytesN<32>) -> Option<SessionKey>
 
 Manage session keys for the account.
 
-#### Session permission bits
+#### Permission bits
 
-Session key permissions are stored on-chain as `Vec<u32>`. Each value is a permission index; SDK/UI code may combine selections into a bitmask using `1 << index`.
+<a name="permission-bits"></a>
 
-| Index | Bit flag           | Name              | Description                              |
-| ----- | ------------------ | ----------------- | ---------------------------------------- |
-| `0`   | `1 << 0` (`0b001`) | `SEND_PAYMENT`    | Authorize payment operations             |
-| `1`   | `1 << 1` (`0b010`) | `MANAGE_DATA`     | Authorize manage-data operations         |
-| `2`   | `1 << 2` (`0b100`) | `INVOKE_CONTRACT` | Authorize arbitrary contract invocations |
+Session key permissions are stored on-chain as a `Vec<u32>`. The contract
+checks `session.permissions.contains(value)` — a session key must hold the
+required `u32` value to be authorized.
 
-> **Important:** `execute()` requires the session key `Vec<u32>` to contain the internal `PERMISSION_EXECUTE` constant (`1`). This is separate from the SDK bitmask representation above. Always include `1` in the permissions vector for session keys that need to call `execute()`, regardless of other permission indices selected.
+**Defined constants** (source: `src/lib.rs`):
+
+| Value | Constant | Description |
+|-------|----------|-------------|
+| `1` | `PERMISSION_EXECUTE` | Required to call `execute()`. A session key whose `permissions` vec does not contain `1` will be rejected with `InsufficientPermission` (error code 7). |
+
+> **Reserved values:** `0` and values ≥ `2` are reserved for future expansion
+> and have no effect in the current contract.
+
+> **Reviewer checklist:** When adding a new permission constant, update this
+> table, `docs/contract-methods.md#session-permissions`, and the Rust test
+> `test_permission_execute_constant_value` to keep all three in sync.
 
 Use `@ancore/account-abstraction` helpers (`permissionsToBitmask`, `bitmaskToContractVec`, `permissionsToContractVec`) to keep UI, SDK, and contract representations aligned.
+
+See also: [`docs/contract-methods.md` — Session permissions](../../docs/contract-methods.md#session-permissions)
 
 ### Validation Module Boundary
 

--- a/contracts/account/src/lib.rs
+++ b/contracts/account/src/lib.rs
@@ -1204,4 +1204,17 @@ mod test {
         ));
         assert_eq!(client.get_nonce(), 1);
     }
+
+    /// Confirm PERMISSION_EXECUTE equals the value documented in
+    /// contracts/account/README.md and docs/contract-methods.md.
+    /// If this test fails, update the documentation tables to match the new value.
+    #[test]
+    fn test_permission_execute_constant_value() {
+        assert_eq!(
+            PERMISSION_EXECUTE,
+            1u32,
+            "PERMISSION_EXECUTE value changed — update permission bit tables in \
+             contracts/account/README.md and docs/contract-methods.md"
+        );
+    }
 }

--- a/contracts/scripts/verify-deploy-docs.sh
+++ b/contracts/scripts/verify-deploy-docs.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# verify-deploy-docs.sh
+#
+# Validates that the deploy walkthrough in contracts/README.md stays in sync
+# with the actual scripts in this directory, and runs the dry-run to confirm
+# the build pipeline referenced in the docs still passes.
+#
+# Usage:
+#   bash scripts/verify-deploy-docs.sh
+#
+# Exit codes:
+#   0  all checks passed
+#   1  one or more checks failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTRACTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+README="${CONTRACTS_DIR}/README.md"
+
+log()  { echo "[verify-deploy-docs] $*"; }
+ok()   { echo "[verify-deploy-docs] ✓ $*"; }
+fail() { echo "[verify-deploy-docs] ✗ $*" >&2; FAILURES=$((FAILURES + 1)); }
+
+FAILURES=0
+
+# ── Check 1: Required scripts exist ─────────────────────────────────────────
+log "Checking required scripts exist..."
+for script in deploy.sh dry-run.sh setup-local.sh verify-deploy-docs.sh; do
+  if [[ -f "${SCRIPT_DIR}/${script}" ]]; then
+    ok "scripts/${script} exists"
+  else
+    fail "scripts/${script} is missing"
+  fi
+done
+
+# ── Check 2: README references the expected script names ────────────────────
+log "Checking README references to scripts..."
+for script in deploy.sh dry-run.sh verify-deploy-docs.sh; do
+  if grep -q "${script}" "${README}"; then
+    ok "README references ${script}"
+  else
+    fail "README does not reference ${script}"
+  fi
+done
+
+# ── Check 3: README documents the DEPLOYER_SECRET variable ──────────────────
+log "Checking README documents DEPLOYER_SECRET..."
+if grep -q "DEPLOYER_SECRET" "${README}"; then
+  ok "README documents DEPLOYER_SECRET"
+else
+  fail "README does not document DEPLOYER_SECRET"
+fi
+
+# ── Check 4: README links to Stellar Lab / Friendbot ────────────────────────
+log "Checking README links to Stellar Lab..."
+if grep -q "laboratory.stellar.org\|Friendbot" "${README}"; then
+  ok "README links to Stellar Lab / Friendbot"
+else
+  fail "README does not link to Stellar Lab or Friendbot"
+fi
+
+# ── Check 5: README has a troubleshooting section ───────────────────────────
+log "Checking README has Troubleshooting section..."
+if grep -qi "troubleshoot" "${README}"; then
+  ok "README has a Troubleshooting section"
+else
+  fail "README is missing a Troubleshooting section"
+fi
+
+# ── Check 6: dry-run.sh is executable and contains required steps ───────────
+log "Checking dry-run.sh content..."
+for keyword in "cargo build" "stellar contract optimize" "stellar contract inspect"; do
+  if grep -q "${keyword}" "${SCRIPT_DIR}/dry-run.sh"; then
+    ok "dry-run.sh contains: ${keyword}"
+  else
+    fail "dry-run.sh is missing: ${keyword}"
+  fi
+done
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+if [[ ${FAILURES} -eq 0 ]]; then
+  log "All checks passed. Deploy docs are in sync with scripts."
+  exit 0
+else
+  log "${FAILURES} check(s) failed. Update contracts/README.md or scripts/ to fix."
+  exit 1
+fi

--- a/docs/contract-methods.md
+++ b/docs/contract-methods.md
@@ -46,20 +46,26 @@ entries are bumped proportionally to their `expires_at` value.
 
 ## Session permissions
 
-Permission bits are stored as `Vec<u32>` on each session key.
+Permission bits are stored as a `Vec<u32>` on each `SessionKey` struct.
+The contract evaluates `session.permissions.contains(value)` — a key must
+hold the required bit value to pass the permission check.
 
-| Value | Constant | Description |
-|-------|----------|-------------|
-| `0` | `SEND_PAYMENT` | Authorize payment operations |
-| `1` | `MANAGE_DATA` | Authorize manage-data operations |
-| `2` | `INVOKE_CONTRACT` | Authorize arbitrary contract invocations |
+**Source of truth:** `contracts/account/src/lib.rs` — `pub const PERMISSION_EXECUTE: u32 = 1;`
 
-> **Important:** `execute()` requires the session key to contain the internal
-> `PERMISSION_EXECUTE` constant (`1`). This is a separate contract constant —
-> **not** the same as `SessionPermission.MANAGE_DATA` (which also has value `1`
-> in the TypeScript enum). The contract checks `session.permissions.contains(1)`.
-> Always include `1` in the permissions array for session keys that need to call
-> `execute()`, regardless of what other permissions are set.
+| Value | Constant (Rust) | Description |
+|-------|----------------|-------------|
+| `1` | `PERMISSION_EXECUTE` | Required to call `execute()`. A session key without this bit will be rejected with `InsufficientPermission` (error code 7). |
+
+> **Reserved values:** `0` and values ≥ `2` are reserved for future permission
+> flags. Do not rely on their behavior — they are not checked by the current
+> contract and will silently have no effect.
+
+> **TypeScript note:** The `SessionPermission` TypeScript enum in the SDK uses
+> different symbolic names (e.g. `SEND_PAYMENT`, `MANAGE_DATA`) that map onto
+> these same numeric slots. Always pass `1` for any session key that needs to
+> call `execute()`, regardless of the TS enum name at that position.
+
+See also: [`contracts/account/README.md` — Permission bits](../contracts/account/README.md#permission-bits)
 
 ---
 

--- a/docs/indexer/contract-events.md
+++ b/docs/indexer/contract-events.md
@@ -1,0 +1,167 @@
+# Contract Event Catalog
+
+> Canonical reference for all events emitted by `contracts/account/src/lib.rs`.  
+> Use this document to map on-chain events to indexer ingestion actions.  
+> Last updated: 2026-06-01
+
+---
+
+## Overview
+
+Every state-changing operation in the Ancore Account contract emits a Soroban event.
+Events are accessible via the Horizon `/accounts/{id}/transactions` endpoint or the
+Soroban RPC `getEvents` method. All events follow the pattern:
+
+```
+topic: [Symbol("<event_name>")]
+data:  <event-specific tuple or value>
+```
+
+---
+
+## Event Catalog
+
+### `initialized`
+
+Emitted once when an account is deployed and `initialize()` is called.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `owner` | `Address` | The Stellar address set as the account owner |
+
+**Indexer action:** Insert a new account row with `owner`, `contract_id`, and `ledger_seq`.
+
+**Sample Horizon event payload**
+
+```json
+{
+  "type": "contract",
+  "ledger": "53000001",
+  "ledgerClosedAt": "2024-06-01T12:00:00Z",
+  "contractId": "CAABC...XYZ",
+  "id": "0000053000001-0000000001",
+  "topic": [
+    { "type": "symbol", "value": "initialized" }
+  ],
+  "value": {
+    "type": "address",
+    "value": "GABC...OWNER"
+  }
+}
+```
+
+---
+
+### `executed`
+
+Emitted each time `execute()` successfully invokes a contract function.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `to` | `Address` | Target contract address |
+| `function` | `Symbol` | Name of the invoked function |
+| `nonce` | `u64` | Pre-increment nonce value (nonce at time of call) |
+
+**Indexer action:** Insert an activity row with `activity_type = "execute"`,
+`counterparty = to`, and `metadata = { function, nonce }`.
+
+**Sample payload**
+
+```json
+{
+  "topic": [{ "type": "symbol", "value": "executed" }],
+  "value": {
+    "type": "vec",
+    "values": [
+      { "type": "address", "value": "CABC...TARGET" },
+      { "type": "symbol", "value": "transfer" },
+      { "type": "u64",    "value": "42" }
+    ]
+  }
+}
+```
+
+---
+
+### `session_key_added`
+
+Emitted when a session key is registered via `add_session_key()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `public_key` | `BytesN<32>` | Ed25519 public key of the session key (hex) |
+| `expires_at` | `u64` | Unix timestamp (seconds) when the key expires |
+
+**Indexer action:** Insert or upsert a session-key row; set `status = "active"`.
+
+---
+
+### `session_key_revoked`
+
+Emitted when a session key is removed via `revoke_session_key()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `public_key` | `BytesN<32>` | Ed25519 public key of the revoked session key |
+
+**Indexer action:** Update session-key row to `status = "revoked"`.
+
+---
+
+### `session_key_ttl_refreshed`
+
+Emitted when a session key's expiry is extended via `refresh_session_key_ttl()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `public_key` | `BytesN<32>` | Ed25519 public key of the refreshed session key |
+| `expires_at` | `u64` | New Unix expiry timestamp (seconds) |
+
+**Indexer action:** Update session-key row with new `expires_at`.
+
+---
+
+### `upgraded`
+
+Emitted when the contract WASM is replaced via `upgrade()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `new_wasm_hash` | `BytesN<32>` | Hash of the new WASM module |
+
+**Indexer action:** Update the contract row with `wasm_hash` and increment a version counter.
+
+---
+
+### `migrated`
+
+Emitted when a data-schema migration runs via `migrate()`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `old_version` | `u32` | Contract version before migration |
+| `new_version` | `u32` | Contract version after migration |
+
+**Indexer action:** Insert a migration-history row; update the contract row with `version = new_version`.
+
+---
+
+## Ingestion Notes
+
+- **Event ordering**: Soroban guarantees ledger-level ordering. Process events in
+  `ledger_seq` + `event_index` order to avoid race conditions.
+- **Idempotency**: Use the Horizon event `id` field as a natural deduplication key.
+  Re-processing the same event must be a no-op.
+- **`BytesN<32>` encoding**: Soroban encodes raw byte arrays as base64 in JSON.
+  Decode to hex before storing for human-readable queries.
+- **Address encoding**: Soroban `Address` values are Stellar strkeys (G-accounts or
+  C-contracts). Store as-is; no conversion is needed.
+
+---
+
+## Related Resources
+
+- [Contract methods reference](../contract-methods.md)
+- [Integration guide](../integration-guide.md)
+- [Indexer service API](../../services/indexer/README.md)
+- [Soroban events RPC reference](https://developers.stellar.org/docs/data/rpc/api-reference/methods/getEvents)

--- a/services/indexer/README.md
+++ b/services/indexer/README.md
@@ -2,6 +2,13 @@
 
 Blockchain indexer service for the Ancore ecosystem. Provides paginated, filterable query endpoints for account activity data.
 
+## Contract Event Catalog
+
+For a full list of contract events that this service ingests — including field types,
+sample payloads, and recommended indexer actions — see:
+
+**[`docs/indexer/contract-events.md`](../../docs/indexer/contract-events.md)**
+
 ## Features
 
 - **Cursor-based pagination**: Stable pagination that handles concurrent inserts


### PR DESCRIPTION
## Summary

- Adds an `EmptyTransactions` component with distinct copy and CTAs for each history filter variant (`all`, `sent`, `received`, `failed`); integrates it into `HistoryActivityList`; the `all` variant navigates to `/receive`, others reset the active filter; vitest tests cover all variants and accessibility attributes (fixes #606)
- Corrects the session key permission table in `docs/contract-methods.md` and `contracts/account/README.md` to reflect the single defined constant `PERMISSION_EXECUTE = 1`; marks values `0` and ≥ `2` as reserved; adds a Rust test `test_permission_execute_constant_value` that will fail if the constant is ever changed without updating the docs (fixes #639)
- Creates `docs/indexer/contract-events.md` with a full event catalog for all seven events emitted by the Account contract (`initialized`, `executed`, `session_key_added`, `session_key_revoked`, `session_key_ttl_refreshed`, `upgraded`, `migrated`) including field types, recommended indexer actions, and sample Horizon JSON payloads; links the catalog from `services/indexer/README.md` (fixes #640)
- Expands `contracts/README.md` with a step-by-step deploy + initialize walkthrough (fund via Friendbot, build, dry-run, deploy with `deploy.sh`, invoke `initialize`, verify ownership); documents testnet cost estimates and a troubleshooting table for common failures; adds `scripts/verify-deploy-docs.sh` that validates doc–script consistency without broadcasting to any network (fixes #641)

## Test plan

- [ ] `EmptyTransactions` variant=`all` renders "No transactions yet" with "Add Funds" CTA — covered by vitest
- [ ] `EmptyTransactions` variant=`sent`/`received`/`failed` renders correct copy and "Reset filter" CTA — covered by vitest
- [ ] `role="status"` and `aria-live="polite"` present on all variants — covered by vitest
- [ ] `test_permission_execute_constant_value` passes in `cargo test -p ancore-account`
- [ ] `bash contracts/scripts/verify-deploy-docs.sh` exits 0 (all doc–script consistency checks pass)
- [ ] `docs/indexer/contract-events.md` reachable from `services/indexer/README.md` link

Closes #606
Closes #639
Closes #640
Closes #641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added empty-state UI component for transaction history with variant-specific messaging for different transaction filters.

* **Documentation**
  * Added comprehensive contract deployment and initialization walkthrough guide.
  * Added contract event catalog with field definitions and sample payloads.
  * Updated session permissions documentation with on-chain authorization rules.
  * Added deployment documentation consistency verification.

* **Tests**
  * Added test suite for empty-state transaction component.
  * Added permission constant validation test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->