### PR TITLE
Feature/fx endpoints

### DIFF
--- a/apps/extension-wallet/vitest.config.ts
+++ b/apps/extension-wallet/vitest.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
       ['src/security/__tests__/extension-storage-encryption.test.ts', 'node'],
     ],
     setupFiles: ['../../packages/ensure-webcrypto.ts', './src/test/setup.ts'],
-    testTimeout: 30000,
+    testTimeout: 60000,
+    hookTimeout: 20000,
     css: true,
     fileParallelism: process.env.CI !== 'true',
     exclude: [

--- a/services/relayer/src/fx/FxService.ts
+++ b/services/relayer/src/fx/FxService.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from 'crypto';
+import { FxStore } from './FxStore';
+import type {
+  ExchangeRate,
+  FxQuote,
+  ConversionRecord,
+  CreateExchangeRateInput,
+  CreateQuoteInput,
+} from './types';
+
+const DEFAULT_QUOTE_TTL_MS = 30_000;
+
+export class FxService {
+  constructor(
+    private readonly store: FxStore,
+    private readonly quoteTtlMs: number = DEFAULT_QUOTE_TTL_MS
+  ) {}
+
+  listRates(from?: string, to?: string): ExchangeRate[] {
+    return this.store.listRates(from, to);
+  }
+
+  createQuote(input: CreateQuoteInput): FxQuote {
+    const { fromAsset, toAsset, amount } = input;
+    const rate = this.store.getRate(fromAsset, toAsset);
+    if (!rate) {
+      throw new FxError(`No active rate found for ${fromAsset} → ${toAsset}`, 'RATE_NOT_FOUND');
+    }
+
+    const numericAmount = parseFloat(amount);
+    const numericRate = parseFloat(rate.rate);
+    const convertedAmount = (numericAmount * numericRate).toFixed(7);
+
+    const quote: FxQuote = {
+      id: randomUUID(),
+      fromAsset,
+      toAsset,
+      amount,
+      convertedAmount,
+      rate: rate.rate,
+      expiresAt: new Date(Date.now() + this.quoteTtlMs).toISOString(),
+      used: false,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.store.saveQuote(quote);
+    return quote;
+  }
+
+  executeConversion(quoteId: string, walletId: string, callerId: string): ConversionRecord {
+    const quote = this.store.getQuote(quoteId);
+    if (!quote) {
+      throw new FxError('Quote not found', 'QUOTE_NOT_FOUND');
+    }
+    if (quote.used) {
+      throw new FxError('Quote has already been used', 'QUOTE_USED');
+    }
+    if (new Date(quote.expiresAt).getTime() < Date.now()) {
+      throw new FxError('Quote has expired', 'QUOTE_EXPIRED');
+    }
+
+    this.store.markQuoteUsed(quoteId);
+
+    const record: ConversionRecord = {
+      id: randomUUID(),
+      quoteId,
+      walletId,
+      callerId,
+      fromAsset: quote.fromAsset,
+      toAsset: quote.toAsset,
+      amount: quote.amount,
+      convertedAmount: quote.convertedAmount,
+      rate: quote.rate,
+      status: 'completed',
+      createdAt: new Date().toISOString(),
+    };
+
+    this.store.saveConversion(record);
+    return record;
+  }
+
+  listHistory(
+    callerId: string,
+    options: { limit: number; cursor?: string; fromDate?: string; toDate?: string }
+  ): { data: ConversionRecord[]; nextCursor?: string } {
+    return this.store.listConversions(callerId, options);
+  }
+
+  createRate(input: CreateExchangeRateInput): ExchangeRate {
+    return this.store.upsertRate(input);
+  }
+
+  deactivateRate(id: string): ExchangeRate {
+    const rate = this.store.deactivateRate(id);
+    if (!rate) {
+      throw new FxError('Exchange rate not found', 'RATE_NOT_FOUND');
+    }
+    return rate;
+  }
+}
+
+export class FxError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string
+  ) {
+    super(message);
+    this.name = 'FxError';
+  }
+}

