### PR TITLE
feat(#781): Keychain production storage adapter for mobile wallet

### DIFF
--- a/apps/mobile-wallet/AGENTS.md
+++ b/apps/mobile-wallet/AGENTS.md
@@ -134,7 +134,7 @@ HistoryScreen → usePaginatedTransactionHistory → TransactionHistoryAdapter
 | Biometric | Keychain            | Password blob for biometric unlock        |
 | Data      | AsyncStorage        | Account metadata, prefs — **never seeds** |
 
-**Today:** `MemorySecureStoreAdapter` for tests only — production needs `react-native-keychain`.
+**Today:** `KeychainSecureStoreAdapter` (`react-native-keychain`) for production, `MemorySecureStoreAdapter` for tests. Pick via `createSecureStoreAdapter()`. Tier rules: [docs/secure-storage.md](./docs/secure-storage.md). Device cold-start QA needs the host app (#780).
 
 **Vault duplication gap:** `MobileSecureVault` parallels `@ancore/core-sdk` `SecureStorageManager` but is not shared with the extension. Unify before shipping.
 

--- a/apps/mobile-wallet/README.md
+++ b/apps/mobile-wallet/README.md
@@ -119,7 +119,7 @@ interface TransactionHistoryAdapter {
 
 - `accounts/` - Account management and key storage
 - `security/` - Encryption and authentication
-- `storage/` - Secure persistent storage
+- `storage/` - Secure persistent storage (Keychain in production, in-memory under tests — see [docs/secure-storage.md](./docs/secure-storage.md))
 - `sdk/` - Stellar SDK integration
 
 ## Testing

--- a/apps/mobile-wallet/docs/secure-storage.md
+++ b/apps/mobile-wallet/docs/secure-storage.md
@@ -1,0 +1,69 @@
+# Mobile Wallet Secure Storage
+
+The mobile wallet separates persisted data into two tiers. **Which tier a field
+lives in is a security boundary, not a preference.**
+
+## Storage tiers
+
+| Tier             | Backend                                       | Adapter                        | Contents                                                                 |
+| ---------------- | --------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------ |
+| **Secure**       | iOS Keychain / Android Keystore               | `KeychainSecureStoreAdapter`   | Mnemonics, private/key material, the encrypted vault state & account blobs |
+| **Data**         | AsyncStorage (added with the host app, #780)  | _not the secure adapter_       | Non-sensitive account metadata, UI preferences, last-selected network    |
+
+### The rule
+
+> **Never** store a mnemonic, private key, or any unencrypted key material in
+> AsyncStorage. Seeds and key material live in the Keychain only — this mirrors
+> Freighter Mobile's `storageFactory` Secure/Data tier split.
+
+Concretely, everything written through `SecureStoreAdapter` (e.g.
+`mobile_vault_state`, `mobile_vault_accounts` from `MobileSecureVault`) belongs
+in the Keychain. AsyncStorage may only hold values that would be harmless if read
+off a compromised device — display labels, the selected network name, feature
+flags. When in doubt, put it in the secure tier.
+
+## Adapters
+
+| Adapter                      | When                              | Persistence                       |
+| ---------------------------- | --------------------------------- | --------------------------------- |
+| `KeychainSecureStoreAdapter` | Production (device / simulator)   | Survives cold start (Keychain)    |
+| `MemorySecureStoreAdapter`   | Jest unit tests                   | In-memory; lost on restart        |
+
+Select the right one with the factory — it returns the memory adapter under Jest
+(where the native Keychain bridge is unavailable) and the Keychain adapter
+otherwise:
+
+```typescript
+import { createSecureStoreAdapter, MobileSecureVault } from '@ancore/mobile-wallet';
+
+const store = createSecureStoreAdapter();
+const vault = new MobileSecureVault(store);
+```
+
+### Keychain service scoping
+
+Keychain entries are namespaced by bundle ID so production and development builds
+installed on the same device never share secrets:
+
+- Production: `org.ancore.wallet`
+- Development: `org.ancore.wallet.dev`
+
+Each logical key is stored under `<bundleId>.<key>` (for example
+`org.ancore.wallet.mobile_vault_state`). Because Keychain has no "list all
+entries" primitive, the adapter maintains a small `__keys__` index entry so
+`clear()` can reset every key it has written.
+
+### Serialization
+
+`SecureStoreAdapter` stores structured objects, while Keychain stores strings, so
+the Keychain adapter JSON-serializes values on write and parses them on read.
+
+## Device validation (requires host app #780)
+
+Unit tests cover the adapter with a mocked `react-native-keychain`. The remaining
+acceptance criterion — _vault persists across cold start_ — requires the React
+Native host app and is validated as manual QA:
+
+1. Create or import a wallet, then fully terminate the app.
+2. Relaunch and confirm the vault unlocks with the existing password and that
+   accounts are still present.

--- a/apps/mobile-wallet/jest.config.cjs
+++ b/apps/mobile-wallet/jest.config.cjs
@@ -12,6 +12,7 @@ module.exports = {
   collectCoverageFrom: [
     'src/**/*.ts',
     'src/**/*.tsx',
+    '!src/**/*.d.ts',
     '!src/**/__tests__/**',
     '!src/index.ts',
     '!src/test/**',

--- a/apps/mobile-wallet/jest.setup.ts
+++ b/apps/mobile-wallet/jest.setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+
+// `react-native-keychain` is a native module that is not installed in this
+// standalone library package (it arrives with the host app, #780). Register a
+// virtual mock so any module importing the storage barrel — which re-exports the
+// Keychain adapter — resolves in unit tests. Suites that assert on Keychain calls
+// override this with their own `jest.mock` factory.
+jest.mock(
+  'react-native-keychain',
+  () => ({
+    getGenericPassword: jest.fn().mockResolvedValue(false),
+    setGenericPassword: jest.fn().mockResolvedValue({ service: '', storage: 'keychain' }),
+    resetGenericPassword: jest.fn().mockResolvedValue(true),
+  }),
+  { virtual: true }
+);

--- a/apps/mobile-wallet/src/storage/__tests__/keychain-secure-store-adapter.test.ts
+++ b/apps/mobile-wallet/src/storage/__tests__/keychain-secure-store-adapter.test.ts
@@ -1,0 +1,205 @@
+import * as Keychain from 'react-native-keychain';
+
+import {
+  DEV_BUNDLE_ID,
+  KEYCHAIN_USERNAME,
+  KeychainSecureStoreAdapter,
+  PROD_BUNDLE_ID,
+} from '../keychain-secure-store-adapter';
+
+// react-native-keychain is a native module; mock it virtually since it is not
+// installed in this standalone library package (it ships with the host app #780).
+jest.mock(
+  'react-native-keychain',
+  () => ({
+    getGenericPassword: jest.fn(),
+    setGenericPassword: jest.fn(),
+    resetGenericPassword: jest.fn(),
+  }),
+  { virtual: true }
+);
+
+const mockKeychain = Keychain as jest.Mocked<typeof Keychain>;
+
+/**
+ * Builds an in-memory fake of the Keychain native module so multi-step flows
+ * (set → cold start → get) can be exercised without a device.
+ */
+function installKeychainFake(): Map<string, string> {
+  const store = new Map<string, string>();
+
+  mockKeychain.setGenericPassword.mockImplementation(
+    async (_username: string, password: string, options?: { service?: string }) => {
+      store.set(options?.service ?? '', password);
+      return { service: options?.service ?? '', storage: 'keychain' };
+    }
+  );
+
+  mockKeychain.getGenericPassword.mockImplementation(async (options?: { service?: string }) => {
+    const service = options?.service ?? '';
+
+    if (!store.has(service)) {
+      return false;
+    }
+
+    return { service, username: KEYCHAIN_USERNAME, password: store.get(service) as string };
+  });
+
+  mockKeychain.resetGenericPassword.mockImplementation(async (options?: { service?: string }) => {
+    return store.delete(options?.service ?? '');
+  });
+
+  return store;
+}
+
+describe('KeychainSecureStoreAdapter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('writes values to the bundle-scoped Keychain service', async () => {
+    mockKeychain.setGenericPassword.mockResolvedValue({
+      service: `${PROD_BUNDLE_ID}.vault_key`,
+      storage: 'keychain',
+    });
+    mockKeychain.getGenericPassword.mockResolvedValue(false);
+
+    const adapter = new KeychainSecureStoreAdapter({ bundleId: PROD_BUNDLE_ID });
+    await adapter.set('vault_key', 'encrypted_data');
+
+    expect(mockKeychain.setGenericPassword).toHaveBeenCalledWith(
+      KEYCHAIN_USERNAME,
+      JSON.stringify('encrypted_data'),
+      { service: 'org.ancore.wallet.vault_key' }
+    );
+  });
+
+  it('returns null when no entry exists', async () => {
+    mockKeychain.getGenericPassword.mockResolvedValue(false);
+
+    const adapter = new KeychainSecureStoreAdapter({ bundleId: PROD_BUNDLE_ID });
+
+    await expect(adapter.get('missing')).resolves.toBeNull();
+    expect(mockKeychain.getGenericPassword).toHaveBeenCalledWith({
+      service: 'org.ancore.wallet.missing',
+    });
+  });
+
+  it('round-trips structured vault state through JSON serialization', async () => {
+    installKeychainFake();
+
+    const adapter = new KeychainSecureStoreAdapter({ bundleId: PROD_BUNDLE_ID });
+    const vaultState = {
+      version: 1 as const,
+      masterSalt: 'c2FsdA==',
+      verification: { iv: 'aXY=', salt: 'c2FsdA==', data: 'ZGF0YQ==' },
+    };
+
+    await adapter.set('mobile_vault_state', vaultState);
+
+    // Simulate a cold start with a fresh adapter instance over the same store.
+    const restarted = new KeychainSecureStoreAdapter({ bundleId: PROD_BUNDLE_ID });
+
+    await expect(restarted.get('mobile_vault_state')).resolves.toEqual(vaultState);
+  });
+
+  it('removes an entry by resetting its service', async () => {
+    const store = installKeychainFake();
+
+    const adapter = new KeychainSecureStoreAdapter({ bundleId: PROD_BUNDLE_ID });
+    await adapter.set('mobile_vault_state', { secret: true });
+    await adapter.remove('mobile_vault_state');
+
+    expect(mockKeychain.resetGenericPassword).toHaveBeenCalledWith({
+      service: 'org.ancore.wallet.mobile_vault_state',
+    });
+    expect(store.has('org.ancore.wallet.mobile_vault_state')).toBe(false);
+    await expect(adapter.get('mobile_vault_state')).resolves.toBeNull();
+  });
+
+  it('clears every previously written key plus the index', async () => {
+    const store = installKeychainFake();
+
+    const adapter = new KeychainSecureStoreAdapter({ bundleId: PROD_BUNDLE_ID });
+    await adapter.set('mobile_vault_state', { a: 1 });
+    await adapter.set('mobile_vault_accounts', { b: 2 });
+
+    await adapter.clear();
+
+    expect(mockKeychain.resetGenericPassword).toHaveBeenCalledWith({
+      service: 'org.ancore.wallet.mobile_vault_state',
+    });
+    expect(mockKeychain.resetGenericPassword).toHaveBeenCalledWith({
+      service: 'org.ancore.wallet.mobile_vault_accounts',
+    });
+    expect(mockKeychain.resetGenericPassword).toHaveBeenCalledWith({
+      service: 'org.ancore.wallet.__keys__',
+    });
+    expect(store.size).toBe(0);
+  });
+
+  it('scopes the service name to the dev bundle ID when configured', async () => {
+    mockKeychain.getGenericPassword.mockResolvedValue(false);
+    mockKeychain.setGenericPassword.mockResolvedValue({
+      service: `${DEV_BUNDLE_ID}.k`,
+      storage: 'keychain',
+    });
+
+    const adapter = new KeychainSecureStoreAdapter({ bundleId: DEV_BUNDLE_ID });
+    await adapter.set('k', 'v');
+
+    expect(mockKeychain.setGenericPassword).toHaveBeenCalledWith(
+      KEYCHAIN_USERNAME,
+      JSON.stringify('v'),
+      { service: 'org.ancore.wallet.dev.k' }
+    );
+  });
+
+  it('defaults to the production bundle ID when none is provided', async () => {
+    installKeychainFake();
+
+    const adapter = new KeychainSecureStoreAdapter();
+    await adapter.set('k', 'v');
+
+    expect(mockKeychain.setGenericPassword).toHaveBeenCalledWith(
+      KEYCHAIN_USERNAME,
+      JSON.stringify('v'),
+      { service: `${PROD_BUNDLE_ID}.k` }
+    );
+  });
+
+  it('defaults to the development bundle ID when __DEV__ is set', async () => {
+    installKeychainFake();
+    (globalThis as { __DEV__?: boolean }).__DEV__ = true;
+
+    try {
+      const adapter = new KeychainSecureStoreAdapter();
+      await adapter.set('k', 'v');
+
+      expect(mockKeychain.setGenericPassword).toHaveBeenCalledWith(
+        KEYCHAIN_USERNAME,
+        JSON.stringify('v'),
+        { service: `${DEV_BUNDLE_ID}.k` }
+      );
+    } finally {
+      delete (globalThis as { __DEV__?: boolean }).__DEV__;
+    }
+  });
+
+  it('tolerates a corrupt key index without throwing', async () => {
+    mockKeychain.getGenericPassword.mockResolvedValue({
+      service: `${PROD_BUNDLE_ID}.__keys__`,
+      username: KEYCHAIN_USERNAME,
+      password: 'not-json',
+    });
+    mockKeychain.resetGenericPassword.mockResolvedValue(true);
+
+    const adapter = new KeychainSecureStoreAdapter({ bundleId: PROD_BUNDLE_ID });
+
+    await expect(adapter.clear()).resolves.toBeUndefined();
+    // Falls back to clearing just the index service.
+    expect(mockKeychain.resetGenericPassword).toHaveBeenCalledWith({
+      service: 'org.ancore.wallet.__keys__',
+    });
+  });
+});

--- a/apps/mobile-wallet/src/storage/__tests__/secure-store-factory.test.ts
+++ b/apps/mobile-wallet/src/storage/__tests__/secure-store-factory.test.ts
@@ -1,0 +1,47 @@
+import { KeychainSecureStoreAdapter, PROD_BUNDLE_ID } from '../keychain-secure-store-adapter';
+import { MemorySecureStoreAdapter } from '../mobile-secure-storage-adapter';
+import { createSecureStoreAdapter, isJestEnvironment } from '../secure-store-factory';
+
+jest.mock(
+  'react-native-keychain',
+  () => ({
+    getGenericPassword: jest.fn().mockResolvedValue(false),
+    setGenericPassword: jest.fn().mockResolvedValue({ service: 's', storage: 'keychain' }),
+    resetGenericPassword: jest.fn().mockResolvedValue(true),
+  }),
+  { virtual: true }
+);
+
+describe('createSecureStoreAdapter', () => {
+  it('detects the Jest environment', () => {
+    expect(isJestEnvironment()).toBe(true);
+  });
+
+  it('returns the in-memory adapter under Jest', () => {
+    const adapter = createSecureStoreAdapter();
+
+    expect(adapter).toBeInstanceOf(MemorySecureStoreAdapter);
+    expect(adapter).not.toBeInstanceOf(KeychainSecureStoreAdapter);
+  });
+
+  it('returns the Keychain adapter when production is forced', () => {
+    const adapter = createSecureStoreAdapter({ forceProduction: true, bundleId: PROD_BUNDLE_ID });
+
+    expect(adapter).toBeInstanceOf(KeychainSecureStoreAdapter);
+  });
+
+  it('wires the forced Keychain adapter to the native module', async () => {
+    const Keychain = jest.requireMock('react-native-keychain') as {
+      setGenericPassword: jest.Mock;
+    };
+
+    const adapter = createSecureStoreAdapter({ forceProduction: true, bundleId: PROD_BUNDLE_ID });
+    await adapter.set('vault_key', 'encrypted_data');
+
+    expect(Keychain.setGenericPassword).toHaveBeenCalledWith(
+      'ancore',
+      JSON.stringify('encrypted_data'),
+      { service: 'org.ancore.wallet.vault_key' }
+    );
+  });
+});

--- a/apps/mobile-wallet/src/storage/index.ts
+++ b/apps/mobile-wallet/src/storage/index.ts
@@ -1,2 +1,4 @@
+export * from './keychain-secure-store-adapter';
 export * from './mobile-secure-storage-adapter';
+export * from './secure-store-factory';
 export * from './types';

--- a/apps/mobile-wallet/src/storage/keychain-secure-store-adapter.ts
+++ b/apps/mobile-wallet/src/storage/keychain-secure-store-adapter.ts
@@ -1,0 +1,139 @@
+import * as Keychain from 'react-native-keychain';
+
+import { SecureStoreAdapter } from './types';
+
+/**
+ * Username stored alongside every Keychain entry. Keychain requires a username,
+ * but the adapter keys data by `service`, so the username is a constant marker.
+ */
+export const KEYCHAIN_USERNAME = 'ancore';
+
+/**
+ * Keychain service names are scoped per bundle ID so the production and
+ * development builds never read or overwrite each other's secrets on a device
+ * that has both installed (mirrors Freighter's per-bundle keychain scoping).
+ */
+export const PROD_BUNDLE_ID = 'org.ancore.wallet';
+export const DEV_BUNDLE_ID = 'org.ancore.wallet.dev';
+
+/**
+ * Reserved logical key used to persist the set of keys this adapter has written.
+ * Keychain has no "enumerate entries" primitive, so we maintain a small index to
+ * support {@link KeychainSecureStoreAdapter.clear}.
+ */
+const KEY_INDEX = '__keys__';
+
+declare const __DEV__: boolean | undefined;
+
+const resolveDefaultBundleId = (): string => {
+  // `__DEV__` is injected by the React Native bundler; true in dev builds.
+  if (typeof __DEV__ !== 'undefined' && __DEV__) {
+    return DEV_BUNDLE_ID;
+  }
+
+  return PROD_BUNDLE_ID;
+};
+
+export interface KeychainSecureStoreAdapterOptions {
+  /**
+   * Bundle ID used to namespace Keychain service names. Defaults to the
+   * production bundle ID, or the dev bundle ID when `__DEV__` is set.
+   */
+  bundleId?: string;
+}
+
+/**
+ * Production {@link SecureStoreAdapter} backed by `react-native-keychain`.
+ *
+ * Secrets persisted here survive app cold starts (unlike
+ * {@link MemorySecureStoreAdapter}) and are stored in the iOS Keychain /
+ * Android Keystore. Values are JSON-serialized because the secure store holds
+ * structured vault state, while Keychain only stores strings.
+ *
+ * **Storage rule:** mnemonics, key material, and the encrypted vault blobs go
+ * here — never in AsyncStorage. Only non-sensitive metadata/preferences belong
+ * in AsyncStorage. See `apps/mobile-wallet/docs/secure-storage.md`.
+ */
+export class KeychainSecureStoreAdapter implements SecureStoreAdapter {
+  private readonly bundleId: string;
+
+  constructor(options: KeychainSecureStoreAdapterOptions = {}) {
+    this.bundleId = options.bundleId ?? resolveDefaultBundleId();
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    const result = await Keychain.getGenericPassword({ service: this.serviceFor(key) });
+
+    if (!result) {
+      return null;
+    }
+
+    return JSON.parse(result.password) as T;
+  }
+
+  async set<T>(key: string, value: T): Promise<void> {
+    await Keychain.setGenericPassword(KEYCHAIN_USERNAME, JSON.stringify(value), {
+      service: this.serviceFor(key),
+    });
+
+    await this.indexAdd(key);
+  }
+
+  async remove(key: string): Promise<void> {
+    await Keychain.resetGenericPassword({ service: this.serviceFor(key) });
+    await this.indexRemove(key);
+  }
+
+  async clear(): Promise<void> {
+    const keys = await this.readIndex();
+
+    await Promise.all(
+      keys.map((key) => Keychain.resetGenericPassword({ service: this.serviceFor(key) }))
+    );
+
+    await Keychain.resetGenericPassword({ service: this.serviceFor(KEY_INDEX) });
+  }
+
+  /** Bundle-scoped Keychain service name for a logical key. */
+  private serviceFor(key: string): string {
+    return `${this.bundleId}.${key}`;
+  }
+
+  private async readIndex(): Promise<string[]> {
+    const result = await Keychain.getGenericPassword({ service: this.serviceFor(KEY_INDEX) });
+
+    if (!result) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(result.password);
+      return Array.isArray(parsed) ? (parsed as string[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private async writeIndex(keys: string[]): Promise<void> {
+    await Keychain.setGenericPassword(KEYCHAIN_USERNAME, JSON.stringify(keys), {
+      service: this.serviceFor(KEY_INDEX),
+    });
+  }
+
+  private async indexAdd(key: string): Promise<void> {
+    const keys = await this.readIndex();
+
+    if (!keys.includes(key)) {
+      await this.writeIndex([...keys, key]);
+    }
+  }
+
+  private async indexRemove(key: string): Promise<void> {
+    const keys = await this.readIndex();
+    const next = keys.filter((existing) => existing !== key);
+
+    if (next.length !== keys.length) {
+      await this.writeIndex(next);
+    }
+  }
+}

--- a/apps/mobile-wallet/src/storage/react-native-keychain.d.ts
+++ b/apps/mobile-wallet/src/storage/react-native-keychain.d.ts
@@ -1,0 +1,47 @@
+/**
+ * Minimal ambient declaration for the subset of `react-native-keychain` used by
+ * {@link KeychainSecureStoreAdapter}.
+ *
+ * The native module is only available once the React Native host app (#780) wires
+ * in `react-native-keychain`. This package builds and unit-tests as a standalone
+ * TypeScript library, so we declare the surface we depend on rather than taking a
+ * hard dependency on the native package. The real package ships its own (richer)
+ * types and is resolved at runtime on device/simulator; Jest mocks it virtually.
+ */
+declare module 'react-native-keychain' {
+  export interface GenericPasswordResult {
+    service: string;
+    username: string;
+    password: string;
+    storage?: string;
+  }
+
+  export interface SetOptions {
+    service?: string;
+    accessGroup?: string;
+    accessible?: string;
+    accessControl?: string;
+    securityLevel?: string;
+  }
+
+  export interface GetOptions {
+    service?: string;
+    accessGroup?: string;
+    authenticationPrompt?: string | { title?: string };
+  }
+
+  export interface ResetOptions {
+    service?: string;
+    accessGroup?: string;
+  }
+
+  export function setGenericPassword(
+    username: string,
+    password: string,
+    options?: SetOptions
+  ): Promise<false | { service: string; storage: string }>;
+
+  export function getGenericPassword(options?: GetOptions): Promise<false | GenericPasswordResult>;
+
+  export function resetGenericPassword(options?: ResetOptions): Promise<boolean>;
+}

--- a/apps/mobile-wallet/src/storage/secure-store-factory.ts
+++ b/apps/mobile-wallet/src/storage/secure-store-factory.ts
@@ -1,0 +1,47 @@
+import {
+  KeychainSecureStoreAdapter,
+  type KeychainSecureStoreAdapterOptions,
+} from './keychain-secure-store-adapter';
+import { MemorySecureStoreAdapter } from './mobile-secure-storage-adapter';
+import { SecureStoreAdapter } from './types';
+
+/**
+ * Detects whether the current process is a Jest test run.
+ *
+ * `react-native-keychain` is a native module that Jest never calls, so the
+ * factory falls back to the in-memory adapter under test.
+ */
+export function isJestEnvironment(): boolean {
+  return (
+    typeof jest !== 'undefined' ||
+    (typeof process !== 'undefined' && process.env?.JEST_WORKER_ID !== undefined)
+  );
+}
+
+export interface CreateSecureStoreAdapterOptions extends KeychainSecureStoreAdapterOptions {
+  /**
+   * Force the production Keychain adapter even under Jest. Used to unit-test the
+   * Keychain adapter wiring with a mocked native module.
+   */
+  forceProduction?: boolean;
+}
+
+/**
+ * Returns the appropriate {@link SecureStoreAdapter} for the current environment:
+ *
+ * - **Production (device/simulator):** {@link KeychainSecureStoreAdapter}, which
+ *   persists secrets in the iOS Keychain / Android Keystore across cold starts.
+ * - **Jest:** {@link MemorySecureStoreAdapter}, since the native Keychain bridge
+ *   is unavailable in unit tests.
+ */
+export function createSecureStoreAdapter(
+  options: CreateSecureStoreAdapterOptions = {}
+): SecureStoreAdapter {
+  const { forceProduction, ...keychainOptions } = options;
+
+  if (!forceProduction && isJestEnvironment()) {
+    return new MemorySecureStoreAdapter();
+  }
+
+  return new KeychainSecureStoreAdapter(keychainOptions);
+}


### PR DESCRIPTION
## Description

Replaces the in-memory-only secure store with a production `react-native-keychain`-backed adapter so vault secrets survive app cold starts (`MemorySecureStoreAdapter` lost all data on every restart).

- **`KeychainSecureStoreAdapter`** implements the existing `SecureStoreAdapter` interface (`get<T>`/`set<T>`/`remove`/`clear`). Keychain stores strings only, so structured vault state is JSON-serialized on write and parsed on read.
- **Per-bundle service scoping:** Keychain service names are namespaced by bundle ID — `org.ancore.wallet` (prod) / `org.ancore.wallet.dev` (dev) — so prod and dev builds on the same device never share secrets. Each logical key is stored under `<bundleId>.<key>`.
- **`createSecureStoreAdapter()`** returns the Keychain adapter in production and `MemorySecureStoreAdapter` under Jest, where the native bridge is unavailable.
- **`clear()`** is supported via a small `__keys__` index entry, since Keychain has no "enumerate entries" primitive.

### Note on the interface

This repo's `SecureStoreAdapter` is generic (`get<T>`/`set<T>`/`remove`/`clear`) and stores structured objects, which differs from the string-only sketch in the issue. The adapter is implemented against the real interface and JSON-serializes values accordingly.

### Building without the native package

The mobile-wallet package is a standalone TypeScript library with no host app yet (#780), so `react-native-keychain` is not installed. A minimal ambient module declaration lets the library build and type-check; the real native package resolves at runtime on device once the host app wires it in. Jest mocks the module virtually.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Security Impact

- [x] This change handles user private keys

Mnemonics, key material, and the encrypted vault blobs are stored in the iOS Keychain / Android Keystore only — never in AsyncStorage. The tier rules are documented in `apps/mobile-wallet/docs/secure-storage.md`.

## Testing

- [x] Unit tests added/updated

`corepack pnpm --filter @ancore/mobile-wallet test` — 140 passing. New suites:

- `keychain-secure-store-adapter.test.ts` — set/get/remove/clear round-trips (incl. a simulated cold start), per-bundle service scoping, default `__DEV__` bundle resolution, key-index handling, corrupt-index tolerance. 100% line coverage on the adapter.
- `secure-store-factory.test.ts` — Jest-vs-production selection and native-module wiring.

### Manual Testing Steps (requires host app #780)

1. Create/import a wallet, then fully terminate the app.
2. Relaunch and confirm the vault unlocks and accounts persist across the cold start.

## Acceptance criteria

- [x] `KeychainSecureStoreAdapter` unit tests pass with mocked `react-native-keychain`
- [x] Factory returns memory adapter in Jest environment
- [x] Keychain service name scoped per bundle ID
- [ ] Vault persists across cold start on device — manual QA, requires host app #780

## Related Issues

Closes #781
Related to #780, #782

## Additional Context

Pre-existing, unrelated build/test failures in this package (`src/config/environment.ts` type errors, `@ancore/core-sdk` dist ESM parsing in `bootstrap`/`sdk` test suites) are not addressed here and exist on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture notes detailing secure storage implementation for production and testing environments
  * Added comprehensive secure storage guide including Keychain usage, configuration, and device validation steps

* **New Features**
  * Implemented Keychain-based secure persistent storage for production environments
  * Added environment-aware storage adapter that automatically selects between Keychain and in-memory implementations

* **Tests**
  * Added test coverage for Keychain-based secure storage functionality
  * Updated Jest configuration to mock native Keychain module and exclude TypeScript declarations from coverage reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->