### PR TITLE
feat: implement ReceiveScreen with smart account contract address and SEP-7 QR

### DIFF
--- a/apps/extension-wallet/src/components/PaymentQRCode.tsx
+++ b/apps/extension-wallet/src/components/PaymentQRCode.tsx
@@ -14,6 +14,10 @@ export interface PaymentQRCodeProps {
    * Additional className applied to the outer wrapper div.
    */
   className?: string;
+  /**
+   * Ref to the inner SVG element, for e.g. PNG download.
+   */
+  qrRef?: React.RefObject<SVGSVGElement | null>;
 }
 
 /**
@@ -21,7 +25,7 @@ export interface PaymentQRCodeProps {
  * Uses qrcode.react under the hood with a styled card border so it fits
  * the extension-wallet design system.
  */
-export function PaymentQRCode({ value, size = 220, className }: PaymentQRCodeProps) {
+export function PaymentQRCode({ value, size = 220, className, qrRef }: PaymentQRCodeProps) {
   return (
     <div
       className={cn(
@@ -31,6 +35,7 @@ export function PaymentQRCode({ value, size = 220, className }: PaymentQRCodePro
       data-testid="payment-qr-code"
     >
       <QRCodeSVG
+        ref={qrRef}
         value={value}
         size={size}
         level="M"

--- a/apps/extension-wallet/src/router/index.tsx
+++ b/apps/extension-wallet/src/router/index.tsx
@@ -11,7 +11,7 @@ import {
   useNavigate,
   useSearchParams,
 } from 'react-router-dom';
-import { ArrowLeft, Copy, Lock, PlusCircle } from 'lucide-react';
+import { ArrowLeft, Lock, PlusCircle } from 'lucide-react';
 import { NotificationProvider } from '@ancore/ui-kit';
 import {
   AuthGuard,
@@ -22,6 +22,7 @@ import {
 } from './AuthGuard';
 import { OnboardingFlow } from '../screens/Onboarding/OnboardingFlow';
 import { NavBar } from '../components/Navigation/NavBar';
+import { ReceiveScreen as ReceiveScreenComponent } from '../screens/ReceiveScreen';
 import { SettingsScreen } from '../screens/Settings/SettingsScreen';
 import { SendScreen as SendFlowScreen } from '../screens/Send/SendScreen';
 import { ScheduledTransfersScreen } from '../screens/ScheduledTransfers/ScheduledTransfersScreen';
@@ -355,37 +356,17 @@ function ScheduledTransfersRoute() {
 
 function ReceiveScreen() {
   const network = useDashboardSettingsStore((state) => state.network);
+  const { authState } = useExtensionAuth();
 
   return (
-    <PageScaffold
-      eyebrow="Payments"
-      title="Receive"
-      description="Expose the wallet address and handoff to copy or QR actions."
-    >
-      <Card
-        title="Receive funds"
-        description={`Share this demo address with another wallet on ${network}.`}
-      >
-        <div className="rounded-xl border border-dashed border-border bg-background px-4 py-4 text-sm text-muted-foreground">
-          GCFX...WALLET
-        </div>
-        <div className="mt-4 flex gap-3">
-          <button
-            className="inline-flex flex-1 items-center justify-center rounded-xl border border-border px-4 py-3 text-sm font-semibold transition hover:bg-accent"
-            type="button"
-          >
-            <Copy className="mr-2 h-4 w-4" />
-            Copy address
-          </button>
-          <button
-            className="inline-flex flex-1 items-center justify-center rounded-xl border border-border px-4 py-3 text-sm font-semibold transition hover:bg-accent"
-            type="button"
-          >
-            Show QR
-          </button>
-        </div>
-      </Card>
-    </PageScaffold>
+    <ReceiveScreenComponent
+      smartAccountId={authState.smartAccountId}
+      ownerPublicKey={
+        authState.accountAddress !== 'GCFX...WALLET' ? authState.accountAddress : null
+      }
+      network={network}
+      onBack={() => window.history.back()}
+    />
   );
 }
 

--- a/apps/extension-wallet/src/screens/ReceiveScreen.tsx
+++ b/apps/extension-wallet/src/screens/ReceiveScreen.tsx
@@ -12,7 +12,6 @@ import {
 import { ArrowLeft, Download } from 'lucide-react';
 import { PaymentQRCode } from '@/components/PaymentQRCode';
 import { useCopyWithFeedback } from '@/hooks/useCopyWithFeedback';
-import { useExtensionAuth } from '@/router/AuthGuard';
 import type { Network } from '@ancore/types';
 
 export interface ReceiveScreenProps {
@@ -46,7 +45,6 @@ function buildPaymentUri(destination: string, network: Network): string {
 }
 
 function downloadSvgAsPng(svgElement: SVGSVGElement, filename: string) {
-  const xmlns = 'http://www.w3.org/2000/svg';
   const svgClone = svgElement.cloneNode(true) as SVGSVGElement;
   const bounds = svgElement.getBoundingClientRect();
   const width = bounds.width;
@@ -80,8 +78,8 @@ function downloadSvgAsPng(svgElement: SVGSVGElement, filename: string) {
 }
 
 export function ReceiveScreen({
-  smartAccountId: smartAccountIdProp,
-  ownerPublicKey: ownerPublicKeyProp,
+  smartAccountId,
+  ownerPublicKey,
   network = 'mainnet',
   onBack,
   className,
@@ -90,20 +88,11 @@ export function ReceiveScreen({
   const { copy: copyPublicKey, copied: publicKeyCopied } = useCopyWithFeedback();
   const qrRef = React.useRef<SVGSVGElement>(null);
 
-  let smartAccountId = smartAccountIdProp;
-  let ownerPublicKey = ownerPublicKeyProp;
-
-  try {
-    const { authState } = useExtensionAuth();
-    if (!smartAccountId && authState.smartAccountId) {
-      smartAccountId = authState.smartAccountId;
+  const handleDownload = React.useCallback(() => {
+    if (qrRef.current && smartAccountId) {
+      downloadSvgAsPng(qrRef.current, `ancore-receive-${smartAccountId.slice(0, 8)}.png`);
     }
-    if (!ownerPublicKey && authState.accountAddress !== 'GCFX...WALLET') {
-      ownerPublicKey = authState.accountAddress;
-    }
-  } catch {
-    // Not inside ExtensionAuthProvider — use provided props only
-  }
+  }, [smartAccountId]);
 
   if (!smartAccountId) {
     return (
@@ -137,12 +126,6 @@ export function ReceiveScreen({
   }
 
   const paymentUri = buildPaymentUri(smartAccountId, network);
-
-  const handleDownload = React.useCallback(() => {
-    if (qrRef.current) {
-      downloadSvgAsPng(qrRef.current, `ancore-receive-${smartAccountId.slice(0, 8)}.png`);
-    }
-  }, [smartAccountId]);
 
   return (
     <Card className={cn('mx-auto w-full max-w-md border-slate-200', className)}>

--- a/apps/extension-wallet/src/screens/ReceiveScreen.tsx
+++ b/apps/extension-wallet/src/screens/ReceiveScreen.tsx
@@ -9,75 +9,150 @@ import {
   AddressDisplay,
   cn,
 } from '@ancore/ui-kit';
-import { ArrowLeft, Printer } from 'lucide-react';
+import { ArrowLeft, Download } from 'lucide-react';
 import { PaymentQRCode } from '@/components/PaymentQRCode';
 import { useCopyWithFeedback } from '@/hooks/useCopyWithFeedback';
-import type { StellarNetwork } from '@/utils/explorer-links';
-
-export interface ReceiveScreenAccount {
-  /** Stellar public key / address */
-  publicKey: string;
-  /** Human-readable account name or label (optional) */
-  name?: string;
-}
+import { useExtensionAuth } from '@/router/AuthGuard';
+import type { Network } from '@ancore/types';
 
 export interface ReceiveScreenProps {
-  /** The account whose address should be displayed and encoded into the QR code */
-  account: ReceiveScreenAccount;
-  /** Active network – shown as a badge in the UI */
-  network?: StellarNetwork;
-  /** Called when the user taps/clicks the back arrow */
+  smartAccountId?: string | null;
+  ownerPublicKey?: string | null;
+  network?: Network;
   onBack?: () => void;
   className?: string;
 }
 
-const NETWORK_LABEL: Record<StellarNetwork, string> = {
+const NETWORK_LABEL: Record<Network, string> = {
   mainnet: 'Mainnet',
   testnet: 'Testnet',
   futurenet: 'Futurenet',
+  local: 'Local',
 };
 
-const NETWORK_BADGE_CLASS: Record<StellarNetwork, string> = {
+const NETWORK_BADGE_CLASS: Record<Network, string> = {
   mainnet:
     'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300',
   testnet:
     'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300',
   futurenet:
     'border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-800 dark:bg-violet-950 dark:text-violet-300',
+  local:
+    'border-slate-200 bg-slate-50 text-slate-700 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-300',
 };
 
-/**
- * ReceiveScreen – wallet receive screen showing a QR code and copyable address.
- *
- * Usage:
- * ```tsx
- * <ReceiveScreen
- *   account={{ publicKey: 'GABC...123', name: 'My Wallet' }}
- *   network="testnet"
- *   onBack={() => navigate(-1)}
- * />
- * ```
- */
+function buildPaymentUri(destination: string, network: Network): string {
+  return `web+stellar:pay?destination=${encodeURIComponent(destination)}&network=${encodeURIComponent(network)}`;
+}
+
+function downloadSvgAsPng(svgElement: SVGSVGElement, filename: string) {
+  const xmlns = 'http://www.w3.org/2000/svg';
+  const svgClone = svgElement.cloneNode(true) as SVGSVGElement;
+  const bounds = svgElement.getBoundingClientRect();
+  const width = bounds.width;
+  const height = bounds.height;
+
+  const serializer = new XMLSerializer();
+  const svgString = serializer.serializeToString(svgClone);
+  const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(svgBlob);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const img = new Image();
+  img.onload = () => {
+    ctx.drawImage(img, 0, 0);
+    URL.revokeObjectURL(url);
+    canvas.toBlob((blob) => {
+      if (!blob) return;
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = filename;
+      link.click();
+      URL.revokeObjectURL(link.href);
+    }, 'image/png');
+  };
+  img.src = url;
+}
+
 export function ReceiveScreen({
-  account,
+  smartAccountId: smartAccountIdProp,
+  ownerPublicKey: ownerPublicKeyProp,
   network = 'mainnet',
   onBack,
   className,
 }: ReceiveScreenProps) {
-  const { copy, copied } = useCopyWithFeedback();
+  const { copy: copySmartId, copied: smartIdCopied } = useCopyWithFeedback();
+  const { copy: copyPublicKey, copied: publicKeyCopied } = useCopyWithFeedback();
+  const qrRef = React.useRef<SVGSVGElement>(null);
 
-  const handlePrint = React.useCallback(() => {
-    window.print();
-  }, []);
+  let smartAccountId = smartAccountIdProp;
+  let ownerPublicKey = ownerPublicKeyProp;
+
+  try {
+    const { authState } = useExtensionAuth();
+    if (!smartAccountId && authState.smartAccountId) {
+      smartAccountId = authState.smartAccountId;
+    }
+    if (!ownerPublicKey && authState.accountAddress !== 'GCFX...WALLET') {
+      ownerPublicKey = authState.accountAddress;
+    }
+  } catch {
+    // Not inside ExtensionAuthProvider — use provided props only
+  }
+
+  if (!smartAccountId) {
+    return (
+      <Card className={cn('mx-auto w-full max-w-md border-slate-200', className)}>
+        <CardHeader className="space-y-0 pb-4">
+          <div className="flex items-center gap-3">
+            {onBack && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Go back"
+                onClick={onBack}
+              >
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            )}
+            <CardTitle className="text-lg">Receive</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center gap-4 pb-8 text-center">
+          <div className="rounded-full bg-slate-100 p-4 dark:bg-slate-800">
+            <Download className="h-8 w-8 text-slate-400" aria-hidden="true" />
+          </div>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Complete onboarding to get your receive address
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const paymentUri = buildPaymentUri(smartAccountId, network);
+
+  const handleDownload = React.useCallback(() => {
+    if (qrRef.current) {
+      downloadSvgAsPng(qrRef.current, `ancore-receive-${smartAccountId.slice(0, 8)}.png`);
+    }
+  }, [smartAccountId]);
 
   return (
     <Card className={cn('mx-auto w-full max-w-md border-slate-200', className)}>
-      {/* ── Header ─────────────────────────────────────────────────── */}
       <CardHeader className="space-y-0 pb-4">
         <div className="flex items-center gap-3">
-          <Button type="button" variant="ghost" size="icon" aria-label="Go back" onClick={onBack}>
-            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-          </Button>
+          {onBack && (
+            <Button type="button" variant="ghost" size="icon" aria-label="Go back" onClick={onBack}>
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          )}
           <CardTitle className="text-lg">Receive</CardTitle>
 
           <div className="ml-auto">
@@ -95,43 +170,45 @@ export function ReceiveScreen({
         </div>
       </CardHeader>
 
-      {/* ── Body ──────────────────────────────────────────────────── */}
       <CardContent className="flex flex-col items-center gap-6 pb-8">
-        {/* QR Code */}
         <PaymentQRCode
-          value={account.publicKey}
+          value={paymentUri}
           size={220}
-          aria-label={`QR code for ${account.name ?? 'your address'}`}
+          qrRef={qrRef}
+          aria-label={`QR code for smart account ${smartAccountId}`}
         />
 
-        {/* Address + copy */}
-        <div className="w-full space-y-2">
-          {account.name && (
-            <p className="text-center text-sm font-medium text-slate-600 dark:text-slate-400">
-              {account.name}
-            </p>
-          )}
+        <div className="w-full space-y-3">
           <AddressDisplay
-            address={account.publicKey}
+            address={smartAccountId}
             copyable
             truncate={8}
-            label="Your address"
-            onCopy={() => void copy(account.publicKey)}
-            copied={copied}
+            label="Contract ID"
+            onCopy={() => void copySmartId(smartAccountId)}
+            copied={smartIdCopied}
           />
+          {ownerPublicKey && (
+            <AddressDisplay
+              address={ownerPublicKey}
+              copyable
+              truncate={8}
+              label="Owner public key"
+              onCopy={() => void copyPublicKey(ownerPublicKey)}
+              copied={publicKeyCopied}
+            />
+          )}
         </div>
 
-        {/* Print button */}
         <Button
           type="button"
           variant="outline"
           size="sm"
           className="w-full"
-          onClick={handlePrint}
-          aria-label="Print QR code"
+          onClick={handleDownload}
+          aria-label="Download QR code as PNG"
         >
-          <Printer className="mr-2 h-4 w-4" aria-hidden="true" />
-          Print QR Code
+          <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+          Download QR Code
         </Button>
       </CardContent>
     </Card>

--- a/apps/extension-wallet/src/screens/__tests__/ReceiveScreen.test.tsx
+++ b/apps/extension-wallet/src/screens/__tests__/ReceiveScreen.test.tsx
@@ -4,22 +4,28 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { NotificationProvider } from '@ancore/ui-kit';
 
-vi.mock('qrcode.react', () => ({
-  QRCodeSVG: ({ value, 'aria-label': ariaLabel }: { value: string; 'aria-label'?: string }) => (
-    <svg data-testid="qr-code-svg" data-value={value} aria-label={ariaLabel} />
-  ),
+vi.mock('qrcode.react', () => {
+  const MockQRCodeSVG = ({
+    value,
+    'aria-label': ariaLabel,
+  }: {
+    value: string;
+    'aria-label'?: string;
+  }) => <svg data-testid="qr-code-svg" data-value={value} aria-label={ariaLabel} />;
+  MockQRCodeSVG.displayName = 'QRCodeSVG';
+  return { QRCodeSVG: MockQRCodeSVG };
+});
+
+vi.mock('@/router/AuthGuard', () => ({
+  useExtensionAuth: () => ({
+    authState: { smartAccountId: undefined, accountAddress: 'GCFX...WALLET' },
+  }),
 }));
 
 import { ReceiveScreen } from '@/screens/ReceiveScreen';
 
-const MAINNET_ACCOUNT = {
-  publicKey: 'GABC1234567890DEFGHIJKLMNOPQRSTUVWXYZ',
-  name: 'Primary Wallet',
-};
-
-const TESTNET_ACCOUNT = {
-  publicKey: 'GTEST9876543210ABCDEFGHIJKLMNOPQRSTUV',
-};
+const SMART_ACCOUNT_ID = 'CA3D5K7UQJZ5BFPZ5G2FYJ3GX7CJYJ2CQZ5BFPZ5G2FYJ3GX7CJYJ2C';
+const OWNER_PUBLIC_KEY = 'GA7QNPKKJ3ZYXPWLUVFXZNXUVXJTQPWMQHZMDMQHLS5VNLQBQNPFLM';
 
 function renderReceive(ui: React.ReactElement) {
   return render(<NotificationProvider>{ui}</NotificationProvider>);
@@ -27,54 +33,67 @@ function renderReceive(ui: React.ReactElement) {
 
 // ─── Test suite ──────────────────────────────────────────────────────────────
 describe('ReceiveScreen', () => {
+  describe('empty state', () => {
+    it('renders empty state when no smartAccountId is provided', () => {
+      renderReceive(<ReceiveScreen />);
+      expect(
+        screen.getByText('Complete onboarding to get your receive address')
+      ).toBeInTheDocument();
+    });
+
+    it('does not crash when neither props nor auth context have smartAccountId', () => {
+      renderReceive(<ReceiveScreen />);
+      expect(screen.getByRole('heading', { name: /receive/i })).toBeInTheDocument();
+    });
+  });
+
   describe('rendering', () => {
     it('renders the screen title', () => {
-      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} />);
       expect(screen.getByRole('heading', { name: /receive/i })).toBeInTheDocument();
     });
 
-    it('renders the QR code with the correct address value', () => {
-      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+    it('renders the QR code with the SEP-7 payment URI', () => {
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} network="testnet" />);
       const qr = screen.getByTestId('qr-code-svg');
       expect(qr).toBeInTheDocument();
-      expect(qr).toHaveAttribute('data-value', MAINNET_ACCOUNT.publicKey);
+      expect(qr).toHaveAttribute(
+        'data-value',
+        `web+stellar:pay?destination=${encodeURIComponent(SMART_ACCOUNT_ID)}&network=testnet`
+      );
     });
 
-    it('renders the QR code without a name', () => {
-      renderReceive(<ReceiveScreen account={TESTNET_ACCOUNT} network="testnet" />);
-      const qr = screen.getByTestId('qr-code-svg');
-      expect(qr).toHaveAttribute('data-value', TESTNET_ACCOUNT.publicKey);
+    it('renders the contract ID label', () => {
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} />);
+      expect(screen.getByText('Contract ID')).toBeInTheDocument();
     });
 
-    it('shows the optional account name', () => {
-      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
-      expect(screen.getByText('Primary Wallet')).toBeInTheDocument();
+    it('renders the owner public key when provided', () => {
+      renderReceive(
+        <ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} ownerPublicKey={OWNER_PUBLIC_KEY} />
+      );
+      expect(screen.getByText('Owner public key')).toBeInTheDocument();
     });
 
-    it('does not render the account name when not provided', () => {
-      renderReceive(<ReceiveScreen account={TESTNET_ACCOUNT} network="testnet" />);
-      expect(screen.queryByText('Primary Wallet')).not.toBeInTheDocument();
-    });
-
-    it('renders the address display label', () => {
-      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
-      expect(screen.getByText('Your address')).toBeInTheDocument();
+    it('does not render owner public key when not provided', () => {
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} />);
+      expect(screen.queryByText('Owner public key')).not.toBeInTheDocument();
     });
   });
 
   describe('network indicator', () => {
     it('shows "Mainnet" badge by default', () => {
-      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} />);
       expect(screen.getByText('Mainnet')).toBeInTheDocument();
     });
 
     it('shows "Testnet" badge when network is testnet', () => {
-      renderReceive(<ReceiveScreen account={TESTNET_ACCOUNT} network="testnet" />);
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} network="testnet" />);
       expect(screen.getByText('Testnet')).toBeInTheDocument();
     });
 
     it('shows "Futurenet" badge when network is futurenet', () => {
-      renderReceive(<ReceiveScreen account={TESTNET_ACCOUNT} network="futurenet" />);
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} network="futurenet" />);
       expect(screen.getByText('Futurenet')).toBeInTheDocument();
     });
   });
@@ -83,35 +102,56 @@ describe('ReceiveScreen', () => {
     it('calls onBack when the back button is clicked', async () => {
       const user = userEvent.setup();
       const handleBack = vi.fn();
-      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} onBack={handleBack} />);
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} onBack={handleBack} />);
 
       await user.click(screen.getByRole('button', { name: /go back/i }));
 
       expect(handleBack).toHaveBeenCalledTimes(1);
     });
+
+    it('does not render back button when onBack is not provided', () => {
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} />);
+      expect(screen.queryByRole('button', { name: /go back/i })).not.toBeInTheDocument();
+    });
   });
 
-  describe('copy address', () => {
-    it('copies the address to the clipboard when the copy button is clicked', async () => {
+  describe('copy addresses', () => {
+    it('copies the smart account ID to the clipboard when copy button is clicked', async () => {
       const user = userEvent.setup();
       const writeText = vi.spyOn(navigator.clipboard, 'writeText');
       writeText.mockResolvedValue(undefined);
 
-      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} />);
 
-      const copyBtn = screen.getByRole('button', { name: /copy address/i });
-      await user.click(copyBtn);
+      const copyBtns = screen.getAllByRole('button', { name: /copy address/i });
+      await user.click(copyBtns[0]);
 
-      expect(writeText).toHaveBeenCalledWith(MAINNET_ACCOUNT.publicKey);
+      expect(writeText).toHaveBeenCalledWith(SMART_ACCOUNT_ID);
     });
 
-    it('shows success toast after copying', async () => {
+    it('copies the owner public key when its copy button is clicked', async () => {
+      const user = userEvent.setup();
+      const writeText = vi.spyOn(navigator.clipboard, 'writeText');
+      writeText.mockResolvedValue(undefined);
+
+      renderReceive(
+        <ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} ownerPublicKey={OWNER_PUBLIC_KEY} />
+      );
+
+      const copyBtns = screen.getAllByRole('button', { name: /copy address/i });
+      await user.click(copyBtns[1]);
+
+      expect(writeText).toHaveBeenCalledWith(OWNER_PUBLIC_KEY);
+    });
+
+    it('shows success toast after copying smart account ID', async () => {
       const user = userEvent.setup();
       vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
 
-      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} />);
 
-      await user.click(screen.getByRole('button', { name: /copy address/i }));
+      const copyBtns = screen.getAllByRole('button', { name: /copy address/i });
+      await user.click(copyBtns[0]);
 
       await waitFor(() => {
         expect(screen.getByText('Address copied')).toBeInTheDocument();
@@ -119,47 +159,35 @@ describe('ReceiveScreen', () => {
     });
   });
 
-  describe('print', () => {
-    it('renders a print button', () => {
-      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
-      expect(screen.getByRole('button', { name: /print qr code/i })).toBeInTheDocument();
-    });
-
-    it('calls window.print when the print button is clicked', async () => {
-      const user = userEvent.setup();
-      const printSpy = vi.spyOn(window, 'print').mockImplementation(() => {});
-
-      renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
-      await user.click(screen.getByRole('button', { name: /print qr code/i }));
-
-      expect(printSpy).toHaveBeenCalledTimes(1);
-      printSpy.mockRestore();
-    });
-  });
-
   describe('QR generation', () => {
-    it('encodes exactly the publicKey in the QR code', () => {
-      const publicKey = 'GD6SZQJNKL3ZYXPWLUVFXZNXUVXJTQPWMQHZMDMQHLS5VNLQBQNPFLM';
-      renderReceive(<ReceiveScreen account={{ publicKey }} />);
-      expect(screen.getByTestId('qr-code-svg')).toHaveAttribute('data-value', publicKey);
+    it('encodes SEP-7 payment URI in the QR code', () => {
+      const smartAccountId = 'CA3D5K7UQJZ5BFPZ5G2FYJ3GX7CJYJ2CQZ5BFPZ5G2FYJ3GX7CJYJ2C';
+      renderReceive(<ReceiveScreen smartAccountId={smartAccountId} network="testnet" />);
+      const expectedUri = `web+stellar:pay?destination=${encodeURIComponent(smartAccountId)}&network=testnet`;
+      expect(screen.getByTestId('qr-code-svg')).toHaveAttribute('data-value', expectedUri);
     });
 
-    it('renders a different QR value when account changes', () => {
-      const { rerender } = renderReceive(<ReceiveScreen account={MAINNET_ACCOUNT} />);
-      expect(screen.getByTestId('qr-code-svg')).toHaveAttribute(
-        'data-value',
-        MAINNET_ACCOUNT.publicKey
+    it('renders a different QR value when network changes', () => {
+      const { rerender } = renderReceive(
+        <ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} network="testnet" />
       );
+      const testnetUri = `web+stellar:pay?destination=${encodeURIComponent(SMART_ACCOUNT_ID)}&network=testnet`;
+      expect(screen.getByTestId('qr-code-svg')).toHaveAttribute('data-value', testnetUri);
 
       rerender(
         <NotificationProvider>
-          <ReceiveScreen account={TESTNET_ACCOUNT} />
+          <ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} network="mainnet" />
         </NotificationProvider>
       );
-      expect(screen.getByTestId('qr-code-svg')).toHaveAttribute(
-        'data-value',
-        TESTNET_ACCOUNT.publicKey
-      );
+      const mainnetUri = `web+stellar:pay?destination=${encodeURIComponent(SMART_ACCOUNT_ID)}&network=mainnet`;
+      expect(screen.getByTestId('qr-code-svg')).toHaveAttribute('data-value', mainnetUri);
+    });
+  });
+
+  describe('download QR', () => {
+    it('renders a download QR code button', () => {
+      renderReceive(<ReceiveScreen smartAccountId={SMART_ACCOUNT_ID} />);
+      expect(screen.getByRole('button', { name: /download qr code/i })).toBeInTheDocument();
     });
   });
 });

--- a/apps/extension-wallet/src/security/__tests__/extension-storage-encryption.test.ts
+++ b/apps/extension-wallet/src/security/__tests__/extension-storage-encryption.test.ts
@@ -66,8 +66,9 @@ describe('Extension storage encryption audit', () => {
 
   beforeEach(async () => {
     mockStorage = createMockChromeStorage();
-    ({ ChromeStorageAdapter } = await import('@ancore/core-sdk'));
-    ({ SecureStorageManager } = await import('@ancore/core-sdk'));
+    const sdk = await import('@ancore/core-sdk');
+    ChromeStorageAdapter = sdk.ChromeStorageAdapter;
+    SecureStorageManager = sdk.SecureStorageManager;
   });
 
   it('never stores plaintext secrets in chrome.storage.local', async () => {

--- a/apps/extension-wallet/vitest.config.ts
+++ b/apps/extension-wallet/vitest.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
       ['src/security/__tests__/extension-storage-encryption.test.ts', 'node'],
     ],
     setupFiles: ['../../packages/ensure-webcrypto.ts', './src/test/setup.ts'],
-    testTimeout: 30000,
+    testTimeout: 60000,
+    hookTimeout: 30000,
     css: true,
     fileParallelism: process.env.CI !== 'true',
     exclude: [


### PR DESCRIPTION
Implements the Receive screen with the smart account contract address and SEP-7 payment URI QR code, replacing the hardcoded demo G-address (`GCFX...WALLET`).

### Changes

**ReceiveScreen.tsx** — Complete rewrite:
- Reads `smartAccountId` (contract C-address) from props (router passes from `useExtensionAuth()`)
- Generates SEP-7 payment URI: `web+stellar:pay?destination=<smartAccountId>&network=<network>`
- QR code encodes the SEP-7 URI (not the raw address)
- Displays `ownerPublicKey` as a secondary copyable address
- Empty/loading state when no smart account is configured — shows "Complete onboarding to get your receive address" with no crash
- Network badge (Mainnet/Testnet/Futurenet/Local) with color-coded styling
- Copy-to-clipboard with toast feedback via `useCopyWithFeedback` on both addresses
- QR PNG download button

**PaymentQRCode.tsx:**
- Added optional `qrRef` prop to expose the inner `QRCodeSVG` element for PNG download

**Router (index.tsx):**
- Replaced the inline demo `ReceiveScreen` (rendered "GCFX...WALLET") with the actual `ReceiveScreenComponent`

**Infrastructure:**
- Increased `vitest.config.ts` `testTimeout` (30s → 60s) and `hookTimeout` (30s)
- Optimized `extension-storage-encryption.test.ts` import

### Closes
- Closes #789 — Extension: Receive screen with smart account contract address and QR code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QR codes can now be downloaded as PNG images from the receive screen.

* **Refactor**
  * Receive screen now displays smart account contract ID instead of public key for fund transfers.
  * Print functionality has been removed from the receive screen.
  * QR code encodes payment URIs for smart account transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->