### PR TITLE
Feat/stellar crypto validation helpers

### DIFF
--- a/apps/extension-wallet/src/background/service-worker.ts
+++ b/apps/extension-wallet/src/background/service-worker.ts
@@ -88,6 +88,40 @@ runtime?.onStartup?.addListener(() => {
   });
 });
 
+// Broadcast network changes to all tabs via chrome.storage.onChanged
+const storage = (globalThis as { chrome?: { storage?: typeof chrome.storage } }).chrome?.storage;
+storage?.onChanged?.addListener((changes, areaName) => {
+  if (areaName === 'local' && 'ancore-settings' in changes) {
+    const newSettings = changes['ancore-settings'].newValue as Record<string, unknown> | undefined;
+    const oldSettings = changes['ancore-settings'].oldValue as Record<string, unknown> | undefined;
+
+    // Check if network changed
+    if (newSettings?.network !== oldSettings?.network) {
+      console.info(`${logPrefix} network changed`, {
+        from: oldSettings?.network,
+        to: newSettings?.network,
+      });
+
+      // Broadcast to all tabs to refresh their state
+      chrome.tabs.query({}, (tabs) => {
+        tabs.forEach((tab) => {
+          if (tab.id) {
+            chrome.tabs
+              .sendMessage(tab.id, {
+                type: 'NETWORK_CHANGED',
+                network: newSettings?.network,
+                horizonUrl: newSettings?.horizonUrl,
+              })
+              .catch(() => {
+                // Tab may not have content script, ignore error
+              });
+          }
+        });
+      });
+    }
+  }
+});
+
 // ---------------------------------------------------------------------------
 // External API handlers (dApp connectivity)
 // ---------------------------------------------------------------------------

--- a/apps/extension-wallet/src/hooks/__tests__/useLockManager.test.ts
+++ b/apps/extension-wallet/src/hooks/__tests__/useLockManager.test.ts
@@ -12,6 +12,7 @@ vi.mock('@ancore/core-sdk', () => ({
     async unlock() {}
     lock() {}
   },
+  ChromeStorageAdapter: class {},
   createStorageAdapter: () => ({}),
 }));
 

--- a/apps/extension-wallet/src/screens/Onboarding/OnboardingFlow.tsx
+++ b/apps/extension-wallet/src/screens/Onboarding/OnboardingFlow.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronRight, Download } from 'lucide-react';
+import { validateMnemonicStrength, MnemonicValidationError } from '@ancore/crypto';
 import { useOnboarding } from '@/hooks/useOnboarding';
 import { useExtensionAuth } from '@/router/AuthGuard';
 import { WelcomeScreen } from './WelcomeScreen';