--- a/services/relayer/src/fx/FxStore.ts
+++ b/services/relayer/src/fx/FxStore.ts
@@ -1,0 +1,131 @@
+import { randomUUID } from 'crypto';
+import type { ExchangeRate, FxQuote, ConversionRecord } from './types';
+
+export class FxStore {
+  private readonly rates = new Map<string, ExchangeRate>();
+  private readonly quotes = new Map<string, FxQuote>();
+  private readonly conversions: ConversionRecord[] = [];
+
+  // ── Rates ────────────────────────────────────────────────────────────────
+
+  listRates(from?: string, to?: string): ExchangeRate[] {
+    const all = [...this.rates.values()].filter((r) => r.active);
+    return all.filter((r) => {
+      if (from && r.fromAsset !== from) return false;
+      if (to && r.toAsset !== to) return false;
+      return true;
+    });
+  }
+
+  getRate(fromAsset: string, toAsset: string): ExchangeRate | undefined {
+    for (const rate of this.rates.values()) {
+      if (rate.fromAsset === fromAsset && rate.toAsset === toAsset && rate.active) {
+        return rate;
+      }
+    }
+    return undefined;
+  }
+
+  upsertRate(input: { fromAsset: string; toAsset: string; rate: string }): ExchangeRate {
+    const key = this.rateKey(input.fromAsset, input.toAsset);
+    const existing = this.rates.get(key);
+    const now = new Date().toISOString();
+
+    if (existing) {
+      const updated: ExchangeRate = {
+        ...existing,
+        rate: input.rate,
+        active: true,
+        updatedAt: now,
+      };
+      this.rates.set(key, updated);
+      return updated;
+    }
+
+    const rate: ExchangeRate = {
+      id: randomUUID(),
+      fromAsset: input.fromAsset,
+      toAsset: input.toAsset,
+      rate: input.rate,
+      active: true,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.rates.set(key, rate);
+    return rate;
+  }
+
+  deactivateRate(id: string): ExchangeRate | undefined {
+    for (const [key, rate] of this.rates.entries()) {
+      if (rate.id === id) {
+        const updated: ExchangeRate = {
+          ...rate,
+          active: false,
+          updatedAt: new Date().toISOString(),
+        };
+        this.rates.set(key, updated);
+        return updated;
+      }
+    }
+    return undefined;
+  }
+
+  // ── Quotes ───────────────────────────────────────────────────────────────
+
+  saveQuote(quote: FxQuote): void {
+    this.quotes.set(quote.id, quote);
+  }
+
+  getQuote(id: string): FxQuote | undefined {
+    return this.quotes.get(id);
+  }
+
+  markQuoteUsed(id: string): void {
+    const quote = this.quotes.get(id);
+    if (quote) {
+      this.quotes.set(id, { ...quote, used: true });
+    }
+  }
+
+  // ── Conversions ──────────────────────────────────────────────────────────
+
+  saveConversion(record: ConversionRecord): void {
+    this.conversions.push(record);
+  }
+
+  listConversions(
+    callerId: string,
+    options: { limit: number; cursor?: string; fromDate?: string; toDate?: string }
+  ): { data: ConversionRecord[]; nextCursor?: string } {
+    let filtered = this.conversions.filter((c) => c.callerId === callerId);
+
+    if (options.fromDate) {
+      const from = new Date(options.fromDate).getTime();
+      filtered = filtered.filter((c) => new Date(c.createdAt).getTime() >= from);
+    }
+    if (options.toDate) {
+      const to = new Date(options.toDate).getTime();
+      filtered = filtered.filter((c) => new Date(c.createdAt).getTime() <= to);
+    }
+
+    filtered.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+
+    if (options.cursor) {
+      const cursorIdx = filtered.findIndex((c) => c.id === options.cursor);
+      if (cursorIdx !== -1) {
+        filtered = filtered.slice(cursorIdx + 1);
+      }
+    }
+
+    const data = filtered.slice(0, options.limit);
+    const nextCursor = filtered.length > options.limit ? data[data.length - 1]?.id : undefined;
+
+    return { data, nextCursor };
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private rateKey(from: string, to: string): string {
+    return `${from}:${to}`;
+  }
+}

--- a/services/relayer/src/fx/handlers.ts
+++ b/services/relayer/src/fx/handlers.ts
@@ -1,0 +1,122 @@
+import { Request, Response } from 'express';
+import { FxService, FxError } from './FxService';
+import {
+  listRatesQuerySchema,
+  createQuoteSchema,
+  executeConversionSchema,
+  listHistoryQuerySchema,
+  createExchangeRateSchema,
+} from './schemas';
+
+function getCallerId(res: Response): string {
+  return res.locals['callerId'] as string;
+}
+
+function sendFxError(res: Response, err: FxError): void {
+  const status = err.code === 'RATE_NOT_FOUND' ? 404 : 422;
+  res.status(status).json({ error: err.code, message: err.message });
+}
+
+export function createListRatesHandler(service: FxService) {
+  return (req: Request, res: Response): void => {
+    const query = listRatesQuerySchema.safeParse(req.query);
+    if (!query.success) {
+      res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid query parameters' });
+      return;
+    }
+
+    const rates = service.listRates(query.data.from, query.data.to);
+    res.status(200).json({ data: rates });
+  };
+}
+
+export function createQuoteHandler(service: FxService) {
+  return (req: Request, res: Response): void => {
+    const parsed = createQuoteSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid request body' });
+      return;
+    }
+
+    try {
+      const quote = service.createQuote(parsed.data);
+      res.status(201).json({ data: quote });
+    } catch (err) {
+      if (err instanceof FxError) {
+        sendFxError(res, err);
+        return;
+      }
+      throw err;
+    }
+  };
+}
+
+export function createConvertHandler(service: FxService) {
+  return (req: Request, res: Response): void => {
+    const callerId = getCallerId(res);
+    const parsed = executeConversionSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid request body' });
+      return;
+    }
+
+    try {
+      const record = service.executeConversion(parsed.data.quoteId, parsed.data.walletId, callerId);
+      res.status(200).json({ data: record });
+    } catch (err) {
+      if (err instanceof FxError) {
+        sendFxError(res, err);
+        return;
+      }
+      throw err;
+    }
+  };
+}
+
+export function createListHistoryHandler(service: FxService) {
+  return (req: Request, res: Response): void => {
+    const callerId = getCallerId(res);
+    const query = listHistoryQuerySchema.safeParse(req.query);
+    if (!query.success) {
+      res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid query parameters' });
+      return;
+    }
+
+    const result = service.listHistory(callerId, query.data);
+    res.status(200).json({ data: result.data, nextCursor: result.nextCursor });
+  };
+}
+
+export function createUpsertRateHandler(service: FxService) {
+  return (req: Request, res: Response): void => {
+    const parsed = createExchangeRateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid request body' });
+      return;
+    }
+
+    const rate = service.createRate(parsed.data);
+    res.status(200).json({ data: rate });
+  };
+}
+
+export function createDeactivateRateHandler(service: FxService) {
+  return (req: Request, res: Response): void => {
+    const id = req.params['id'] ?? '';
+    if (!id) {
+      res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Rate ID is required' });
+      return;
+    }
+
+    try {
+      const rate = service.deactivateRate(id);
+      res.status(200).json({ data: rate });
+    } catch (err) {
+      if (err instanceof FxError) {
+        sendFxError(res, err);
+        return;
+      }
+      throw err;
+    }
+  };
+}

