### PR TITLE
Add Prometheus /metrics endpoint with lag gauges

### DIFF
--- a/PROMETHEUS_METRICS_IMPLEMENTATION.md
+++ b/PROMETHEUS_METRICS_IMPLEMENTATION.md
@@ -1,0 +1,101 @@
+# Prometheus Metrics Implementation
+
+## Summary
+
+This PR adds a Prometheus `/metrics` endpoint to the indexer service that exposes ingest lag gauges for monitoring and alerting.
+
+## Changes Made
+
+### 1. Added Prometheus Dependencies (`services/indexer/Cargo.toml`)
+- Added `metrics = "0.22"` for metric recording
+- Added `metrics-exporter-prometheus = "0.13"` with HTTP listener feature for Prometheus text format export
+
+### 2. Enhanced Metrics Module (`services/indexer/src/metrics.rs`)
+- Added `init_prometheus_metrics()` function to register metric descriptions at startup
+- Added `record_lag()` function to update Prometheus gauges with lag values
+- Metrics exposed:
+  - `indexer_lag_blocks`: Number of ledgers behind chain head
+  - `indexer_lag_seconds`: Estimated seconds behind chain head
+
+### 3. Updated Main Entry Point (`services/indexer/src/main.rs`)
+- Initialized Prometheus exporter with HTTP listener on configurable port (default: 9090)
+- Called `metrics::init_prometheus_metrics()` at startup
+- Added `/metrics/prometheus` route for documentation (actual metrics served on separate port)
+
+### 4. Updated Health Handler (`services/indexer/src/api/health.rs`)
+- Integrated `record_lag()` call to update Prometheus metrics on each health check
+- Metrics are automatically updated whenever `/health` endpoint is called
+
+### 5. Updated Metrics API Handler (`services/indexer/src/api/metrics.rs`)
+- Added documentation clarifying JSON vs Prometheus format endpoints
+- Added `prometheus_metrics_handler()` for informational purposes
+
+### 6. Updated Prometheus Configuration (`services/prometheus.yml`)
+- Changed indexer scrape target from `indexer:8081` to `indexer:9090`
+- Renamed job from `indexer` to `ancore-indexer` for clarity
+- Configured to scrape `/metrics` endpoint every 15 seconds
+
+### 7. Updated Documentation (`services/indexer/README.md`)
+- Added Prometheus Metrics section with usage examples
+- Documented available metrics and their meanings
+- Added Prometheus configuration example
+- Updated API examples with correct ports (3000 for API, 9090 for metrics)
+- Added `PROMETHEUS_PORT` environment variable documentation
+
+## Architecture
+
+The implementation follows best practices:
+
+1. **Separate Ports**: API runs on port 3000, Prometheus metrics on port 9090
+2. **Automatic Updates**: Metrics are updated on every health check call
+3. **Standard Format**: Uses Prometheus text format for scraping
+4. **Configurable**: Port is configurable via `PROMETHEUS_PORT` environment variable
+5. **Non-blocking**: Metrics recording is synchronous and fast
+
+## Testing
+
+### Manual Testing
+
+```bash
+# Check Prometheus metrics endpoint
+curl -s localhost:9090/metrics
+
+# Expected output:
+# HELP indexer_lag_blocks Number of ledgers behind chain head
+# TYPE indexer_lag_blocks gauge
+indexer_lag_blocks 0
+
+# HELP indexer_lag_seconds Estimated seconds behind chain head
+# TYPE indexer_lag_seconds gauge
+indexer_lag_seconds 0
+```
+
+### Prometheus Configuration Validation
+
+```bash
+promtool check config services/prometheus.yml
+```
+
+## Acceptance Criteria
+
+- ✅ GET /metrics returns Prometheus text format
+- ✅ Lag gauges updated on health/ingest tick (via health handler)
+- ✅ Prometheus configuration updated with indexer scrape target
+- ✅ Documented in services/indexer/README.md
+
+## Environment Variables
+
+- `PROMETHEUS_PORT`: Port for Prometheus metrics endpoint (default: 9090)
+
+## Deployment Notes
+
+1. Ensure port 9090 is exposed in Docker/Kubernetes configuration
+2. Update Prometheus scraper to target `indexer:9090`
+3. Set `PROMETHEUS_PORT` environment variable if using a different port
+4. Metrics are automatically populated when the `/health` endpoint is called
+
+## Related Issues
+
+- Independent of cursor serializer tests (#477)
+- Part of Stellar Wave initiative
+- Enhances developer experience and infrastructure monitoring

--- a/services/indexer/Cargo.toml
+++ b/services/indexer/Cargo.toml
@@ -39,6 +39,10 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Metrics
+metrics = "0.22"
+metrics-exporter-prometheus = { version = "0.13", default-features = false, features = ["http-listener"] }
+
 # Environment
 dotenvy = "0.15"
 

--- a/services/indexer/README.md
+++ b/services/indexer/README.md
@@ -18,6 +18,33 @@ sample payloads, and recommended indexer actions — see:
 
 ## API Endpoints
 
+### Prometheus Metrics
+
+```
+GET /metrics (Prometheus text format)
+```
+
+Exposes operational metrics in Prometheus text format for scraping. The metrics are served on a dedicated port (default: 9090, configurable via `PROMETHEUS_PORT` environment variable).
+
+**Available metrics:**
+- `indexer_lag_blocks`: Number of ledgers the indexer is behind the chain head
+- `indexer_lag_seconds`: Estimated seconds the indexer is behind the chain head (calculated as `lag_blocks × 5`)
+
+These metrics are automatically updated on each health check and can be used for alerting and monitoring dashboards.
+
+**Prometheus configuration:**
+
+Add the following scrape job to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: ancore-indexer
+    metrics_path: /metrics
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['indexer:9090']
+```
+
 ### List Account Activity
 
 ```
@@ -174,17 +201,38 @@ bash scripts/curl-smoke-indexer.sh
 ### Health check
 
 ```bash
-curl -s localhost:8080/health | jq
+curl -s localhost:3000/health | jq
 ```
 
-Sample response (`fixtures/api/health-response.json`):
+Sample response:
 
 ```json
 {
+  "timestamp": "2024-01-15T10:30:00Z",
   "status": "ok",
-  "version": "0.1.0",
-  "uptime_seconds": 3600
+  "latest_indexed_ledger": 50123456,
+  "chain_head": 50123456,
+  "lag_blocks": 0,
+  "lag_seconds": 0
 }
+```
+
+### Prometheus metrics
+
+```bash
+curl -s localhost:9090/metrics
+```
+
+Sample response (Prometheus text format):
+
+```
+# HELP indexer_lag_blocks Number of ledgers behind chain head
+# TYPE indexer_lag_blocks gauge
+indexer_lag_blocks 0
+
+# HELP indexer_lag_seconds Estimated seconds behind chain head
+# TYPE indexer_lag_seconds gauge
+indexer_lag_seconds 0
 ```
 
 ### List account activity
@@ -192,7 +240,7 @@ Sample response (`fixtures/api/health-response.json`):
 ```bash
 ACCOUNT="GABC123XYZ456DEF789GHI012JKL345MNO678PQR901STU234VWX567YZA"
 
-curl -s "localhost:8080/api/v1/accounts/$ACCOUNT/activity?limit=5" | jq
+curl -s "localhost:3000/api/v1/accounts/$ACCOUNT/activity?limit=5" | jq
 ```
 
 Sample response (`fixtures/api/account-activity-response.json`):
@@ -226,7 +274,7 @@ Sample response (`fixtures/api/account-activity-response.json`):
 ### Filter by activity type
 
 ```bash
-curl -s "localhost:8080/api/v1/accounts/$ACCOUNT/activity?activity_type=payment&limit=5" | jq
+curl -s "localhost:3000/api/v1/accounts/$ACCOUNT/activity?activity_type=payment&limit=5" | jq
 ```
 
 ### Cursor pagination
@@ -234,13 +282,13 @@ curl -s "localhost:8080/api/v1/accounts/$ACCOUNT/activity?activity_type=payment&
 Use the `next_cursor` value from a previous response:
 
 ```bash
-curl -s "localhost:8080/api/v1/accounts/$ACCOUNT/activity?cursor_after=eyJ0IjoiMjAyNC...&limit=5" | jq
+curl -s "localhost:3000/api/v1/accounts/$ACCOUNT/activity?cursor_after=eyJ0IjoiMjAyNC...&limit=5" | jq
 ```
 
 ### Filter by ledger range
 
 ```bash
-curl -s "localhost:8080/api/v1/accounts/$ACCOUNT/activity?ledger_min=50000000&ledger_max=50200000" | jq
+curl -s "localhost:3000/api/v1/accounts/$ACCOUNT/activity?ledger_min=50000000&ledger_max=50200000" | jq
 ```
 
 ### Error envelope
@@ -248,7 +296,7 @@ curl -s "localhost:8080/api/v1/accounts/$ACCOUNT/activity?ledger_min=50000000&le
 Invalid parameters return a structured error. Example — `limit` exceeds maximum:
 
 ```bash
-curl -s "localhost:8080/api/v1/accounts/$ACCOUNT/activity?limit=500" | jq
+curl -s "localhost:3000/api/v1/accounts/$ACCOUNT/activity?limit=500" | jq
 ```
 
 Sample error response (`fixtures/api/error-response.json`):
@@ -294,6 +342,7 @@ docker-compose logs indexer
 DATABASE_URL=postgresql://user:password@localhost:5432/ancore
 TEST_DATABASE_URL=postgresql://user:password@localhost:5432/ancore_test
 DB_QUERY_TIMEOUT_SEC=30 # Optional, defaults to 30
+PROMETHEUS_PORT=9090 # Optional, defaults to 9090
 # SQLX_OFFLINE is set automatically via .cargo/config.toml — no manual export needed
 ```
 

--- a/services/indexer/src/api/health.rs
+++ b/services/indexer/src/api/health.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use sqlx::{PgPool, Row};
 
 use crate::error::Result;
+use crate::metrics::record_lag;
 
 /// Health response body.
 ///
@@ -70,6 +71,9 @@ pub async fn health_handler(State(db): State<PgPool>) -> Result<Json<HealthRespo
     } else {
         "ok".to_string()
     };
+
+    // Update Prometheus metrics
+    record_lag(lag_blocks, lag_seconds);
 
     Ok(Json(HealthResponse {
         timestamp: Utc::now().to_rfc3339(),

--- a/services/indexer/src/api/metrics.rs
+++ b/services/indexer/src/api/metrics.rs
@@ -1,4 +1,4 @@
-use axum::{extract::State, response::Json};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, response::Json};
 use serde::Serialize;
 use sqlx::PgPool;
 
@@ -16,11 +16,15 @@ pub struct MetricsResponse {
     pub status: String,
 }
 
-/// GET /metrics
+/// GET /metrics (JSON format)
 ///
 /// Returns cursor staleness metrics for operational monitoring and alerting.
 /// Exposes whether any ingestion streams have stale cursors that may indicate
 /// processing issues.
+///
+/// Note: This endpoint returns JSON. For Prometheus scraping, use the
+/// Prometheus exporter's built-in `/metrics` endpoint which returns
+/// Prometheus text format.
 pub async fn metrics_handler(State(db): State<PgPool>) -> Result<Json<MetricsResponse>> {
     let cursors = get_cursor_metrics(&db).await?;
 
@@ -32,4 +36,17 @@ pub async fn metrics_handler(State(db): State<PgPool>) -> Result<Json<MetricsRes
     };
 
     Ok(Json(MetricsResponse { cursors, status }))
+}
+
+/// GET /metrics/prometheus
+///
+/// Returns metrics in Prometheus text format for scraping.
+/// This is a placeholder that delegates to the Prometheus exporter's
+/// built-in HTTP listener on a separate port.
+pub async fn prometheus_metrics_handler() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        "# Prometheus metrics are exposed on the metrics port (default: 9090)\n\
+         # Configure your Prometheus scraper to target that port instead.\n",
+    )
 }

--- a/services/indexer/src/main.rs
+++ b/services/indexer/src/main.rs
@@ -1,4 +1,5 @@
 use axum::{routing::get, Router};
+use metrics_exporter_prometheus::PrometheusBuilder;
 use sqlx::postgres::PgPoolOptions;
 use std::net::SocketAddr;
 use std::str::FromStr;
@@ -16,7 +17,7 @@ use ancore_indexer::ingest::CheckpointStore;
 
 use api::account_activity;
 use api::health;
-use api::metrics::metrics_handler;
+use api::metrics::{metrics_handler, prometheus_metrics_handler};
 use api::statements;
 
 #[tokio::main]
@@ -32,6 +33,22 @@ async fn main() -> anyhow::Result<()> {
 
     // Load environment variables
     dotenvy::dotenv().ok();
+
+    // Initialize Prometheus metrics exporter
+    let prometheus_port = std::env::var("PROMETHEUS_PORT")
+        .unwrap_or_else(|_| "9090".to_string())
+        .parse::<u16>()
+        .unwrap_or(9090);
+
+    PrometheusBuilder::new()
+        .with_http_listener(SocketAddr::from(([0, 0, 0, 0], prometheus_port)))
+        .install()
+        .expect("failed to install Prometheus exporter");
+
+    tracing::info!("Prometheus metrics available on port {}", prometheus_port);
+
+    // Initialize metric descriptions
+    metrics::init_prometheus_metrics();
 
     // Configure rate limiting
     let per_second = std::env::var("RATE_LIMIT_PER_SECOND")
@@ -109,6 +126,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .route("/health", get(health::health_handler))
         .route("/metrics", get(metrics_handler))
+        .route("/metrics/prometheus", get(prometheus_metrics_handler))
         .layer(GovernorLayer {
             config: governor_conf,
         })

--- a/services/indexer/src/metrics.rs
+++ b/services/indexer/src/metrics.rs
@@ -4,6 +4,7 @@
 //! to enable proactive monitoring and alerting.
 
 use chrono::{DateTime, Utc};
+use metrics::{describe_gauge, gauge};
 use serde::Serialize;
 use sqlx::{PgPool, Row};
 
@@ -27,6 +28,23 @@ pub struct CursorMetrics {
 /// Threshold in seconds after which a cursor is considered stale.
 /// Default: 5 minutes (60 ledgers at 5s per ledger).
 pub const CURSOR_STALE_THRESHOLD_SECONDS: i64 = 300;
+
+/// Initialize Prometheus metrics descriptions.
+///
+/// Call this once at application startup to register metric metadata.
+pub fn init_prometheus_metrics() {
+    describe_gauge!("indexer_lag_blocks", "Number of ledgers behind chain head");
+    describe_gauge!("indexer_lag_seconds", "Estimated seconds behind chain head");
+}
+
+/// Record lag metrics for Prometheus export.
+///
+/// Updates the Prometheus gauges with current lag values.
+/// These metrics are exposed via the `/metrics` endpoint in Prometheus text format.
+pub fn record_lag(lag_blocks: i64, lag_seconds: i64) {
+    gauge!("indexer_lag_blocks").set(lag_blocks as f64);
+    gauge!("indexer_lag_seconds").set(lag_seconds as f64);
+}
 
 /// Fetch cursor staleness metrics for all ingestion streams.
 ///

--- a/services/prometheus.yml
+++ b/services/prometheus.yml
@@ -37,11 +37,11 @@ scrape_configs:
         regex: '([^:]+)(?::\d+)?'
         replacement: '$1'
 
-  - job_name: indexer
+  - job_name: ancore-indexer
     metrics_path: /metrics
     scrape_interval: 15s
     static_configs:
-      - targets: ['indexer:8081']
+      - targets: ['indexer:9090']
     relabel_configs:
       - source_labels: [__address__]
         target_label: instance


### PR DESCRIPTION
This closes #566 

- Add metrics and metrics-exporter-prometheus dependencies
- Expose indexer_lag_blocks and indexer_lag_seconds gauges
- Initialize Prometheus HTTP listener on port 9090 (configurable)
- Update lag metrics on each health check call
- Configure Prometheus scraper to target indexer:9090
- Document Prometheus metrics in README with examples

## Summary

Expose a Prometheus `/metrics` endpoint on the indexer reporting ingest lag gauges.

## Background

The indexer already has GET /health with lag fields. Prometheus config at services/prometheus.yml had no scrape target for the indexer yet. This PR is independent of cursor serializer tests (#477).

## Changes

### Files Modified
- **services/indexer/Cargo.toml**: Added metrics and metrics-exporter-prometheus dependencies
- **services/indexer/src/metrics.rs**: Added `init_prometheus_metrics()` and `record_lag()` functions
- **services/indexer/src/main.rs**: Initialize Prometheus exporter with HTTP listener on port 9090
- **services/indexer/src/api/health.rs**: Update Prometheus metrics on each health check
- **services/indexer/src/api/metrics.rs**: Added documentation for Prometheus endpoint
- **services/prometheus.yml**: Added scrape job for ancore-indexer targeting port 9090
- **services/indexer/README.md**: Documented Prometheus metrics with examples

### Files Created
- **PROMETHEUS_METRICS_IMPLEMENTATION.md**: Detailed implementation documentation

## Implementation

### Metrics Module
```rust
// services/indexer/src/metrics.rs
use metrics::{describe_gauge, gauge};

pub fn record_lag(lag_blocks: i64, lag_seconds: i64) {
    gauge!("indexer_lag_blocks").set(lag_blocks as f64);
    gauge!("indexer_lag_seconds").set(lag_seconds as f64);
}

pub fn init_prometheus_metrics() {
    describe_gauge!("indexer_lag_blocks", "Number of ledgers behind chain head");
    describe_gauge!("indexer_lag_seconds", "Estimated seconds behind chain head");
}
```

### Main Entry Point
```rust
// services/indexer/src/main.rs
use metrics_exporter_prometheus::PrometheusBuilder;

// Initialize Prometheus metrics exporter
let prometheus_port = std::env::var("PROMETHEUS_PORT")
    .unwrap_or_else(|_| "9090".to_string())
    .parse::<u16>()
    .unwrap_or(9090);

PrometheusBuilder::new()
    .with_http_listener(SocketAddr::from(([0, 0, 0, 0], prometheus_port)))
    .install()
    .expect("failed to install Prometheus exporter");

metrics::init_prometheus_metrics();
```

### Health Handler Integration
```rust
// services/indexer/src/api/health.rs
use crate::metrics::record_lag;

// Update Prometheus metrics
record_lag(lag_blocks, lag_seconds);
```

### Prometheus Configuration
```yaml
# services/prometheus.yml (scrape job added)
scrape_configs:
  - job_name: ancore-indexer
    metrics_path: /metrics
    scrape_interval: 15s
    static_configs:
      - targets: ['indexer:9090']
```

## Acceptance Criteria

- ✅ GET /metrics returns Prometheus text format
- ✅ Lag gauges updated on health/ingest tick (via health handler)
- ✅ Prometheus configuration updated with indexer scrape target
- ✅ Documented in services/indexer/README.md

## Testing

### Manual Testing
```bash
# Check Prometheus metrics endpoint
curl -s localhost:9090/metrics

# Expected output:
# HELP indexer_lag_blocks Number of ledgers behind chain head
# TYPE indexer_lag_blocks gauge
indexer_lag_blocks 0

# HELP indexer_lag_seconds Estimated seconds behind chain head
# TYPE indexer_lag_seconds gauge
indexer_lag_seconds 0
```

### Validate Prometheus Config
```bash
promtool check config services/prometheus.yml
```

## Configuration

### Environment Variables
- `PROMETHEUS_PORT`: Port for Prometheus metrics endpoint (default: 9090)

### Deployment Notes
1. Ensure port 9090 is exposed in Docker/Kubernetes configuration
2. Update Prometheus scraper to target `indexer:9090`
3. Metrics are automatically populated when the `/health` endpoint is called

## Architecture

The implementation follows best practices:

1. **Separate Ports**: API runs on port 3000, Prometheus metrics on port 9090
2. **Automatic Updates**: Metrics are updated on every health check call
3. **Standard Format**: Uses Prometheus text format for scraping
4. **Configurable**: Port is configurable via `PROMETHEUS_PORT` environment variable
5. **Non-blocking**: Metrics recording is synchronous and fast

## Metrics Exposed

| Metric Name | Type | Description |
|-------------|------|-------------|
| `indexer_lag_blocks` | gauge | Number of ledgers the indexer is behind the chain head |
| `indexer_lag_seconds` | gauge | Estimated seconds the indexer is behind the chain head (lag_blocks × 5) |

## Labels

- enhancement
- medium
- developer-experience
- infrastructure

## Impact Area

Infrastructure

## Related Issues

- Independent of cursor serializer tests (#477)
- Part of Stellar Wave initiative
- Enhances developer experience and infrastructure monitoring



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prometheus metrics endpoint now available on a dedicated port (configurable via `PROMETHEUS_PORT`, defaults to 9090)
  * Health check endpoint automatically records lag metrics (blocks and seconds)

* **Documentation**
  * README updated with Prometheus metrics documentation, including metric names, configuration, and curl examples
  * Added comprehensive Prometheus metrics implementation documentation file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->