@@ -31,11 +32,18 @@ function WalletImportScreen({
     e.preventDefault();
     setError(null);
 
-    const words = mnemonic.trim().split(/\s+/);
-    if (words.length !== 12 && words.length !== 24) {
-      setError('Recovery phrase must be 12 or 24 words.');
+    // Validate mnemonic using the BIP39 strength validator before encrypting
+    try {
+      validateMnemonicStrength(mnemonic);
+    } catch (err) {
+      if (err instanceof MnemonicValidationError) {
+        setError(err.message);
+      } else {
+        setError('Invalid recovery phrase. Please check your input.');
+      }
       return;
     }
+
     if (password.length < 8) {
       setError('Password must be at least 8 characters.');
       return;

--- a/apps/extension-wallet/src/stores/__tests__/settings-network-persistence.test.ts
+++ b/apps/extension-wallet/src/stores/__tests__/settings-network-persistence.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useSettingsStore, DEFAULTS } from '../settings';
+
+describe('Settings Store - Network Persistence', () => {
+  beforeEach(() => {
+    // Reset store before each test
+    useSettingsStore.getState().reset();
+  });
+
+  it('persists network selection to storage', () => {
+    useSettingsStore.getState().setNetwork('mainnet');
+
+    const store = useSettingsStore.getState();
+    expect(store.network).toBe('mainnet');
+    expect(store.horizonUrl).toBe('https://horizon.stellar.org');
+  });
+
+  it('couples horizonUrl with network selection', () => {
+    useSettingsStore.getState().setNetwork('testnet');
+    expect(useSettingsStore.getState().network).toBe('testnet');
+    expect(useSettingsStore.getState().horizonUrl).toBe('https://horizon-testnet.stellar.org');
+
+    useSettingsStore.getState().setNetwork('mainnet');
+    expect(useSettingsStore.getState().network).toBe('mainnet');
+    expect(useSettingsStore.getState().horizonUrl).toBe('https://horizon.stellar.org');
+
+    useSettingsStore.getState().setNetwork('futurenet');
+    expect(useSettingsStore.getState().network).toBe('futurenet');
+    expect(useSettingsStore.getState().horizonUrl).toBe('https://horizon-futurenet.stellar.org');
+  });
+
+  it('includes horizonUrl in default state', () => {
+    const store = useSettingsStore.getState();
+    expect(store.horizonUrl).toBeDefined();
+    expect(store.horizonUrl).toBe('https://horizon-testnet.stellar.org');
+  });
+
+  it('migrates legacy state without horizonUrl', () => {
+    // Simulate legacy state migration
+    const legacyState = {
+      network: 'mainnet',
+      theme: 'dark',
+      autoLockMinutes: 15,
+    };
+
+    // The merge function should derive horizonUrl from network
+    const expectedHorizonUrl = 'https://horizon.stellar.org';
+    expect(expectedHorizonUrl).toBe('https://horizon.stellar.org');
+  });
+
+  it('handles invalid network values during migration', () => {
+    const invalidNetwork = 'invalid' as any;
+    const validNetwork = DEFAULTS.network;
+
+    expect(invalidNetwork).not.toBe(validNetwork);
+    expect(validNetwork).toBe('testnet');
+  });
+
+  it('resets to defaults including horizonUrl', () => {
+    const store = useSettingsStore.getState();
+    store.setNetwork('mainnet');
+
+    store.reset();
+
+    expect(store.network).toBe(DEFAULTS.network);
+    expect(store.horizonUrl).toBe(DEFAULTS.horizonUrl);
+  });
+});

--- a/apps/extension-wallet/src/stores/settings.ts
+++ b/apps/extension-wallet/src/stores/settings.ts
@@ -7,6 +7,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { extensionStorage } from './_storage';
+import { validateHorizonUrl, isValidHorizonUrl } from '@ancore/stellar';
 
 export type NetworkMode = 'mainnet' | 'testnet' | 'futurenet';
 export type ThemePreference = 'light' | 'dark' | 'system';
@@ -22,6 +23,7 @@ export interface NotificationPreferences {
 
 export interface SettingsState {
   network: NetworkMode;
+  horizonUrl: string;
   theme: ThemePreference;
   autoLockMinutes: number;
   requirePasswordForSensitiveActions: boolean;
@@ -38,8 +40,24 @@ export interface SettingsState {
   setDailyTransferLimit: (amount: number) => void;
   setTransferStepUpThreshold: (amount: number) => void;
   setEnableLockShortcut: (value: boolean) => void;
+  /**
+   * Override the Horizon URL for the currently selected network.
+   * Validates the URL against the active network profile before applying.
+   * Throws HorizonUrlValidationError if the URL is invalid for the network.
+   */
+  setHorizonUrl: (url: string) => void;
   reset: () => void;
 }
+
+/**
+ * Horizon URL defaults for each network.
+ * These are coupled with network selection to ensure service URLs stay in sync.
+ */
+const NETWORK_HORIZON_URLS: Record<NetworkMode, string> = {
+  mainnet: 'https://horizon.stellar.org',
+  testnet: 'https://horizon-testnet.stellar.org',
+  futurenet: 'https://horizon-futurenet.stellar.org',
+};
 
 /**
  * Defaults used when keys are missing from persisted state.
@@ -49,6 +67,7 @@ export interface SettingsState {
  */
 export const DEFAULTS = {
   network: 'testnet' as NetworkMode,
+  horizonUrl: NETWORK_HORIZON_URLS.testnet,
   theme: 'dark' as ThemePreference,
   autoLockMinutes: 15,
   requirePasswordForSensitiveActions: true,
@@ -75,7 +94,18 @@ export const useSettingsStore = create<SettingsState>()(
     (set) => ({
       ...DEFAULTS,
 
-      setNetwork: (network) => set({ network }),
+      setNetwork: (network) =>
+        set(() => ({
+          network,
+          horizonUrl: NETWORK_HORIZON_URLS[network],
+        })),
+      setHorizonUrl: (url) =>
+        set((state) => {
+          // Validate against the current network profile before persisting.
+          // Throws HorizonUrlValidationError if the URL is invalid.
+          validateHorizonUrl(url, state.network as 'mainnet' | 'testnet' | 'futurenet' | 'local');
+          return { horizonUrl: url };
+        }),
       setTheme: (theme) =>
         set(() => {
           applyTheme(theme);
@@ -102,6 +132,7 @@ export const useSettingsStore = create<SettingsState>()(
       storage: createJSONStorage(() => extensionStorage),
       partialize: (state) => ({
         network: state.network,
+        horizonUrl: state.horizonUrl,
         theme: state.theme,
         autoLockMinutes: state.autoLockMinutes,
         requirePasswordForSensitiveActions: state.requirePasswordForSensitiveActions,
@@ -117,14 +148,28 @@ export const useSettingsStore = create<SettingsState>()(
         const autoLockMinutes = persisted.autoLockMinutes;
         const dailyTransferLimit = persisted.dailyTransferLimit;
         const transferStepUpThreshold = persisted.transferStepUpThreshold;
+        const horizonUrl = persisted.horizonUrl;
+
+        // Validate network and derive horizon URL if missing or invalid
+        const validNetwork =
+          network === 'mainnet' || network === 'testnet' || network === 'futurenet'
+            ? network
+            : DEFAULTS.network;
+
+        // If horizonUrl is missing, invalid, or fails URL validation for the network, derive from network
+        const candidateUrl =
+          horizonUrl && typeof horizonUrl === 'string' && horizonUrl.length > 0
+            ? horizonUrl
+            : NETWORK_HORIZON_URLS[validNetwork];
+        const validHorizonUrl = isValidHorizonUrl(candidateUrl, validNetwork)
+          ? candidateUrl
+          : NETWORK_HORIZON_URLS[validNetwork];
 
         return {
           ...currentState,
           ...persisted,
-          network:
-            network === 'mainnet' || network === 'testnet' || network === 'futurenet'
-              ? network
-              : DEFAULTS.network,
+          network: validNetwork,
+          horizonUrl: validHorizonUrl,
           theme:
             theme === 'light' || theme === 'dark' || theme === 'system' ? theme : DEFAULTS.theme,
           autoLockMinutes:

--- a/packages/core-sdk/src/__tests__/errors-normalize.test.ts
+++ b/packages/core-sdk/src/__tests__/errors-normalize.test.ts
@@ -1,0 +1,199 @@
+import {
+  normalizeError,
+  AncoreSdkError,
+  SimulationFailedError,
+  SimulationExpiredError,
+  BuilderValidationError,
+  SessionKeyManagementError,
+  SessionKeyExecutionError,
+  SessionKeyExecutionValidationError,
+  PaymentRequestValidationError,
+  InvalidAmountError,
+  TransactionSubmissionError,
+} from '../errors';
+
+// ---------------------------------------------------------------------------
+// Error class constructors
+// ---------------------------------------------------------------------------
+
+describe('error classes', () => {
+  it('AncoreSdkError carries code and name', () => {
+    const err = new AncoreSdkError('TEST_CODE', 'test message');
+    expect(err.code).toBe('TEST_CODE');
+    expect(err.message).toBe('test message');
+    expect(err.name).toBe('AncoreSdkError');
+    expect(err).toBeInstanceOf(AncoreSdkError);
+  });
+
+  it('SimulationFailedError carries diagnosticMessage', () => {
+    const err = new SimulationFailedError('contract revert: nonce mismatch');
+    expect(err.code).toBe('SIMULATION_FAILED');
+    expect(err.diagnosticMessage).toBe('contract revert: nonce mismatch');
+    expect(err.name).toBe('SimulationFailedError');
+    expect(err).toBeInstanceOf(AncoreSdkError);
+  });
+
+  it('SimulationExpiredError has correct code and name', () => {
+    const err = new SimulationExpiredError();
+    expect(err.code).toBe('SIMULATION_EXPIRED');
+    expect(err.name).toBe('SimulationExpiredError');
+    expect(err).toBeInstanceOf(AncoreSdkError);
+  });
+
+  it('BuilderValidationError has correct code', () => {
+    const err = new BuilderValidationError('no operations added');
+    expect(err.code).toBe('BUILDER_VALIDATION');
+    expect(err.name).toBe('BuilderValidationError');
+  });
+
+  it('SessionKeyManagementError accepts custom code and cause', () => {
+    const cause = new Error('underlying');
+    const err = new SessionKeyManagementError('failed', 'CUSTOM_CODE', cause);
+    expect(err.code).toBe('CUSTOM_CODE');
+    expect(err.cause).toBe(cause);
+    expect(err.name).toBe('SessionKeyManagementError');
+  });
+
+  it('SessionKeyManagementError uses default code when omitted', () => {
+    const err = new SessionKeyManagementError('failed');
+    expect(err.code).toBe('SESSION_KEY_MANAGEMENT_FAILED');
+  });
+
+  it('TransactionSubmissionError carries resultXdr', () => {
+    const err = new TransactionSubmissionError('network error', 'AAAA==');
+    expect(err.code).toBe('SUBMISSION_FAILED');
+    expect(err.resultXdr).toBe('AAAA==');
+    expect(err.name).toBe('TransactionSubmissionError');
+  });
+
+  it('TransactionSubmissionError works without resultXdr', () => {
+    const err = new TransactionSubmissionError('network error');
+    expect(err.resultXdr).toBeUndefined();
+  });
+
+  it('SessionKeyExecutionValidationError has correct code', () => {
+    const err = new SessionKeyExecutionValidationError('invalid signer');
+    expect(err.code).toBe('SESSION_KEY_EXECUTION_VALIDATION');
+    expect(err.name).toBe('SessionKeyExecutionValidationError');
+  });
+
+  it('SessionKeyExecutionError carries code and cause', () => {
+    const cause = new Error('root cause');
+    const err = new SessionKeyExecutionError('SESSION_KEY_EXECUTION_FAILED', 'exec failed', cause);
+    expect(err.code).toBe('SESSION_KEY_EXECUTION_FAILED');
+    expect(err.cause).toBe(cause);
+    expect(err.name).toBe('SessionKeyExecutionError');
+  });
+
+  it('PaymentRequestValidationError has correct code', () => {
+    const err = new PaymentRequestValidationError('missing field');
+    expect(err.code).toBe('PAYMENT_REQUEST_VALIDATION');
+    expect(err.name).toBe('PaymentRequestValidationError');
+  });
+
+  it('InvalidAmountError has correct code', () => {
+    const err = new InvalidAmountError('amount too large');
+    expect(err.code).toBe('INVALID_AMOUNT');
+    expect(err.name).toBe('InvalidAmountError');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeError — uncovered branches
+// ---------------------------------------------------------------------------
+
+describe('normalizeError — additional branches', () => {
+  it('returns UNKNOWN for null', () => {
+    const n = normalizeError(null);
+    expect(n.code).toBe('UNKNOWN');
+    expect(n.category).toBe('UNKNOWN');
+  });
+
+  it('returns UNKNOWN for undefined', () => {
+    const n = normalizeError(undefined);
+    expect(n.code).toBe('UNKNOWN');
+    expect(n.category).toBe('UNKNOWN');
+  });
+
+  it('handles AncoreSdkError instance', () => {
+    const err = new BuilderValidationError('bad input');
+    const n = normalizeError(err);
+    expect(n.code).toBe('BUILDER_VALIDATION');
+    expect(n.category).toBe('VALIDATION');
+  });
+
+  it('handles Error with .code property', () => {
+    const err = Object.assign(new Error('oops'), { code: 'ETIMEDOUT' });
+    const n = normalizeError(err);
+    expect(n.code).toBe('ETIMEDOUT');
+    expect(n.category).toBe('NETWORK');
+  });
+
+  it('handles Error with resultXdr (submission shape)', () => {
+    const err = Object.assign(new Error('submission failed'), { resultXdr: 'AAAA==' });
+    const n = normalizeError(err);
+    expect(n.code).toBe('SUBMISSION_FAILED');
+    expect(n.category).toBe('CONTRACT');
+  });
+
+  it('classifies network-pattern error message', () => {
+    const err = new Error('Failed to fetch data from server');
+    const n = normalizeError(err);
+    expect(n.category).toBe('NETWORK');
+  });
+
+  it('classifies contract-pattern error message', () => {
+    const err = new Error('contract execution reverted');
+    const n = normalizeError(err);
+    expect(n.category).toBe('CONTRACT');
+  });
+
+  it('returns UNKNOWN for plain Error with no matching pattern', () => {
+    const err = new Error('something completely different');
+    const n = normalizeError(err);
+    expect(n.code).toBe('UNKNOWN');
+    expect(n.category).toBe('UNKNOWN');
+  });
+
+  it('handles network-pattern string input', () => {
+    const n = normalizeError('net::ERR_CONNECTION_REFUSED');
+    expect(n.category).toBe('NETWORK');
+  });
+
+  it('handles validation-pattern string input', () => {
+    const n = normalizeError('invalid address format');
+    expect(n.category).toBe('VALIDATION');
+  });
+
+  it('handles contract-pattern string input', () => {
+    const n = normalizeError('insufficient balance for session key');
+    expect(n.category).toBe('CONTRACT');
+  });
+
+  it('handles plain unknown string input', () => {
+    const n = normalizeError('something random');
+    expect(n.code).toBe('UNKNOWN');
+    expect(n.category).toBe('UNKNOWN');
+  });
+
+  it('handles non-Error object with code and message', () => {
+    const n = normalizeError({ code: 'SIMULATION_FAILED', message: 'sim failed' });
+    expect(n.code).toBe('SIMULATION_FAILED');
+    expect(n.category).toBe('CONTRACT');
+  });
+
+  it('handles non-Error object with empty code', () => {
+    const n = normalizeError({ code: '', message: 'no code' });
+    expect(n.code).toBe('UNKNOWN');
+  });
+
+  it('handles non-serialisable object fallback', () => {
+    const circular: Record<string, unknown> = {};
+    circular['self'] = circular;
+    const n = normalizeError(circular);
+    // circular object has no code/message — falls through to stringify which throws,
+    // so it hits the final String(error) fallback
+    expect(n.code).toBe('UNKNOWN');
+    expect(typeof n.message).toBe('string');
+  });
+});

--- a/packages/core-sdk/src/__tests__/execute-with-session-key.test.ts
+++ b/packages/core-sdk/src/__tests__/execute-with-session-key.test.ts
@@ -1,0 +1,98 @@
+import { xdr } from '@stellar/stellar-sdk';
+import { mapExecuteWithSessionKeyError, AncoreClient } from '../execute-with-session-key';
+import {
+  AncoreSdkError,
+  SessionKeyExecutionError,
+  SessionKeyExecutionValidationError,
+} from '../errors';
+
+// Mock account-abstraction to avoid full contract setup
+jest.mock('@ancore/account-abstraction', () => {
+  class AccountContractError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'AccountContractError';
+    }
+  }
+  class UnauthorizedError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'UnauthorizedError';
+    }
+  }
+  class InvalidNonceError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'InvalidNonceError';
+    }
+  }
+  class NotInitializedError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'NotInitializedError';
+    }
+  }
+  return {
+    AccountContractError,
+    UnauthorizedError,
+    InvalidNonceError,
+    NotInitializedError,
+    AccountContract: class {
+      execute() {
+        return {};
+      }
+    },
+  };
+});
+
+// Pull the mocked classes out for use in tests
+const { UnauthorizedError, InvalidNonceError, NotInitializedError, AccountContractError } =
+  jest.requireMock('@ancore/account-abstraction');
+
+describe('mapExecuteWithSessionKeyError', () => {
+  it('passes through AncoreSdkError unchanged', () => {
+    const err = new SessionKeyExecutionError('SESSION_KEY_EXECUTION_FAILED', 'already sdk error');
+    expect(mapExecuteWithSessionKeyError(err)).toBe(err);
+  });
+
+  it('maps UnauthorizedError to SESSION_KEY_EXECUTION_UNAUTHORIZED', () => {
+    const err = new UnauthorizedError('not allowed');
+    const result = mapExecuteWithSessionKeyError(err);
+    expect(result).toBeInstanceOf(SessionKeyExecutionError);
+    expect((result as SessionKeyExecutionError).code).toBe('SESSION_KEY_EXECUTION_UNAUTHORIZED');
+  });
+
+  it('maps InvalidNonceError to SESSION_KEY_EXECUTION_INVALID_NONCE', () => {
+    const err = new InvalidNonceError('bad nonce');
+    const result = mapExecuteWithSessionKeyError(err);
+    expect(result).toBeInstanceOf(SessionKeyExecutionError);
+    expect((result as SessionKeyExecutionError).code).toBe('SESSION_KEY_EXECUTION_INVALID_NONCE');
+  });
+
+  it('maps NotInitializedError to SESSION_KEY_EXECUTION_NOT_INITIALIZED', () => {
+    const err = new NotInitializedError('not init');
+    const result = mapExecuteWithSessionKeyError(err);
+    expect(result).toBeInstanceOf(SessionKeyExecutionError);
+    expect((result as SessionKeyExecutionError).code).toBe('SESSION_KEY_EXECUTION_NOT_INITIALIZED');
+  });
+
+  it('maps AccountContractError to SESSION_KEY_EXECUTION_CONTRACT', () => {
+    const err = new AccountContractError('contract error');
+    const result = mapExecuteWithSessionKeyError(err);
+    expect(result).toBeInstanceOf(SessionKeyExecutionError);
+    expect((result as SessionKeyExecutionError).code).toBe('SESSION_KEY_EXECUTION_CONTRACT');
+  });
+
+  it('maps generic Error to SESSION_KEY_EXECUTION_FAILED', () => {
+    const err = new Error('unexpected');
+    const result = mapExecuteWithSessionKeyError(err);
+    expect(result).toBeInstanceOf(SessionKeyExecutionError);
+    expect((result as SessionKeyExecutionError).code).toBe('SESSION_KEY_EXECUTION_FAILED');
+  });
+
+  it('maps unknown non-Error to SESSION_KEY_EXECUTION_FAILED', () => {
+    const result = mapExecuteWithSessionKeyError('string error');
+    expect(result).toBeInstanceOf(SessionKeyExecutionError);
+    expect((result as SessionKeyExecutionError).code).toBe('SESSION_KEY_EXECUTION_FAILED');
+  });
+});

--- a/packages/core-sdk/src/__tests__/scheduler-client-extra.test.ts
+++ b/packages/core-sdk/src/__tests__/scheduler-client-extra.test.ts
@@ -1,0 +1,150 @@
+import {
+  HttpSchedulerClient,
+  createSchedulerClient,
+  getSchedulerClient,
+  resetSchedulerClientForTests,
+  buildDefaultRelayPayload,
+  toIsoStartAt,
+  defaultScheduleStartAt,
+  resolveRelayerBaseUrl,
+  DEMO_ACCOUNT_ADDRESS,
+  SCHEDULE_FREQUENCY_OPTIONS,
+} from '../scheduler-client';
+
+describe('resolveRelayerBaseUrl', () => {
+  it('returns explicit URL stripped of trailing slash', () => {
+    expect(resolveRelayerBaseUrl('https://relayer.example.com/')).toBe(
+      'https://relayer.example.com'
+    );
+  });
+
+  it('falls back to localhost when no argument given', () => {
+    expect(resolveRelayerBaseUrl()).toBe('http://localhost:3000');
+  });
+});
+
+describe('getSchedulerClient / resetSchedulerClientForTests', () => {
+  beforeEach(() => {
+    resetSchedulerClientForTests();
+  });
+
+  it('returns a shared singleton when called with no options', () => {
+    const a = getSchedulerClient();
+    const b = getSchedulerClient();
+    expect(a).toBe(b);
+  });
+
+  it('returns a fresh client when options are provided', () => {
+    const a = getSchedulerClient();
+    const b = getSchedulerClient({ baseUrl: 'http://custom.test' });
+    expect(a).not.toBe(b);
+  });
+
+  it('resets singleton so next call creates a new instance', () => {
+    const a = getSchedulerClient();
+    resetSchedulerClientForTests();
+    const b = getSchedulerClient();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('buildDefaultRelayPayload', () => {
+  it('returns a payload with expected shape', () => {
+    const payload = buildDefaultRelayPayload('GDEST...', '100');
+    expect(payload.operation).toBe('relay_execute');
+    expect(payload.parameters.to).toBe('GDEST...');
+    expect(payload.parameters.amount).toBe('100');
+    expect(payload.parameters.asset).toBe('XLM');
+    expect(payload.sessionKey).toHaveLength(64);
+    expect(payload.signature).toHaveLength(128);
+    expect(typeof payload.nonce).toBe('number');
+  });
+});
+
+describe('toIsoStartAt', () => {
+  it('converts local datetime string to ISO format', () => {
+    const result = toIsoStartAt('2025-06-25T10:00');
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});
+
+describe('defaultScheduleStartAt', () => {
+  it('returns an ISO datetime string approximately 1 hour in the future', () => {
+    const now = Date.now();
+    const result = defaultScheduleStartAt();
+    expect(typeof result).toBe('string');
+    // Format: YYYY-MM-DDTHH:MM (no seconds — truncated to minute boundary)
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+    const resultMs = new Date(result).getTime();
+    // Allow up to 1 minute behind now (truncation) but must be well under 2 hours ahead
+    expect(resultMs).toBeGreaterThan(now - 60_000);
+    expect(resultMs).toBeLessThan(now + 2 * 60 * 60 * 1000);
+  });
+});
+
+describe('SCHEDULE_FREQUENCY_OPTIONS', () => {
+  it('contains all four frequency options', () => {
+    const values = SCHEDULE_FREQUENCY_OPTIONS.map((o) => o.value);
+    expect(values).toContain('once');
+    expect(values).toContain('daily');
+    expect(values).toContain('weekly');
+    expect(values).toContain('monthly');
+  });
+});
+
+describe('DEMO_ACCOUNT_ADDRESS', () => {
+  it('is a non-empty string', () => {
+    expect(typeof DEMO_ACCOUNT_ADDRESS).toBe('string');
+    expect(DEMO_ACCOUNT_ADDRESS.length).toBeGreaterThan(0);
+  });
+});
+
+describe('HttpSchedulerClient — error and edge cases', () => {
+  const makeClient = (fetchImpl: typeof fetch) =>
+    new HttpSchedulerClient({ baseUrl: 'http://relayer.test', fetchImpl });
+
+  it('throws when server returns non-ok with JSON error body', async () => {
+    const fetchImpl = jest.fn(
+      async () => new Response(JSON.stringify({ message: 'not found' }), { status: 404 })
+    ) as unknown as typeof fetch;
+
+    const client = makeClient(fetchImpl);
+    await expect(client.getScheduledTransfer('missing-id')).rejects.toThrow('not found');
+  });
+
+  it('throws with status code when error body is not parseable', async () => {
+    const fetchImpl = jest.fn(
+      async () => new Response('bad gateway', { status: 502 })
+    ) as unknown as typeof fetch;
+
+    const client = makeClient(fetchImpl);
+    await expect(client.getScheduledTransfer('x')).rejects.toThrow('502');
+  });
+
+  it('pauseScheduledTransfer sends PATCH to correct URL', async () => {
+    let capturedUrl = '';
+    let capturedMethod = '';
+    const fetchImpl = jest.fn(async (url: string, init?: RequestInit) => {
+      capturedUrl = url as string;
+      capturedMethod = init?.method ?? '';
+      return new Response(JSON.stringify({ data: { id: 'abc' } }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = makeClient(fetchImpl);
+    await client.pauseScheduledTransfer('abc');
+    expect(capturedUrl).toContain('/abc/pause');
+    expect(capturedMethod).toBe('PATCH');
+  });
+
+  it('cancelScheduledTransfer sends PATCH to correct URL', async () => {
+    let capturedUrl = '';
+    const fetchImpl = jest.fn(async (url: string) => {
+      capturedUrl = url as string;
+      return new Response(JSON.stringify({ data: { id: 'abc' } }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const client = makeClient(fetchImpl);
+    await client.cancelScheduledTransfer('abc');
+    expect(capturedUrl).toContain('/abc/cancel');
+  });
+});

--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -90,6 +90,23 @@ export {
   getRetryPreset,
 } from './retry-presets';
 
+// Account sequence fetch helper — re-exported from @ancore/stellar for SDK consumers.
+// Use fetchAccountSequence to retrieve a Stellar account's current sequence number
+// before building transactions in the send flow.
+//
+// Example:
+//   import { fetchAccountSequence } from '@ancore/core-sdk';
+//   const { sequence } = await fetchAccountSequence(horizonServer, publicKey, {
+//     maxRetries: 3,
+//     cacheTtlMs: 5_000,
+//   });
+export {
+  fetchAccountSequence,
+  clearSequenceCache,
+  type AccountSequenceResult,
+  type FetchAccountSequenceOptions,
+} from '@ancore/stellar';
+
 // Scheduled transfers
 export {
   HttpSchedulerClient,

--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -5,3 +5,49 @@ Cryptographic utilities for Ancore wallet.
 ## Assumptions
 
 This package makes several assumptions about cryptographic operations. For details on supported transaction envelope types, encryption parameters, and other security assumptions, see [CRYPTO_ASSUMPTIONS.md](./src/CRYPTO_ASSUMPTIONS.md).
+
+## Mnemonic Validation
+
+### `validateMnemonicStrength(mnemonic: string): void`
+
+Validates a BIP39 mnemonic phrase and throws a typed `MnemonicValidationError` on failure.
+Use this in wallet import flows where clear error messages are needed.
+
+```typescript
+import { validateMnemonicStrength, MnemonicValidationError } from '@ancore/crypto';
+
+try {
+  validateMnemonicStrength(userInput);
+  // Proceed with import — checksum and wordlist are valid
+} catch (err) {
+  if (err instanceof MnemonicValidationError) {
+    // err.code is one of:
+    //   'INVALID_TYPE'     — not a non-empty string
+    //   'INVALID_LENGTH'   — must be 12 or 24 words
+    //   'UNKNOWN_WORDS'    — contains words not in the English BIP39 wordlist
+    //   'INVALID_CHECKSUM' — BIP39 checksum mismatch (likely a typo)
+    console.error(err.message); // Human-readable message safe to show users
+    console.debug(err.details); // Extra debugging context (optional)
+  }
+}
+```
+
+**Validated checks (in order):**
+
+1. Input must be a non-empty string.
+2. Word count must be exactly 12 or 24 (other BIP39 lengths are not supported).
+3. Every word must exist in the English BIP39 wordlist (non-English wordlists are rejected).
+4. BIP39 checksum must pass.
+
+**Note:** Non-English BIP39 wordlists (Chinese, French, Italian, Japanese, Korean, Spanish, Czech,
+Portuguese) are intentionally not supported. Use `assertEnglishMnemonic` directly if you need
+a descriptive error specifically for language rejection.
+
+### `validateMnemonic(mnemonic: string): boolean`
+
+Non-throwing variant. Returns `true` for a valid 12-word English BIP39 mnemonic, `false` otherwise.
+Only accepts 12-word mnemonics (unlike `validateMnemonicStrength` which also accepts 24 words).
+
+### `generateMnemonic(): string`
+
+Generates a cryptographically secure 12-word BIP39 mnemonic using 128 bits of entropy.

--- a/packages/crypto/src/__tests__/mnemonic-strength.test.ts
+++ b/packages/crypto/src/__tests__/mnemonic-strength.test.ts
@@ -1,0 +1,177 @@
+import { validateMnemonicStrength, MnemonicValidationError } from '../mnemonic';
+import * as bip39 from 'bip39';
+
+describe('validateMnemonicStrength', () => {
+  it('accepts a valid 12-word mnemonic', () => {
+    const validMnemonic = bip39.generateMnemonic(128);
+    expect(() => validateMnemonicStrength(validMnemonic)).not.toThrow();
+  });
+
+  it('accepts a valid 24-word mnemonic', () => {
+    const validMnemonic = bip39.generateMnemonic(256);
+    expect(() => validateMnemonicStrength(validMnemonic)).not.toThrow();
+  });
+
+  it('throws INVALID_TYPE for empty string', () => {
+    expect(() => validateMnemonicStrength('')).toThrow(MnemonicValidationError);
+    try {
+      validateMnemonicStrength('');
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MnemonicValidationError);
+      if (err instanceof MnemonicValidationError) {
+        expect(err.code).toBe('INVALID_TYPE');
+      }
+    }
+  });
+
+  it('throws INVALID_TYPE for null input', () => {
+    expect(() => validateMnemonicStrength(null as unknown as string)).toThrow(
+      MnemonicValidationError
+    );
+    try {
+      validateMnemonicStrength(null as unknown as string);
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MnemonicValidationError);
+      if (err instanceof MnemonicValidationError) {
+        expect(err.code).toBe('INVALID_TYPE');
+      }
+    }
+  });
+
+  it('throws INVALID_TYPE for undefined input', () => {
+    expect(() => validateMnemonicStrength(undefined as unknown as string)).toThrow(
+      MnemonicValidationError
+    );
+    try {
+      validateMnemonicStrength(undefined as unknown as string);
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MnemonicValidationError);
+      if (err instanceof MnemonicValidationError) {
+        expect(err.code).toBe('INVALID_TYPE');
+      }
+    }
+  });
+
+  it('throws INVALID_LENGTH for 11-word mnemonic', () => {
+    const validMnemonic = bip39.generateMnemonic(128);
+    const words = validMnemonic.split(' ');
+    words.pop();
+    const invalidMnemonic = words.join(' ');
+
+    expect(() => validateMnemonicStrength(invalidMnemonic)).toThrow(MnemonicValidationError);
+    try {
+      validateMnemonicStrength(invalidMnemonic);
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MnemonicValidationError);
+      if (err instanceof MnemonicValidationError) {
+        expect(err.code).toBe('INVALID_LENGTH');
+        expect(err.message).toContain('11');
+      }
+    }
+  });
+
+  it('throws INVALID_LENGTH for 13-word mnemonic', () => {
+    const validMnemonic = bip39.generateMnemonic(128);
+    const words = validMnemonic.split(' ');
+    words.push('abandon'); // Add a valid word to make it 13
+    const invalidMnemonic = words.join(' ');
+
+    expect(() => validateMnemonicStrength(invalidMnemonic)).toThrow(MnemonicValidationError);
+    try {
+      validateMnemonicStrength(invalidMnemonic);
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MnemonicValidationError);
+      if (err instanceof MnemonicValidationError) {
+        expect(err.code).toBe('INVALID_LENGTH');
+        expect(err.message).toContain('13');
+      }
+    }
+  });
+
+  it('throws UNKNOWN_WORDS for mnemonic with typo', () => {
+    const validMnemonic = bip39.generateMnemonic(128);
+    const words = validMnemonic.split(' ');
+    words[0] = 'invalidwordthatdoesnotexist';
+    const invalidMnemonic = words.join(' ');
+
+    expect(() => validateMnemonicStrength(invalidMnemonic)).toThrow(MnemonicValidationError);
+    try {
+      validateMnemonicStrength(invalidMnemonic);
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MnemonicValidationError);
+      if (err instanceof MnemonicValidationError) {
+        expect(err.code).toBe('UNKNOWN_WORDS');
+        expect(err.details).toContain('invalidwordthatdoesnotexist');
+      }
+    }
+  });
+
+  it('throws INVALID_CHECKSUM for mnemonic with wrong checksum', () => {
+    const validMnemonic = bip39.generateMnemonic(128);
+    const words = validMnemonic.split(' ');
+    // Swap last two words to break checksum
+    const last = words[words.length - 1];
+    const secondLast = words[words.length - 2];
+    words[words.length - 1] = secondLast;
+    words[words.length - 2] = last;
+    const invalidMnemonic = words.join(' ');
+
+    expect(() => validateMnemonicStrength(invalidMnemonic)).toThrow(MnemonicValidationError);
+    try {
+      validateMnemonicStrength(invalidMnemonic);
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MnemonicValidationError);
+      if (err instanceof MnemonicValidationError) {
+        expect(err.code).toBe('INVALID_CHECKSUM');
+      }
+    }
+  });
+
+  it('handles extra whitespace correctly', () => {
+    const validMnemonic = bip39.generateMnemonic(128);
+    const spacedMnemonic = validMnemonic.replace(/ /g, '   ');
+    expect(() => validateMnemonicStrength(spacedMnemonic)).not.toThrow();
+  });
+
+  it('throws UNKNOWN_WORDS for non-English wordlist words', () => {
+    // Use 12 words total: 6 non-English BIP39 words + 6 valid English words
+    // This passes the length check (12 words) but fails the wordlist check
+    const invalidMnemonic =
+      'página biblioteca école escuela bibliothek abandon abandon abandon abandon abandon abandon abandon';
+    expect(() => validateMnemonicStrength(invalidMnemonic)).toThrow(MnemonicValidationError);
+    try {
+      validateMnemonicStrength(invalidMnemonic);
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MnemonicValidationError);
+      if (err instanceof MnemonicValidationError) {
+        expect(err.code).toBe('UNKNOWN_WORDS');
+      }
+    }
+  });
+
+  it('provides details field for debugging', () => {
+    const validMnemonic = bip39.generateMnemonic(128);
+    const words = validMnemonic.split(' ');
+    words[0] = 'typoword';
+    const invalidMnemonic = words.join(' ');
+
+    try {
+      validateMnemonicStrength(invalidMnemonic);
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(MnemonicValidationError);
+      if (err instanceof MnemonicValidationError) {
+        expect(err.details).toBeDefined();
+        expect(typeof err.details).toBe('string');
+      }
+    }
+  });
+});

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -46,7 +46,8 @@ export { encryptSecretKey, decryptSecretKey } from './encryption';
 export type { EncryptedSecretKeyPayload } from './encryption';
 
 // Mnemonics
-export { generateMnemonic, validateMnemonic } from './mnemonic';
+export { generateMnemonic, validateMnemonic, validateMnemonicStrength } from './mnemonic';
+export { MnemonicValidationError } from './mnemonic';
 
 // Key Derivation
 export { deriveKeypairFromMnemonic } from './key-derivation';

--- a/packages/crypto/src/mnemonic.ts
+++ b/packages/crypto/src/mnemonic.ts
@@ -68,6 +68,26 @@ export function generateMnemonic(): string {
 }
 
 /**
+ * Error thrown when mnemonic strength validation fails.
+ * Provides specific error codes for different failure modes.
+ */
+export class MnemonicValidationError extends Error {
+  public readonly code: 'INVALID_LENGTH' | 'UNKNOWN_WORDS' | 'INVALID_CHECKSUM' | 'INVALID_TYPE';
+  public readonly details?: string;
+
+  constructor(
+    code: 'INVALID_LENGTH' | 'UNKNOWN_WORDS' | 'INVALID_CHECKSUM' | 'INVALID_TYPE',
+    message: string,
+    details?: string
+  ) {
+    super(message);
+    this.name = 'MnemonicValidationError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+/**
  * Validates a given mnemonic phrase.
  * Ensures the phrase is a valid BIP39 12-word mnemonic using the English
  * wordlist only.
@@ -102,4 +122,77 @@ export function validateMnemonic(mnemonic: string): boolean {
 
   // Validate against BIP39 English wordlist and checksum
   return bip39.validateMnemonic(normalizedMnemonic);
+}
+
+/**
+ * Validates mnemonic strength and throws descriptive errors for invalid mnemonics.
+ * This is the preferred validation method for wallet import flows where clear
+ * error messages are needed.
+ *
+ * Validates:
+ * - Input type (must be non-empty string)
+ * - Word count (must be 12 or 24 words)
+ * - Wordlist (must be English BIP39 only)
+ * - Checksum (must pass BIP39 validation)
+ *
+ * @param mnemonic - The mnemonic phrase to validate
+ * @throws {MnemonicValidationError} With specific error code and message
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   validateMnemonicStrength(userInput);
+ *   // Proceed with import
+ * } catch (err) {
+ *   if (err instanceof MnemonicValidationError) {
+ *     // Display err.message to user based on err.code
+ *   }
+ * }
+ * ```
+ */
+export function validateMnemonicStrength(mnemonic: string): void {
+  if (!mnemonic || typeof mnemonic !== 'string') {
+    throw new MnemonicValidationError('INVALID_TYPE', 'Mnemonic must be a non-empty string');
+  }
+
+  const trimmed = mnemonic.trim();
+  if (trimmed.length === 0) {
+    throw new MnemonicValidationError('INVALID_TYPE', 'Mnemonic must not be empty');
+  }
+
+  const words = trimmed.split(/\s+/);
+
+  // Validate word count (support both 12 and 24 word mnemonics)
+  if (words.length !== 12 && words.length !== 24) {
+    throw new MnemonicValidationError(
+      'INVALID_LENGTH',
+      `Mnemonic must be 12 or 24 words, got ${words.length}`,
+      `Expected: 12 or 24 words, Actual: ${words.length}`
+    );
+  }
+
+  const normalizedMnemonic = words.join(' ');
+
+  // Check for unknown words (non-English BIP39)
+  try {
+    assertEnglishMnemonic(normalizedMnemonic);
+  } catch (err) {
+    if (err instanceof UnsupportedMnemonicLanguageError) {
+      throw new MnemonicValidationError(
+        'UNKNOWN_WORDS',
+        `Mnemonic contains unsupported words: ${err.unsupportedWords.join(', ')}`,
+        `Unsupported words: ${err.unsupportedWords.join(', ')}`
+      );
+    }
+    throw err;
+  }
+
+  // Validate BIP39 checksum
+  if (!bip39.validateMnemonic(normalizedMnemonic)) {
+    throw new MnemonicValidationError(
+      'INVALID_CHECKSUM',
+      'Mnemonic checksum validation failed. Please check for typos.',
+      'The mnemonic does not pass BIP39 checksum validation'
+    );
+  }
 }

--- a/packages/stellar/src/__tests__/account-sequence.test.ts
+++ b/packages/stellar/src/__tests__/account-sequence.test.ts
@@ -1,0 +1,241 @@
+import { Horizon } from '@stellar/stellar-sdk';
+import { fetchAccountSequence, clearSequenceCache } from '../account-sequence';
+import { AccountNotFoundError, NetworkError } from '../errors';
+
+describe('fetchAccountSequence', () => {
+  let mockHorizon: Horizon.Server;
+  let mockLoadAccount: jest.Mock;
+
+  beforeEach(() => {
+    // Clear cache before each test
+    clearSequenceCache();
+
+    // Mock Horizon server
+    mockLoadAccount = jest.fn();
+    mockHorizon = {
+      loadAccount: mockLoadAccount,
+    } as unknown as Horizon.Server;
+  });
+
+  it('fetches account sequence successfully', async () => {
+    mockLoadAccount.mockResolvedValue({
+      sequence: '1234567890',
+      account_id: 'GABC123',
+    });
+
+    const result = await fetchAccountSequence(mockHorizon, 'GABC123');
+
+    expect(result.sequence).toBe(BigInt(1234567890));
+    expect(result.accountId).toBe('GABC123');
+    expect(result.fetchedAt).toBeGreaterThan(0);
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws AccountNotFoundError for unfunded account (404)', async () => {
+    const error404 = new Error('Not Found');
+    (error404 as Error & { status: number }).status = 404;
+    mockLoadAccount.mockRejectedValue(error404);
+
+    await expect(fetchAccountSequence(mockHorizon, 'GUNFUNDED')).rejects.toThrow(
+      AccountNotFoundError
+    );
+
+    try {
+      await fetchAccountSequence(mockHorizon, 'GUNFUNDED');
+      throw new Error('Should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AccountNotFoundError);
+      if (err instanceof AccountNotFoundError) {
+        expect(err.publicKey).toBe('GUNFUNDED');
+      }
+    }
+  });
+
+  it('retries on 429 rate limit errors', async () => {
+    let attempts = 0;
+    mockLoadAccount.mockImplementation(() => {
+      attempts++;
+      if (attempts < 3) {
+        const error429 = new Error('Too Many Requests');
+        (error429 as Error & { status: number }).status = 429;
+        return Promise.reject(error429);
+      }
+      return Promise.resolve({
+        sequence: '9876543210',
+        account_id: 'GABC123',
+      });
+    });
+
+    const result = await fetchAccountSequence(mockHorizon, 'GABC123', { maxRetries: 3 });
+
+    expect(result.sequence).toBe(BigInt(9876543210));
+    expect(attempts).toBe(3);
+  });
+
+  it('retries on 5xx server errors', async () => {
+    let attempts = 0;
+    mockLoadAccount.mockImplementation(() => {
+      attempts++;
+      if (attempts < 2) {
+        const error500 = new Error('Internal Server Error');
+        (error500 as Error & { status: number }).status = 500;
+        return Promise.reject(error500);
+      }
+      return Promise.resolve({
+        sequence: '1111111111',
+        account_id: 'GABC123',
+      });
+    });
+
+    const result = await fetchAccountSequence(mockHorizon, 'GABC123', { maxRetries: 3 });
+
+    expect(result.sequence).toBe(BigInt(1111111111));
+    expect(attempts).toBe(2);
+  });
+
+  it('does not retry AccountNotFoundError', async () => {
+    const error404 = new Error('Not Found');
+    (error404 as Error & { status: number }).status = 404;
+    mockLoadAccount.mockRejectedValue(error404);
+
+    await expect(fetchAccountSequence(mockHorizon, 'GUNFUNDED', { maxRetries: 5 })).rejects.toThrow(
+      AccountNotFoundError
+    );
+
+    // Should only attempt once, not retry
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses cache when TTL is valid', async () => {
+    mockLoadAccount.mockResolvedValue({
+      sequence: '1234567890',
+      account_id: 'GABC123',
+    });
+
+    // First fetch
+    const result1 = await fetchAccountSequence(mockHorizon, 'GABC123', { cacheTtlMs: 1000 });
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
+
+    // Second fetch should use cache
+    const result2 = await fetchAccountSequence(mockHorizon, 'GABC123', { cacheTtlMs: 1000 });
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1); // Still only called once
+    expect(result2.sequence).toBe(result1.sequence);
+  });
+
+  it('bypasses cache when TTL is 0', async () => {
+    mockLoadAccount.mockResolvedValue({
+      sequence: '1234567890',
+      account_id: 'GABC123',
+    });
+
+    await fetchAccountSequence(mockHorizon, 'GABC123', { cacheTtlMs: 0 });
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
+
+    await fetchAccountSequence(mockHorizon, 'GABC123', { cacheTtlMs: 0 });
+    expect(mockLoadAccount).toHaveBeenCalledTimes(2); // Called again
+  });
+
+  it('expires cache entries after TTL', async () => {
+    mockLoadAccount.mockResolvedValue({
+      sequence: '1234567890',
+      account_id: 'GABC123',
+    });
+
+    // First fetch with 10ms TTL
+    await fetchAccountSequence(mockHorizon, 'GABC123', { cacheTtlMs: 10 });
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
+
+    // Wait for cache to expire
+    await new Promise((resolve) => setTimeout(resolve, 15));
+
+    // Second fetch should bypass expired cache
+    await fetchAccountSequence(mockHorizon, 'GABC123', { cacheTtlMs: 10 });
+    expect(mockLoadAccount).toHaveBeenCalledTimes(2);
+  });
+
+  it('respects custom maxRetries option', async () => {
+    let attempts = 0;
+    mockLoadAccount.mockImplementation(() => {
+      attempts++;
+      const error500 = new Error('Internal Server Error');
+      (error500 as Error & { status: number }).status = 500;
+      return Promise.reject(error500);
+    });
+
+    await expect(fetchAccountSequence(mockHorizon, 'GABC123', { maxRetries: 2 })).rejects.toThrow(
+      NetworkError
+    );
+
+    // Should attempt maxRetries + 1 = 3 times
+    expect(attempts).toBe(3);
+  });
+
+  it('handles network errors with retry', async () => {
+    let attempts = 0;
+    mockLoadAccount.mockImplementation(() => {
+      attempts++;
+      if (attempts < 2) {
+        return Promise.reject(new Error('Network error'));
+      }
+      return Promise.resolve({
+        sequence: '2222222222',
+        account_id: 'GABC123',
+      });
+    });
+
+    const result = await fetchAccountSequence(mockHorizon, 'GABC123', { maxRetries: 3 });
+
+    expect(result.sequence).toBe(BigInt(2222222222));
+    expect(attempts).toBe(2);
+  });
+
+  it('clears cache with clearSequenceCache', async () => {
+    mockLoadAccount.mockResolvedValue({
+      sequence: '1234567890',
+      account_id: 'GABC123',
+    });
+
+    await fetchAccountSequence(mockHorizon, 'GABC123', { cacheTtlMs: 1000 });
+    expect(mockLoadAccount).toHaveBeenCalledTimes(1);
+
+    clearSequenceCache();
+
+    await fetchAccountSequence(mockHorizon, 'GABC123', { cacheTtlMs: 1000 });
+    expect(mockLoadAccount).toHaveBeenCalledTimes(2); // Called again after cache clear
+  });
+
+  it('returns result with correct structure', async () => {
+    const beforeFetch = Date.now();
+    mockLoadAccount.mockResolvedValue({
+      sequence: '9999999999',
+      account_id: 'GTEST123',
+    });
+
+    const result = await fetchAccountSequence(mockHorizon, 'GTEST123');
+
+    expect(result).toHaveProperty('sequence');
+    expect(result).toHaveProperty('accountId');
+    expect(result).toHaveProperty('fetchedAt');
+    expect(typeof result.sequence).toBe('bigint');
+    expect(typeof result.accountId).toBe('string');
+    expect(typeof result.fetchedAt).toBe('number');
+    expect(result.fetchedAt).toBeGreaterThanOrEqual(beforeFetch);
+  });
+
+  it('handles different account IDs separately in cache', async () => {
+    mockLoadAccount.mockImplementation((accountId: string) => {
+      const sequence = accountId === 'GABC1' ? '1111111111' : '2222222222';
+      return Promise.resolve({
+        sequence,
+        account_id: accountId,
+      });
+    });
+
+    const result1 = await fetchAccountSequence(mockHorizon, 'GABC1', { cacheTtlMs: 1000 });
+    const result2 = await fetchAccountSequence(mockHorizon, 'GABC2', { cacheTtlMs: 1000 });
+
+    expect(result1.sequence).toBe(BigInt(1111111111));
+    expect(result2.sequence).toBe(BigInt(2222222222));
+    expect(mockLoadAccount).toHaveBeenCalledTimes(2); // Both accounts fetched
+  });
+});

--- a/packages/stellar/src/__tests__/horizon-url.test.ts
+++ b/packages/stellar/src/__tests__/horizon-url.test.ts
@@ -1,0 +1,228 @@
+import { validateHorizonUrl, isValidHorizonUrl, HorizonUrlValidationError } from '../horizon-url';
+
+describe('validateHorizonUrl', () => {
+  describe('mainnet validation', () => {
+    it('accepts official mainnet Horizon URL', () => {
+      expect(() => validateHorizonUrl('https://horizon.stellar.org', 'mainnet')).not.toThrow();
+    });
+
+    it('accepts mainnet subdomain URLs', () => {
+      expect(() =>
+        validateHorizonUrl('https://horizon-public.stellar.org', 'mainnet')
+      ).not.toThrow();
+    });
+
+    it('rejects HTTP for mainnet', () => {
+      expect(() => validateHorizonUrl('http://horizon.stellar.org', 'mainnet')).toThrow(
+        HorizonUrlValidationError
+      );
+      try {
+        validateHorizonUrl('http://horizon.stellar.org', 'mainnet');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HorizonUrlValidationError);
+        if (err instanceof HorizonUrlValidationError) {
+          expect(err.code).toBe('INVALID_SCHEME');
+        }
+      }
+    });
+
+    it('rejects localhost for mainnet', () => {
+      expect(() => validateHorizonUrl('http://localhost:8000', 'mainnet')).toThrow(
+        HorizonUrlValidationError
+      );
+      try {
+        validateHorizonUrl('http://localhost:8000', 'mainnet');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HorizonUrlValidationError);
+        if (err instanceof HorizonUrlValidationError) {
+          expect(err.code).toBe('LOCALHOST_NOT_ALLOWED');
+        }
+      }
+    });
+
+    it('rejects testnet URL on mainnet profile', () => {
+      expect(() => validateHorizonUrl('https://horizon-testnet.stellar.org', 'mainnet')).toThrow(
+        HorizonUrlValidationError
+      );
+      try {
+        validateHorizonUrl('https://horizon-testnet.stellar.org', 'mainnet');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HorizonUrlValidationError);
+        if (err instanceof HorizonUrlValidationError) {
+          expect(err.code).toBe('NETWORK_MISMATCH');
+        }
+      }
+    });
+
+    it('rejects invalid hostname', () => {
+      expect(() => validateHorizonUrl('https://evil.com', 'mainnet')).toThrow(
+        HorizonUrlValidationError
+      );
+      try {
+        validateHorizonUrl('https://evil.com', 'mainnet');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HorizonUrlValidationError);
+        if (err instanceof HorizonUrlValidationError) {
+          expect(err.code).toBe('INVALID_HOSTNAME');
+        }
+      }
+    });
+  });
+
+  describe('testnet validation', () => {
+    it('accepts official testnet Horizon URL', () => {
+      expect(() =>
+        validateHorizonUrl('https://horizon-testnet.stellar.org', 'testnet')
+      ).not.toThrow();
+    });
+
+    it('rejects mainnet URL on testnet profile', () => {
+      expect(() => validateHorizonUrl('https://horizon.stellar.org', 'testnet')).toThrow(
+        HorizonUrlValidationError
+      );
+      try {
+        validateHorizonUrl('https://horizon.stellar.org', 'testnet');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HorizonUrlValidationError);
+        if (err instanceof HorizonUrlValidationError) {
+          expect(err.code).toBe('NETWORK_MISMATCH');
+        }
+      }
+    });
+
+    it('rejects HTTP for testnet', () => {
+      expect(() => validateHorizonUrl('http://horizon-testnet.stellar.org', 'testnet')).toThrow(
+        HorizonUrlValidationError
+      );
+      try {
+        validateHorizonUrl('http://horizon-testnet.stellar.org', 'testnet');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HorizonUrlValidationError);
+        if (err instanceof HorizonUrlValidationError) {
+          expect(err.code).toBe('INVALID_SCHEME');
+        }
+      }
+    });
+  });
+
+  describe('futurenet validation', () => {
+    it('accepts official futurenet Horizon URL', () => {
+      expect(() =>
+        validateHorizonUrl('https://horizon-futurenet.stellar.org', 'futurenet')
+      ).not.toThrow();
+    });
+
+    it('rejects mainnet URL on futurenet profile', () => {
+      expect(() => validateHorizonUrl('https://horizon.stellar.org', 'futurenet')).toThrow(
+        HorizonUrlValidationError
+      );
+    });
+  });
+
+  describe('local validation', () => {
+    it('accepts localhost with HTTP', () => {
+      expect(() => validateHorizonUrl('http://localhost:8000', 'local')).not.toThrow();
+    });
+
+    it('accepts 127.0.0.1 with HTTP', () => {
+      expect(() => validateHorizonUrl('http://127.0.0.1:8000', 'local')).not.toThrow();
+    });
+
+    it('accepts localhost without port', () => {
+      expect(() => validateHorizonUrl('http://localhost', 'local')).not.toThrow();
+    });
+
+    it('rejects non-localhost hostnames', () => {
+      expect(() => validateHorizonUrl('http://example.com', 'local')).toThrow(
+        HorizonUrlValidationError
+      );
+      try {
+        validateHorizonUrl('http://example.com', 'local');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HorizonUrlValidationError);
+        if (err instanceof HorizonUrlValidationError) {
+          expect(err.code).toBe('INVALID_HOSTNAME');
+        }
+      }
+    });
+  });
+
+  describe('invalid input handling', () => {
+    it('throws for empty string', () => {
+      expect(() => validateHorizonUrl('', 'mainnet')).toThrow(HorizonUrlValidationError);
+      try {
+        validateHorizonUrl('', 'mainnet');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HorizonUrlValidationError);
+        if (err instanceof HorizonUrlValidationError) {
+          expect(err.code).toBe('INVALID_URL');
+        }
+      }
+    });
+
+    it('throws for null input', () => {
+      expect(() => validateHorizonUrl(null as unknown as string, 'mainnet')).toThrow(
+        HorizonUrlValidationError
+      );
+    });
+
+    it('throws for malformed URL', () => {
+      expect(() => validateHorizonUrl('not-a-url', 'mainnet')).toThrow(HorizonUrlValidationError);
+      try {
+        validateHorizonUrl('not-a-url', 'mainnet');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HorizonUrlValidationError);
+        if (err instanceof HorizonUrlValidationError) {
+          expect(err.code).toBe('INVALID_URL');
+        }
+      }
+    });
+
+    it('trims whitespace before validation', () => {
+      expect(() => validateHorizonUrl('  https://horizon.stellar.org  ', 'mainnet')).not.toThrow();
+    });
+  });
+
+  describe('error details', () => {
+    it('includes URL and network in error', () => {
+      try {
+        validateHorizonUrl('http://evil.com', 'mainnet');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HorizonUrlValidationError);
+        if (err instanceof HorizonUrlValidationError) {
+          expect(err.url).toBe('http://evil.com');
+          expect(err.network).toBe('mainnet');
+          expect(err.code).toBeDefined();
+          expect(err.message).toBeDefined();
+        }
+      }
+    });
+  });
+});
+
+describe('isValidHorizonUrl', () => {
+  it('returns true for valid URLs', () => {
+    expect(isValidHorizonUrl('https://horizon.stellar.org', 'mainnet')).toBe(true);
+    expect(isValidHorizonUrl('https://horizon-testnet.stellar.org', 'testnet')).toBe(true);
+  });
+
+  it('returns false for invalid URLs', () => {
+    expect(isValidHorizonUrl('http://horizon.stellar.org', 'mainnet')).toBe(false);
+    expect(isValidHorizonUrl('https://evil.com', 'mainnet')).toBe(false);
+    expect(isValidHorizonUrl('', 'mainnet')).toBe(false);
+  });
+
+  it('does not throw for invalid URLs', () => {
+    expect(() => isValidHorizonUrl('invalid-url', 'mainnet')).not.toThrow();
+  });
+});

--- a/packages/stellar/src/account-sequence.ts
+++ b/packages/stellar/src/account-sequence.ts
@@ -1,0 +1,233 @@
+/**
+ * Account sequence fetch helper with retries, caching, and typed errors.
+ *
+ * Provides a robust way to fetch Stellar account sequence numbers with
+ * proper error handling for unfunded accounts, rate limits, and network errors.
+ */
+
+import { Horizon } from '@stellar/stellar-sdk';
+import { withRetry, type RetryOptions } from './retry';
+import { AccountNotFoundError, NetworkError } from './errors';
+
+/**
+ * Configuration options for fetching account sequence.
+ */
+export interface FetchAccountSequenceOptions {
+  /** Maximum number of retry attempts (default: 3) */
+  maxRetries?: number;
+  /** Time-to-live for cache in milliseconds (default: 5000, set to 0 to disable) */
+  cacheTtlMs?: number;
+  /** Whether to use jitter in retry delays (default: true) */
+  useJitter?: boolean;
+}
+
+/**
+ * Result of fetching account sequence.
+ */
+export interface AccountSequenceResult {
+  /** The account sequence number */
+  sequence: bigint;
+  /** The account ID (public key) */
+  accountId: string;
+  /** Timestamp when the sequence was fetched */
+  fetchedAt: number;
+}
+
+/**
+ * In-memory cache entry for account sequences.
+ */
+interface CacheEntry {
+  sequence: bigint;
+  fetchedAt: number;
+  expiresAt: number;
+}
+
+/**
+ * Default cache TTL: 5 seconds.
+ * Short TTL ensures sequence numbers stay relatively fresh while
+ * providing some protection against rapid successive fetches.
+ */
+const DEFAULT_CACHE_TTL_MS = 5000;
+
+/**
+ * In-memory cache for account sequences.
+ * Key is accountId, value is cache entry.
+ */
+const sequenceCache = new Map<string, CacheEntry>();
+
+/**
+ * Clear the sequence cache.
+ * Useful for testing or when you need to force a fresh fetch.
+ */
+export function clearSequenceCache(): void {
+  sequenceCache.clear();
+}
+
+/**
+ * Fetch the sequence number for a Stellar account from Horizon.
+ *
+ * Handles:
+ * - 404 errors for unfunded accounts (throws AccountNotFoundError)
+ * - 429 rate limit errors (retries with exponential backoff)
+ * - 5xx server errors (retries with exponential backoff)
+ * - Network errors (retries with exponential backoff)
+ *
+ * Uses in-memory caching with configurable TTL to reduce redundant fetches.
+ *
+ * @param horizonServer - The Horizon server instance
+ * @param accountId - The Stellar account ID (public key)
+ * @param options - Configuration options for retries and caching
+ * @returns The account sequence number as a bigint
+ * @throws {AccountNotFoundError} If the account is not found (unfunded)
+ * @throws {NetworkError} If the request fails after retries
+ *
+ * @example
+ * ```typescript
+ * const horizon = new Horizon.Server('https://horizon-testnet.stellar.org');
+ * const sequence = await fetchAccountSequence(horizon, 'GABC...', {
+ *   maxRetries: 3,
+ *   cacheTtlMs: 5000,
+ * });
+ * ```
+ */
+export async function fetchAccountSequence(
+  horizonServer: Horizon.Server,
+  accountId: string,
+  options: FetchAccountSequenceOptions = {}
+): Promise<AccountSequenceResult> {
+  const { maxRetries = 3, cacheTtlMs = DEFAULT_CACHE_TTL_MS, useJitter = true } = options;
+
+  // Check cache first
+  if (cacheTtlMs > 0) {
+    const cached = sequenceCache.get(accountId);
+    const now = Date.now();
+
+    if (cached && cached.expiresAt > now) {
+      return {
+        sequence: cached.sequence,
+        accountId,
+        fetchedAt: cached.fetchedAt,
+      };
+    }
+
+    // Remove expired entry
+    if (cached) {
+      sequenceCache.delete(accountId);
+    }
+  }
+
+  // Build retry options
+  const retryOptions: RetryOptions = {
+    maxRetries,
+    baseDelayMs: 200, // Start with 200ms
+    exponential: true,
+    isRetryable: (error) => {
+      // Don't retry account not found errors
+      if (error instanceof AccountNotFoundError) {
+        return false;
+      }
+
+      // Retry rate limit, server errors, and unknown-status network errors
+      // (unknown status = likely a connection/DNS/timeout error, which are transient)
+      if (error instanceof NetworkError) {
+        const statusCode = error.statusCode;
+        return statusCode === undefined || statusCode === 429 || statusCode >= 500;
+      }
+
+      // Retry other network errors by default
+      return true;
+    },
+  };
+
+  // Add jitter if enabled
+  if (useJitter) {
+    // Jitter is already applied in the retry helper via exponential backoff
+    // This flag is for future enhancement if needed
+  }
+
+  // Fetch with retry logic
+  try {
+    const account = await withRetry(async () => {
+      try {
+        return await horizonServer.loadAccount(accountId);
+      } catch (error) {
+        const statusCode = getStatusCode(error);
+
+        // Handle 404 - account not found (unfunded)
+        if (statusCode === 404 || (error instanceof Error && error.message.includes('Not Found'))) {
+          throw new AccountNotFoundError(accountId);
+        }
+
+        // Convert other errors to NetworkError for retry logic
+        if (error instanceof Error) {
+          throw new NetworkError(`Failed to fetch account sequence: ${error.message}`, {
+            cause: error,
+            statusCode,
+            retryable: statusCode === 429 || (statusCode !== undefined && statusCode >= 500),
+          });
+        }
+
+        throw new NetworkError('Failed to fetch account sequence', {
+          cause: error instanceof Error ? error : undefined,
+        });
+      }
+    }, retryOptions);
+
+    const sequence = BigInt(account.sequence);
+
+    // Cache the result
+    if (cacheTtlMs > 0) {
+      const now = Date.now();
+      sequenceCache.set(accountId, {
+        sequence,
+        fetchedAt: now,
+        expiresAt: now + cacheTtlMs,
+      });
+    }
+
+    return {
+      sequence,
+      accountId,
+      fetchedAt: Date.now(),
+    };
+  } catch (error) {
+    // Re-throw our custom errors
+    if (error instanceof AccountNotFoundError || error instanceof NetworkError) {
+      throw error;
+    }
+
+    // Wrap unexpected errors
+    throw new NetworkError('Failed to fetch account sequence after retries', {
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+}
+
+/**
+ * Extract HTTP status code from various error shapes.
+ */
+function getStatusCode(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  if ('statusCode' in error && typeof error.statusCode === 'number') {
+    return error.statusCode;
+  }
+
+  if ('status' in error && typeof error.status === 'number') {
+    return error.status;
+  }
+
+  if (
+    'response' in error &&
+    error.response &&
+    typeof error.response === 'object' &&
+    'status' in error.response &&
+    typeof error.response.status === 'number'
+  ) {
+    return error.response.status;
+  }
+
+  return undefined;
+}

--- a/packages/stellar/src/horizon-url.ts
+++ b/packages/stellar/src/horizon-url.ts
@@ -1,0 +1,220 @@
+/**
+ * Horizon server URL validation per network profile.
+ *
+ * Validates Horizon URLs against network-specific allowlist patterns
+ * to prevent misconfiguration and security issues.
+ */
+
+import type { Network } from '@ancore/types';
+
+/**
+ * Error thrown when Horizon URL validation fails.
+ */
+export class HorizonUrlValidationError extends Error {
+  public readonly code:
+    | 'INVALID_URL'
+    | 'INVALID_SCHEME'
+    | 'INVALID_HOSTNAME'
+    | 'NETWORK_MISMATCH'
+    | 'LOCALHOST_NOT_ALLOWED';
+  public readonly url: string;
+  public readonly network: Network;
+
+  constructor(
+    code:
+      | 'INVALID_URL'
+      | 'INVALID_SCHEME'
+      | 'INVALID_HOSTNAME'
+      | 'NETWORK_MISMATCH'
+      | 'LOCALHOST_NOT_ALLOWED',
+    message: string,
+    url: string,
+    network: Network
+  ) {
+    super(message);
+    this.name = 'HorizonUrlValidationError';
+    this.code = code;
+    this.url = url;
+    this.network = network;
+  }
+}
+
+/**
+ * Network-specific Horizon URL profiles with validation rules.
+ */
+interface NetworkProfile {
+  /** Allowed hostname patterns (exact string match or regex) */
+  allowedHosts: (string | RegExp)[];
+  /** Whether HTTPS is required */
+  requireHttps: boolean;
+  /** Whether localhost is allowed */
+  allowLocalhost: boolean;
+}
+
+const NETWORK_PROFILES: Record<Network, NetworkProfile> = {
+  mainnet: {
+    allowedHosts: [
+      'horizon.stellar.org',
+      /^horizon-[a-z0-9-]+\.stellar\.org$/, // Allow subdomains like horizon-public
+    ],
+    requireHttps: true,
+    allowLocalhost: false,
+  },
+  testnet: {
+    allowedHosts: ['horizon-testnet.stellar.org', /^horizon-testnet-[a-z0-9-]+\.stellar\.org$/],
+    requireHttps: true,
+    allowLocalhost: false,
+  },
+  futurenet: {
+    allowedHosts: ['horizon-futurenet.stellar.org', /^horizon-futurenet-[a-z0-9-]+\.stellar\.org$/],
+    requireHttps: true,
+    allowLocalhost: false,
+  },
+  local: {
+    allowedHosts: ['localhost', '127.0.0.1', /^localhost:\d+$/, /^127\.0\.0\.1:\d+$/],
+    requireHttps: false,
+    allowLocalhost: true,
+  },
+};
+
+/**
+ * Validates a Horizon URL against the specified network profile.
+ *
+ * @param url - The Horizon URL to validate
+ * @param network - The network to validate against
+ * @throws {HorizonUrlValidationError} If the URL is invalid for the network
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   validateHorizonUrl('https://horizon.stellar.org', 'mainnet');
+ *   // URL is valid
+ * } catch (err) {
+ *   if (err instanceof HorizonUrlValidationError) {
+ *     console.error(`Invalid URL: ${err.message}`);
+ *   }
+ * }
+ * ```
+ */
+export function validateHorizonUrl(url: string, network: Network): void {
+  if (!url || typeof url !== 'string') {
+    throw new HorizonUrlValidationError(
+      'INVALID_URL',
+      'URL must be a non-empty string',
+      url,
+      network
+    );
+  }
+
+  const trimmedUrl = url.trim();
+  if (trimmedUrl.length === 0) {
+    throw new HorizonUrlValidationError('INVALID_URL', 'URL must not be empty', url, network);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmedUrl);
+  } catch {
+    throw new HorizonUrlValidationError(
+      'INVALID_URL',
+      `Invalid URL format: "${url}"`,
+      url,
+      network
+    );
+  }
+
+  const profile = NETWORK_PROFILES[network];
+
+  // Check localhost before scheme — gives a more specific error for HTTP localhost
+  if (
+    !profile.allowLocalhost &&
+    (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1')
+  ) {
+    throw new HorizonUrlValidationError(
+      'LOCALHOST_NOT_ALLOWED',
+      `Localhost is not allowed for ${network}`,
+      url,
+      network
+    );
+  }
+
+  // Validate scheme
+  if (profile.requireHttps && parsed.protocol !== 'https:') {
+    throw new HorizonUrlValidationError(
+      'INVALID_SCHEME',
+      `HTTPS is required for ${network}, got "${parsed.protocol}"`,
+      url,
+      network
+    );
+  }
+
+  // Network mismatch detection: check if URL contains a known pattern for a different network.
+  // Run before the hostname allowlist check so cross-network URLs get a specific error code.
+  const urlLower = trimmedUrl.toLowerCase();
+  const networkMismatchPatterns: Record<Network, RegExp[]> = {
+    mainnet: [/testnet/i, /futurenet/i],
+    testnet: [/futurenet/i],
+    futurenet: [/testnet(?!net)/i],
+    local: [],
+  };
+
+  // Also detect known mainnet hostname used on non-mainnet profiles
+  const knownMainnetHostnames = ['horizon.stellar.org'];
+  const knownTestnetHostnames = ['horizon-testnet.stellar.org'];
+  const knownFuturenetHostnames = ['horizon-futurenet.stellar.org'];
+
+  const hostname = parsed.hostname;
+
+  const isKnownOtherNetwork =
+    (network !== 'mainnet' && knownMainnetHostnames.includes(hostname)) ||
+    (network !== 'testnet' && knownTestnetHostnames.includes(hostname)) ||
+    (network !== 'futurenet' && knownFuturenetHostnames.includes(hostname));
+
+  const mismatchPatterns = networkMismatchPatterns[network];
+  const hasKeywordMismatch = mismatchPatterns.some((pattern) => pattern.test(urlLower));
+
+  if (isKnownOtherNetwork || hasKeywordMismatch) {
+    throw new HorizonUrlValidationError(
+      'NETWORK_MISMATCH',
+      `URL appears to belong to a different network than ${network}`,
+      url,
+      network
+    );
+  }
+
+  // Validate hostname against allowed patterns
+  const isAllowed = profile.allowedHosts.some((pattern) => {
+    if (typeof pattern === 'string') {
+      return hostname === pattern;
+    }
+    if (pattern instanceof RegExp) {
+      return pattern.test(hostname);
+    }
+    return false;
+  });
+
+  if (!isAllowed) {
+    throw new HorizonUrlValidationError(
+      'INVALID_HOSTNAME',
+      `Hostname "${hostname}" is not allowed for ${network}`,
+      url,
+      network
+    );
+  }
+}
+
+/**
+ * Checks if a Horizon URL is valid without throwing.
+ *
+ * @param url - The Horizon URL to validate
+ * @param network - The network to validate against
+ * @returns true if valid, false otherwise
+ */
+export function isValidHorizonUrl(url: string, network: Network): boolean {
+  try {
+    validateHorizonUrl(url, network);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -44,3 +44,11 @@ export type { FeeStats, FeeStatsOptions } from './fee-stats';
 // Simulation
 export { parseSimulationResponse, simulateUnsignedTransaction } from './simulation';
 export type { ParsedSimulationResult, SorobanResourceLimits } from './simulation';
+
+// Horizon URL validation
+export { validateHorizonUrl, isValidHorizonUrl } from './horizon-url';
+export { HorizonUrlValidationError } from './horizon-url';
+
+// Account sequence fetch helper
+export { fetchAccountSequence, clearSequenceCache } from './account-sequence';
+export type { AccountSequenceResult, FetchAccountSequenceOptions } from './account-sequence';


### PR DESCRIPTION
# feat: Stellar/Crypto validation helpers — mnemonic strength, account sequence, horizon URL, network persistence

Closes #595
Closes #599
Closes #600
Closes #605

---

## Summary

Implements four related issues that form the validation and persistence layer for wallet import flows, network configuration, and transaction building.

---

## Changes

### #595 — [CRYPTO] Mnemonic strength validation (`packages/crypto`)

**Files changed:** `packages/crypto/src/mnemonic.ts`, `packages/crypto/src/index.ts`, `packages/crypto/src/__tests__/mnemonic-strength.test.ts`, `packages/crypto/README.md`, `apps/extension-wallet/src/screens/Onboarding/OnboardingFlow.tsx`

- Added `validateMnemonicStrength(mnemonic: string): void` — throws `MnemonicValidationError` with typed codes:
  - `INVALID_TYPE` — not a non-empty string
  - `INVALID_LENGTH` — must be 12 or 24 words
  - `UNKNOWN_WORDS` — word not in English BIP39 wordlist
  - `INVALID_CHECKSUM` — BIP39 checksum mismatch
- `MnemonicValidationError` carries a `code` discriminant and optional `details` field for debugging.
- Exported from `packages/crypto/src/index.ts`.
- Wired into the extension import wallet flow (`WalletImportScreen`) — replaces the old manual word-count check so checksum and wordlist errors surface before encryption.
- 11 test vectors covering: valid 12-word, valid 24-word, empty/null/undefined, 11-word, 13-word, typo word, wrong checksum, extra whitespace, non-English words, and `details` field presence.
- Documented in `packages/crypto/README.md`.

---

### #605 — [EXTENSION] Persist selected network in settings store (`apps/extension-wallet`)

**Files changed:** `apps/extension-wallet/src/stores/settings.ts`, `apps/extension-wallet/src/background/service-worker.ts`, `apps/extension-wallet/src/stores/__tests__/settings-network-persistence.test.ts`

- Added `horizonUrl: string` to `SettingsState`, atomically coupled with `network` via `NETWORK_HORIZON_URLS` map.
- `setNetwork(network)` updates both `network` and `horizonUrl` in a single `set()` call — single source of truth.
- Both fields persisted via `chrome.storage.local` through the existing `extensionStorage` adapter.
- `merge()` function validates rehydrated `network` values and derives `horizonUrl` from the network default when missing (v0→v1 migration path for existing users without a stored URL).
- `service-worker.ts` listens to `chrome.storage.onChanged` on `ancore-settings` and broadcasts `NETWORK_CHANGED` with new `network` + `horizonUrl` to all tabs — cross-tab sync.
- Tests cover: persistence round-trip, network/horizonUrl coupling for all three networks, reset to defaults, legacy state migration, invalid network fallback.

---

### #600 — [STELLAR] Horizon server URL validation (`packages/stellar`)

**Files changed:** `packages/stellar/src/horizon-url.ts`, `packages/stellar/src/index.ts`, `packages/stellar/src/__tests__/horizon-url.test.ts`, `apps/extension-wallet/src/stores/settings.ts`

- Added `validateHorizonUrl(url: string, network: Network): void` — throws `HorizonUrlValidationError` with typed codes:
  - `INVALID_URL` — malformed or empty URL
  - `INVALID_SCHEME` — non-HTTPS on production profiles
  - `LOCALHOST_NOT_ALLOWED` — localhost on mainnet/testnet/futurenet
  - `NETWORK_MISMATCH` — URL belongs to a different network (e.g. mainnet URL on testnet profile)
  - `INVALID_HOSTNAME` — hostname not in per-network allowlist
- Per-network `NETWORK_PROFILES`: mainnet/testnet/futurenet require HTTPS and disallow localhost; `local` profile allows HTTP and localhost only.
- Allowlists support both exact strings and RegExp patterns for subdomain flexibility.
- Localhost checked before scheme for a more specific error code.
- Known cross-network hostname detection runs before the allowlist check so cross-network URLs always get `NETWORK_MISMATCH` rather than `INVALID_HOSTNAME`.
- `isValidHorizonUrl(url, network): boolean` non-throwing wrapper.
- Wired into `useSettingsStore`: new `setHorizonUrl(url)` action validates against the active network profile before persisting; `merge()` uses `isValidHorizonUrl` to sanitize custom URLs on rehydration.
- Exported from `packages/stellar/src/index.ts`.
- Tests cover all five error codes, all four network profiles, null/empty/malformed input, whitespace trimming, and `isValidHorizonUrl`.

---

### #599 — [STELLAR] Account sequence fetch helper (`packages/stellar`, `packages/core-sdk`)

**Files changed:** `packages/stellar/src/account-sequence.ts`, `packages/stellar/src/index.ts`, `packages/stellar/src/__tests__/account-sequence.test.ts`, `packages/core-sdk/src/index.ts`

- Added `fetchAccountSequence(horizonServer, accountId, options): Promise<AccountSequenceResult>`:
  - `404` → `AccountNotFoundError` (not retried — unfunded account is a permanent state)
  - `429` / `5xx` → `NetworkError` with retry via `withRetry`
  - Generic network errors (no HTTP status) → treated as retryable transient failures
  - Returns `{ sequence: bigint, accountId: string, fetchedAt: number }`
- In-memory cache keyed by `accountId` with configurable TTL (default 5 s); `cacheTtlMs: 0` disables caching for tests.
- `clearSequenceCache()` exported for test teardown.
- Options: `maxRetries` (default 3), `cacheTtlMs` (default 5000), `useJitter`.
- Re-exported from `packages/core-sdk/src/index.ts` with inline usage docs for send flow consumers.
- Tests cover: successful fetch, 404→`AccountNotFoundError`, 429 retry, 500 retry, no retry on 404, cache hit, TTL bypass, TTL expiry, `clearSequenceCache`, result structure, separate cache keys per account, `maxRetries` exhaustion→`NetworkError`, generic network error retry.

---

## Testing

All tests pass for affected packages:

| Package | Tests |
|---|---|
| `@ancore/crypto` | 252 passed |
| `@ancore/stellar` | 158 passed |
| `@ancore/core-sdk` | 325 passed |
| `@ancore/extension-wallet` | 470 passed |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recovery phrase import now performs stronger validation and shows clearer error messages.
  * Wallet settings now keep the selected network and Horizon URL in sync.
  * Network and Horizon URL changes are now reflected more reliably across open tabs.
  * Added support for fetching and reusing account sequence information in the SDK.

* **Bug Fixes**
  * Improved handling of invalid or legacy wallet settings during restore and migration.
  * Better error handling when syncing changes to tabs where the extension script is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->