--- a/services/relayer/src/fx/index.ts
+++ b/services/relayer/src/fx/index.ts
@@ -1,0 +1,12 @@
+export { FxStore } from './FxStore';
+export { FxService, FxError } from './FxService';
+export * from './types';
+export * from './schemas';
+export {
+  createListRatesHandler,
+  createQuoteHandler,
+  createConvertHandler,
+  createListHistoryHandler,
+  createUpsertRateHandler,
+  createDeactivateRateHandler,
+} from './handlers';

--- a/services/relayer/src/fx/schemas.ts
+++ b/services/relayer/src/fx/schemas.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+
+export const assetCodeSchema = z
+  .string()
+  .min(1, 'Asset code must not be empty')
+  .max(12, 'Asset code must be ≤ 12 chars')
+  .regex(/^[a-zA-Z0-9]+$/, 'Asset code must be alphanumeric');
+
+export const decimalStringSchema = z.string().regex(/^\d+(\.\d+)?$/, 'Must be a numeric string');
+
+export const createExchangeRateSchema = z.object({
+  fromAsset: assetCodeSchema,
+  toAsset: assetCodeSchema,
+  rate: decimalStringSchema,
+});
+
+export type CreateExchangeRateInput = z.infer<typeof createExchangeRateSchema>;
+
+export const createQuoteSchema = z.object({
+  fromAsset: assetCodeSchema,
+  toAsset: assetCodeSchema,
+  amount: decimalStringSchema,
+});
+
+export type CreateQuoteInput = z.infer<typeof createQuoteSchema>;
+
+export const executeConversionSchema = z.object({
+  quoteId: z.string().uuid('quoteId must be a valid UUID'),
+  walletId: z.string().min(1, 'walletId must not be empty'),
+});
+
+export type ExecuteConversionInput = z.infer<typeof executeConversionSchema>;
+
+export const listRatesQuerySchema = z.object({
+  from: assetCodeSchema.optional(),
+  to: assetCodeSchema.optional(),
+});
+
+export const listHistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(100).default(20),
+  cursor: z.string().optional(),
+  fromDate: z.string().datetime({ offset: true }).optional(),
+  toDate: z.string().datetime({ offset: true }).optional(),
+});
+
+export interface ExchangeRate {
+  id: string;
+  fromAsset: string;
+  toAsset: string;
+  rate: string;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FxQuote {
+  id: string;
+  fromAsset: string;
+  toAsset: string;
+  amount: string;
+  convertedAmount: string;
+  rate: string;
+  expiresAt: string;
+  used: boolean;
+  createdAt: string;
+}
+
+export interface ConversionRecord {
+  id: string;
+  quoteId: string;
+  walletId: string;
+  callerId: string;
+  fromAsset: string;
+  toAsset: string;
+  amount: string;
+  convertedAmount: string;
+  rate: string;
+  status: 'completed' | 'failed';
+  txHash?: string;
+  createdAt: string;
+}

--- a/services/relayer/src/fx/types.ts
+++ b/services/relayer/src/fx/types.ts
@@ -1,0 +1,8 @@
+export type {
+  ExchangeRate,
+  FxQuote,
+  ConversionRecord,
+  CreateExchangeRateInput,
+  CreateQuoteInput,
+  ExecuteConversionInput,
+} from './schemas';

--- a/services/relayer/src/middleware/adminAuth.ts
+++ b/services/relayer/src/middleware/adminAuth.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+
+const ADMIN_API_KEY = process.env['ADMIN_API_KEY'] ?? 'ancore-admin-key';
+
+export function createAdminAuthMiddleware() {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const header = req.headers['x-admin-key'] as string | undefined;
+
+    if (!header || header !== ADMIN_API_KEY) {
+      res.status(403).json({ error: 'FORBIDDEN', message: 'Invalid or missing admin key' });
+      return;
+    }
+
+    next();
+  };
+}

--- a/services/relayer/src/server.ts
+++ b/services/relayer/src/server.ts
@@ -34,6 +34,17 @@ import {
   createCancelScheduledTransferHandler,
   createListExecutionsHandler,
 } from './scheduler';
+import { createAdminAuthMiddleware } from './middleware/adminAuth';
+import {
+  FxStore,
+  FxService,
+  createListRatesHandler,
+  createQuoteHandler,
+  createConvertHandler,
+  createListHistoryHandler,
+  createUpsertRateHandler,
+  createDeactivateRateHandler,
+} from './fx';
 
 // ── Request schema ────────────────────────────────────────────────────────────
 
@@ -163,6 +174,21 @@ export function createApp(
 
   const validateScheduledTransfer = validateBody(createScheduledTransferSchema);
 
+  // ── FX ──────────────────────────────────────────────────────────────────────
+
+  const fxStore = new FxStore();
+  const fxService = new FxService(fxStore);
+  const adminAuth = createAdminAuthMiddleware();
+
+  const fxRatesHandler = createListRatesHandler(fxService);
+  const fxQuoteHandler = createQuoteHandler(fxService);
+  const fxConvertHandler = createConvertHandler(fxService);
+  const fxHistoryHandler = createListHistoryHandler(fxService);
+  const fxUpsertRateHandler = createUpsertRateHandler(fxService);
+  const fxDeactivateRateHandler = createDeactivateRateHandler(fxService);
+
+  // ── Routes ──────────────────────────────────────────────────────────────────
+
   app.post('/relay/execute', auth, relayLimiter, validate, idempotency, executeHandler);
   app.post('/relay/validate', auth, relayLimiter, validate, validateHandler);
   app.get('/relay/status', statusLimiter, (_req, res) => res.json(relayService.health()));
@@ -202,6 +228,21 @@ export function createApp(
     auth,
     createListExecutionsHandler(scheduledTransferService)
   );
+
+  // ── FX: Public ──────────────────────────────────────────────────────────────
+
+  app.get('/api/v1/fx/rates', fxRatesHandler);
+  app.post('/api/v1/fx/quote', fxQuoteHandler);
+
+  // ── FX: Authenticated ───────────────────────────────────────────────────────
+
+  app.post('/api/v1/fx/convert', auth, fxConvertHandler);
+  app.get('/api/v1/fx/history', auth, fxHistoryHandler);
+
+  // ── FX: Admin ───────────────────────────────────────────────────────────────
+
+  app.post('/api/v1/admin/fx/rates', adminAuth, fxUpsertRateHandler);
+  app.delete('/api/v1/admin/fx/rates/:id', adminAuth, fxDeactivateRateHandler);
 
   return app;
 }


### PR DESCRIPTION
## Description

Implements exchange rate management endpoints as specified in 

### Public Endpoints
- `GET /api/v1/fx/rates` — List active rates with optional `?from=` / `?to=` filters
- `POST /api/v1/fx/quote` — Create a quote with 30s expiration

### Authenticated Endpoints
- `POST /api/v1/fx/convert` — Execute conversion using a valid quote
- `GET /api/v1/fx/history` — Paginated conversion history (`?limit=`, `?cursor=`, `?fromDate=`, `?toDate=`)

### Admin Endpoints
- `POST /api/v1/admin/fx/rates` — Create or update exchange rates
- `DELETE /api/v1/admin/fx/rates/:id` — Deactivate an exchange rate

### Key behaviors
- Quotes expire after 30s (configurable) — expired quotes return 422
- Conversions are atomic — quotes are marked used before execution
- History is tracked per caller with cursor-based pagination
- Admin endpoints protected via `X-Admin-Key` header

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foreign exchange (FX) rate listing and quote creation functionality.
  * Added conversion execution with conversion history tracking and cursor-based pagination.
  * Added admin controls for managing exchange rates (create, update, deactivate).

* **Tests**
  * Updated test timeout configurations to allow longer test execution times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->