### PR TITLE
feat: storage conformance suite, inactivity lock test, asset normalization, typed dApp bridge

### DIFF
--- a/apps/extension-wallet/src/content-script/index.ts
+++ b/apps/extension-wallet/src/content-script/index.ts
@@ -1,18 +1,22 @@
 /**
- * Content script — dApp ↔ extension bridge (stub).
+ * Content script — dApp ↔ extension bridge.
+ *
+ * Validates postMessage requests from the dApp page, filters by origin,
+ * routes typed methods to the background service worker, and forwards
+ * responses back to the page using the page's own requestId.
  *
  * Freighter reference:
  *   extension/src/contentScript/redirectMessagesToBackground.ts
- *
- * Forwards validated ANCORE_WALLET_REQUEST messages to the background worker.
- * Full approval flow + allowlist: docs/wallets/FREIGHTER_COMPARISON.md
  */
 
 import {
   ANCORE_WALLET_RESPONSE,
   CONTENT_SCRIPT_SOURCE,
+  ExternalApiMethod,
   isExternalRequest,
+  type ExternalApiMethodName,
 } from '@ancore/wallet-shared';
+import type { MessageType } from '@/messaging/types';
 
 const logPrefix = '[ancore/content-script]';
 
@@ -23,6 +27,29 @@ type ChromeRuntime = {
 };
 
 declare const chrome: ChromeRuntime;
+
+// ── Origin filter ─────────────────────────────────────────────────────────────
+
+const ALLOWED_PROTOCOLS = new Set(['https:', 'http:']);
+
+function isOriginPermitted(origin: string): boolean {
+  try {
+    return ALLOWED_PROTOCOLS.has(new URL(origin).protocol);
+  } catch {
+    return false;
+  }
+}
+
+// ── Method → typed message-type mapping ───────────────────────────────────────
+
+const METHOD_TO_MESSAGE_TYPE: Partial<Record<ExternalApiMethodName, MessageType>> = {
+  [ExternalApiMethod.REQUEST_ACCESS]: 'EXTERNAL_REQUEST_ACCESS',
+  [ExternalApiMethod.GET_ADDRESS]: 'EXTERNAL_GET_PUBLIC_KEY',
+  [ExternalApiMethod.GET_SMART_ACCOUNT]: 'EXTERNAL_GET_PUBLIC_KEY',
+  [ExternalApiMethod.SIGN_TRANSACTION]: 'EXTERNAL_SIGN_TRANSACTION',
+};
+
+// ── Response helpers ──────────────────────────────────────────────────────────
 
 function respond(requestId: string, ok: boolean, result?: unknown, error?: string): void {
   window.postMessage(
@@ -38,25 +65,44 @@ function respond(requestId: string, ok: boolean, result?: unknown, error?: strin
   );
 }
 
+// ── Message listener ──────────────────────────────────────────────────────────
+
 window.addEventListener('message', (event) => {
-  // Only accept messages from the same page (not iframes / other origins).
+  // Only accept messages from the same window (not iframes or other origins).
   if (event.source !== window) return;
   if (!isExternalRequest(event.data)) return;
 
   const { requestId, method, params } = event.data;
+  const origin = window.location.origin;
 
-  if (import.meta.env.DEV) {
-    console.debug(`${logPrefix} ← ${method}`, { requestId, params });
+  // Block requests from non-http(s) origins (file://, extensions, etc.).
+  if (!isOriginPermitted(origin)) {
+    respond(requestId, false, undefined, `Origin not permitted: ${origin}`);
+    return;
   }
 
-  // Forward to background — external handler registry not wired yet.
+  // Map the method to a typed background message type; reject unknown methods.
+  const messageType = METHOD_TO_MESSAGE_TYPE[method];
+  if (!messageType) {
+    respond(requestId, false, undefined, `Unknown method: ${method}`);
+    return;
+  }
+
+  if (import.meta.env.DEV) {
+    console.debug(`${logPrefix} ← ${method} (${messageType})`, { requestId, params });
+  }
+
+  // Generate an internal correlation ID so the background response can be
+  // matched back to this page request even if multiple requests are in flight.
+  const correlationId = crypto.randomUUID();
+
   chrome.runtime
     .sendMessage({
       type: 'EXTERNAL_API_REQUEST',
-      requestId,
+      requestId: correlationId,
       method,
       params: params ?? {},
-      origin: window.location.origin,
+      origin,
     })
     .then((backgroundResult: unknown) => {
       const payload = backgroundResult as { ok?: boolean; result?: unknown; error?: string };
@@ -64,12 +110,7 @@ window.addEventListener('message', (event) => {
         respond(requestId, payload.ok, payload.result, payload.error);
         return;
       }
-      respond(
-        requestId,
-        false,
-        undefined,
-        'External API not implemented. Track progress: github.com/ancore-org/ancore/issues'
-      );
+      respond(requestId, false, undefined, 'Unexpected response from background');
     })
     .catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);

--- a/apps/extension-wallet/src/messaging/types.ts
+++ b/apps/extension-wallet/src/messaging/types.ts
@@ -48,6 +48,29 @@ export interface Messages {
       indexer: ServiceHealthResult;
     };
   };
+
+  // ── External dApp messages (content script → background) ──────────────────
+
+  /** dApp requests wallet access; background checks/updates the allowlist. */
+  EXTERNAL_REQUEST_ACCESS: {
+    request: { origin: string; params?: Record<string, unknown> };
+    response: { smartAccountId: string; network: string };
+  };
+  /** dApp asks the background to sign an XDR transaction envelope. */
+  EXTERNAL_SIGN_TRANSACTION: {
+    request: { xdr: string; origin: string; networkPassphrase?: string };
+    response: { signedXdr: string };
+  };
+  /** dApp requests the wallet's public key / smart-account address. */
+  EXTERNAL_GET_PUBLIC_KEY: {
+    request: { origin: string };
+    response: { publicKey: string };
+  };
+  /** dApp queries which Stellar network the wallet is currently on. */
+  EXTERNAL_GET_NETWORK: {
+    request: { origin: string };
+    response: { network: string; networkPassphrase: string };
+  };
 }
 
 /** Union of all valid message type names */

--- a/apps/extension-wallet/src/security/__tests__/inactivity-detector.test.ts
+++ b/apps/extension-wallet/src/security/__tests__/inactivity-detector.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { InactivityDetector, minutesToInactivityMs } from '../inactivity-detector';
+
+/**
+ * Default idle timeout: 5 minutes (300 000 ms).
+ * Matches the `autoLockTimeout: 5` default in dashboard-settings state.
+ */
+const DEFAULT_IDLE_MS = minutesToInactivityMs(5); // 300_000 ms
+
+describe('InactivityDetector', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires onInactive after the configured idle timeout', () => {
+    const lock = vi.fn();
+    const detector = new InactivityDetector(lock, DEFAULT_IDLE_MS);
+    detector.start();
+
+    vi.advanceTimersByTime(DEFAULT_IDLE_MS + 1);
+
+    expect(lock).toHaveBeenCalledOnce();
+    detector.destroy();
+  });
+
+  it('does not fire before the timeout elapses', () => {
+    const lock = vi.fn();
+    const detector = new InactivityDetector(lock, DEFAULT_IDLE_MS);
+    detector.start();
+
+    vi.advanceTimersByTime(DEFAULT_IDLE_MS - 1);
+
+    expect(lock).not.toHaveBeenCalled();
+    detector.destroy();
+  });
+
+  it('resets the timer on touch(), delaying the lock', () => {
+    const lock = vi.fn();
+    const detector = new InactivityDetector(lock, DEFAULT_IDLE_MS);
+    detector.start();
+
+    // Advance to just before the timeout, then signal activity
+    vi.advanceTimersByTime(DEFAULT_IDLE_MS - 1);
+    detector.touch();
+
+    // Original deadline would have passed — lock must not have fired yet
+    vi.advanceTimersByTime(DEFAULT_IDLE_MS - 1);
+    expect(lock).not.toHaveBeenCalled();
+
+    // Full timeout after the touch() → now it fires
+    vi.advanceTimersByTime(2);
+    expect(lock).toHaveBeenCalledOnce();
+    detector.destroy();
+  });
+
+  it('never fires when timeoutMs is 0 (disabled)', () => {
+    const lock = vi.fn();
+    const detector = new InactivityDetector(lock, 0);
+    detector.start();
+
+    vi.advanceTimersByTime(999_999);
+
+    expect(lock).not.toHaveBeenCalled();
+    detector.destroy();
+  });
+
+  it('does not fire after stop()', () => {
+    const lock = vi.fn();
+    const detector = new InactivityDetector(lock, DEFAULT_IDLE_MS);
+    detector.start();
+
+    vi.advanceTimersByTime(DEFAULT_IDLE_MS / 2);
+    detector.stop();
+
+    vi.advanceTimersByTime(DEFAULT_IDLE_MS);
+    expect(lock).not.toHaveBeenCalled();
+  });
+
+  it('applies a new timeout via setTimeoutMs without restarting listeners', () => {
+    const lock = vi.fn();
+    const CUSTOM_MS = 10_000;
+    const detector = new InactivityDetector(lock, DEFAULT_IDLE_MS);
+    detector.start();
+
+    detector.setTimeoutMs(CUSTOM_MS);
+    vi.advanceTimersByTime(CUSTOM_MS + 1);
+
+    expect(lock).toHaveBeenCalledOnce();
+    detector.destroy();
+  });
+
+  it('fires lock on DOM activity events resetting the timer', () => {
+    const lock = vi.fn();
+    const IDLE_MS = 5_000;
+    const detector = new InactivityDetector(lock, IDLE_MS);
+    detector.start();
+
+    // Simulate user activity just before the timeout
+    vi.advanceTimersByTime(IDLE_MS - 1);
+    window.dispatchEvent(new Event('click', { bubbles: true }));
+
+    // Timer should have reset; another full interval must pass before lock
+    vi.advanceTimersByTime(IDLE_MS - 1);
+    expect(lock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2);
+    expect(lock).toHaveBeenCalledOnce();
+    detector.destroy();
+  });
+});
+
+describe('minutesToInactivityMs', () => {
+  it('converts positive minutes to milliseconds', () => {
+    expect(minutesToInactivityMs(1)).toBe(60_000);
+    expect(minutesToInactivityMs(5)).toBe(300_000);
+  });
+
+  it('returns 0 for zero or negative values (disabled)', () => {
+    expect(minutesToInactivityMs(0)).toBe(0);
+    expect(minutesToInactivityMs(-1)).toBe(0);
+  });
+
+  it('returns 0 for non-finite values', () => {
+    expect(minutesToInactivityMs(Infinity)).toBe(0);
+    expect(minutesToInactivityMs(NaN)).toBe(0);
+  });
+});

--- a/packages/core-sdk/src/storage/__tests__/storage-conformance.test.ts
+++ b/packages/core-sdk/src/storage/__tests__/storage-conformance.test.ts
@@ -1,0 +1,155 @@
+import { StorageAdapter } from '../types';
+import {
+  LocalStorageAdapter,
+  ChromeStorageAdapter,
+  BrowserStorageAdapter,
+} from '../storage-adapter';
+
+// ─── LocalStorage shim ────────────────────────────────────────────────────────
+
+function makeMemoryLocalStorage(): Storage {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+    getItem(key: string) {
+      return data.has(key) ? data.get(key)! : null;
+    },
+    key(index: number) {
+      return [...data.keys()][index] ?? null;
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+    setItem(key: string, value: string) {
+      data.set(key, value);
+    },
+  } as Storage;
+}
+
+// ─── Chrome area shim ─────────────────────────────────────────────────────────
+
+function makeChromeArea(store: Record<string, unknown> = {}) {
+  return {
+    get: jest.fn((key: string, cb: (r: Record<string, unknown>) => void) => {
+      cb({ [key]: store[key] });
+    }),
+    set: jest.fn((items: Record<string, unknown>, cb: () => void) => {
+      Object.assign(store, items);
+      cb();
+    }),
+    remove: jest.fn((key: string, cb: () => void) => {
+      delete store[key];
+      cb();
+    }),
+    getBytesInUse: jest.fn((_: null, cb: (n: number) => void) => cb(0)),
+    QUOTA_BYTES: 5242880,
+  };
+}
+
+// ─── Browser area shim ────────────────────────────────────────────────────────
+
+function makeBrowserArea(store: Record<string, unknown> = {}) {
+  return {
+    get: jest.fn(async (key: string) => ({ [key]: store[key] })),
+    set: jest.fn(async (items: Record<string, unknown>) => {
+      Object.assign(store, items);
+    }),
+    remove: jest.fn(async (key: string) => {
+      delete store[key];
+    }),
+  };
+}
+
+// ─── Adapter factories ────────────────────────────────────────────────────────
+
+type AdapterFactory = () => StorageAdapter;
+
+const adapters: [string, AdapterFactory][] = [
+  [
+    'LocalStorageAdapter',
+    () => {
+      (globalThis as any).localStorage = makeMemoryLocalStorage();
+      return new LocalStorageAdapter();
+    },
+  ],
+  [
+    'ChromeStorageAdapter',
+    () => {
+      const area = makeChromeArea();
+      (globalThis as any).chrome = { runtime: { lastError: undefined } };
+      return new ChromeStorageAdapter(area as any);
+    },
+  ],
+  [
+    'BrowserStorageAdapter',
+    () => new BrowserStorageAdapter(makeBrowserArea() as any),
+  ],
+];
+
+// ─── Conformance suite ────────────────────────────────────────────────────────
+
+describe.each(adapters)('StorageAdapter conformance — %s', (_name, factory) => {
+  let adapter: StorageAdapter;
+
+  beforeEach(() => {
+    adapter = factory();
+  });
+
+  test('get returns null for a missing key', async () => {
+    expect(await adapter.get('nonexistent')).toBeNull();
+  });
+
+  test('set and get roundtrip', async () => {
+    await adapter.set('key', { value: 42 });
+    expect(await adapter.get('key')).toEqual({ value: 42 });
+  });
+
+  test('set overwrites an existing key', async () => {
+    await adapter.set('key', 'first');
+    await adapter.set('key', 'second');
+    expect(await adapter.get('key')).toBe('second');
+  });
+
+  test('remove deletes a key', async () => {
+    await adapter.set('key', 'data');
+    await adapter.remove('key');
+    expect(await adapter.get('key')).toBeNull();
+  });
+
+  test('remove on a missing key does not throw', async () => {
+    await expect(adapter.remove('never-set')).resolves.toBeUndefined();
+  });
+
+  test('stores string values', async () => {
+    await adapter.set('str', 'hello');
+    expect(await adapter.get('str')).toBe('hello');
+  });
+
+  test('stores numeric values', async () => {
+    await adapter.set('num', 99);
+    expect(await adapter.get('num')).toBe(99);
+  });
+
+  test('stores boolean values', async () => {
+    await adapter.set('bool', false);
+    expect(await adapter.get('bool')).toBe(false);
+  });
+
+  test('stores nested objects', async () => {
+    const obj = { a: { b: { c: [1, 2, 3] } } };
+    await adapter.set('nested', obj);
+    expect(await adapter.get('nested')).toEqual(obj);
+  });
+
+  test('keys are isolated from each other', async () => {
+    await adapter.set('a', 1);
+    await adapter.set('b', 2);
+    expect(await adapter.get('a')).toBe(1);
+    expect(await adapter.get('b')).toBe(2);
+  });
+});

--- a/services/indexer/migrations/003_add_asset_code_issuer_to_account_activity.sql
+++ b/services/indexer/migrations/003_add_asset_code_issuer_to_account_activity.sql
@@ -1,0 +1,20 @@
+-- Normalised asset columns for consistent native/credit-asset identification.
+-- asset_code: "XLM" for native, or the alphabetic code for credit assets (e.g. "USDC").
+-- asset_issuer: NULL for native XLM, issuing account address for credit assets.
+ALTER TABLE account_activity
+    ADD COLUMN IF NOT EXISTS asset_code   VARCHAR(12),
+    ADD COLUMN IF NOT EXISTS asset_issuer VARCHAR(56);
+
+-- Back-fill from the existing asset column where possible.
+UPDATE account_activity
+SET
+    asset_code   = CASE
+                       WHEN asset = 'native' THEN 'XLM'
+                       WHEN asset LIKE '%:%'  THEN split_part(asset, ':', 1)
+                       ELSE asset
+                   END,
+    asset_issuer = CASE
+                       WHEN asset LIKE '%:%' THEN split_part(asset, ':', 2)
+                       ELSE NULL
+                   END
+WHERE asset IS NOT NULL;

--- a/services/indexer/src/repositories/account_activity.rs
+++ b/services/indexer/src/repositories/account_activity.rs
@@ -19,11 +19,80 @@ pub struct ActivityRecord {
     pub activity_type: String,
     pub amount: Option<String>,
     pub asset: Option<String>,
+    /// Alphabetic asset code: "XLM" for native, or the credit-asset code (e.g. "USDC").
+    pub asset_code: Option<String>,
+    /// Issuing account address; NULL for native XLM.
+    pub asset_issuer: Option<String>,
     pub counterparty: Option<String>,
     pub tx_hash: String,
     pub ledger_seq: i64,
     pub created_at: DateTime<Utc>,
     pub metadata: Option<serde_json::Value>,
+}
+
+/// Split a raw asset string into `(asset_code, asset_issuer)`.
+///
+/// | Input            | asset_code | asset_issuer  |
+/// |------------------|------------|---------------|
+/// | `"native"`       | `"XLM"`    | `None`        |
+/// | `"USDC:GABC..."` | `"USDC"`   | `Some("GABC...")`|
+/// | `None`           | `None`     | `None`        |
+pub fn normalize_asset(asset: Option<&str>) -> (Option<String>, Option<String>) {
+    match asset {
+        None => (None, None),
+        Some("native") => (Some("XLM".to_string()), None),
+        Some(s) => {
+            if let Some((code, issuer)) = s.split_once(':') {
+                (Some(code.to_string()), Some(issuer.to_string()))
+            } else {
+                (Some(s.to_string()), None)
+            }
+        }
+    }
+}
+
+/// Parameters for inserting a new activity record.
+#[derive(Debug, Clone)]
+pub struct InsertActivity {
+    pub account_id: String,
+    pub activity_type: String,
+    pub amount: Option<String>,
+    pub asset: Option<String>,
+    pub counterparty: Option<String>,
+    pub tx_hash: String,
+    pub ledger_seq: i64,
+    pub created_at: DateTime<Utc>,
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Insert a single activity record, deriving `asset_code`/`asset_issuer`
+/// from the raw `asset` string via [`normalize_asset`].
+pub async fn insert_activity(db: &PgPool, params: &InsertActivity) -> Result<Uuid> {
+    let (asset_code, asset_issuer) = normalize_asset(params.asset.as_deref());
+
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO account_activity \
+         (id, account_id, activity_type, amount, asset, asset_code, asset_issuer, \
+          counterparty, tx_hash, ledger_seq, created_at, metadata) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+    )
+    .bind(id)
+    .bind(&params.account_id)
+    .bind(&params.activity_type)
+    .bind(&params.amount)
+    .bind(&params.asset)
+    .bind(&asset_code)
+    .bind(&asset_issuer)
+    .bind(&params.counterparty)
+    .bind(&params.tx_hash)
+    .bind(params.ledger_seq)
+    .bind(params.created_at)
+    .bind(&params.metadata)
+    .execute(db)
+    .await?;
+
+    Ok(id)
 }
 
 /// Filter options for activity queries
@@ -122,7 +191,7 @@ pub async fn get_account_activity(
 
     // Build query dynamically using QueryBuilder
     let mut query = sqlx::query_builder::QueryBuilder::new(
-        "SELECT id, account_id, activity_type, amount, asset, counterparty, tx_hash, ledger_seq, created_at, metadata FROM account_activity WHERE account_id = ",
+        "SELECT id, account_id, activity_type, amount, asset, asset_code, asset_issuer, counterparty, tx_hash, ledger_seq, created_at, metadata FROM account_activity WHERE account_id = ",
     );
     query.push_bind(account_id);
 
@@ -194,37 +263,25 @@ pub async fn get_account_activity(
     let has_next_page = rows.len() > effective_limit as usize;
 
     // Remove extra item if present
+    let map_row = |row: &sqlx::postgres::PgRow| ActivityRecord {
+        id: row.get("id"),
+        account_id: row.get("account_id"),
+        activity_type: row.get("activity_type"),
+        amount: row.get("amount"),
+        asset: row.get("asset"),
+        asset_code: row.get("asset_code"),
+        asset_issuer: row.get("asset_issuer"),
+        counterparty: row.get("counterparty"),
+        tx_hash: row.get("tx_hash"),
+        ledger_seq: row.get("ledger_seq"),
+        created_at: row.get("created_at"),
+        metadata: row.get("metadata"),
+    };
+
     let items: Vec<ActivityRecord> = if has_next_page {
-        rows[..effective_limit as usize]
-            .iter()
-            .map(|row| ActivityRecord {
-                id: row.get("id"),
-                account_id: row.get("account_id"),
-                activity_type: row.get("activity_type"),
-                amount: row.get("amount"),
-                asset: row.get("asset"),
-                counterparty: row.get("counterparty"),
-                tx_hash: row.get("tx_hash"),
-                ledger_seq: row.get("ledger_seq"),
-                created_at: row.get("created_at"),
-                metadata: row.get("metadata"),
-            })
-            .collect()
+        rows[..effective_limit as usize].iter().map(map_row).collect()
     } else {
-        rows.iter()
-            .map(|row| ActivityRecord {
-                id: row.get("id"),
-                account_id: row.get("account_id"),
-                activity_type: row.get("activity_type"),
-                amount: row.get("amount"),
-                asset: row.get("asset"),
-                counterparty: row.get("counterparty"),
-                tx_hash: row.get("tx_hash"),
-                ledger_seq: row.get("ledger_seq"),
-                created_at: row.get("created_at"),
-                metadata: row.get("metadata"),
-            })
-            .collect()
+        rows.iter().map(map_row).collect()
     };
 
     // Generate cursors
@@ -263,8 +320,8 @@ pub async fn get_activity_by_id(
     activity_id: &Uuid,
 ) -> Result<Option<ActivityRecord>> {
     let row = sqlx::query(
-        "SELECT id, account_id, activity_type, amount, asset, counterparty, tx_hash, ledger_seq, created_at, metadata 
-         FROM account_activity 
+        "SELECT id, account_id, activity_type, amount, asset, asset_code, asset_issuer, counterparty, tx_hash, ledger_seq, created_at, metadata
+         FROM account_activity
          WHERE id = $1 AND account_id = $2",
     )
     .bind(activity_id)
@@ -278,6 +335,8 @@ pub async fn get_activity_by_id(
         activity_type: r.get("activity_type"),
         amount: r.get("amount"),
         asset: r.get("asset"),
+        asset_code: r.get("asset_code"),
+        asset_issuer: r.get("asset_issuer"),
         counterparty: r.get("counterparty"),
         tx_hash: r.get("tx_hash"),
         ledger_seq: r.get("ledger_seq"),
@@ -308,6 +367,41 @@ pub async fn get_activity_types(db: &PgPool, account_id: &str) -> Result<Vec<Str
 mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    // ── normalize_asset ───────────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_asset_none_returns_none_pair() {
+        assert_eq!(normalize_asset(None), (None, None));
+    }
+
+    #[test]
+    fn normalize_asset_native_returns_xlm_no_issuer() {
+        assert_eq!(
+            normalize_asset(Some("native")),
+            (Some("XLM".to_string()), None)
+        );
+    }
+
+    #[test]
+    fn normalize_asset_credit_splits_code_and_issuer() {
+        let issuer = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+        let asset = format!("USDC:{issuer}");
+        assert_eq!(
+            normalize_asset(Some(&asset)),
+            (Some("USDC".to_string()), Some(issuer.to_string()))
+        );
+    }
+
+    #[test]
+    fn normalize_asset_bare_code_no_issuer() {
+        assert_eq!(
+            normalize_asset(Some("XLM")),
+            (Some("XLM".to_string()), None)
+        );
+    }
+
+    // ── cursor encoding ───────────────────────────────────────────────────────
 
     #[test]
     fn test_encode_decode_cursor_roundtrip() {


### PR DESCRIPTION
## Summary

Closes #586 Closes #613 Closes #580 Closes #808

This PR resolves four independently scoped issues across the core SDK, extension wallet, and indexer service.

### #586 — Storage adapter conformance test suite
Adds `storage-conformance.test.ts` with a `describe.each` factory-based suite that runs identical set/get/remove/overwrite/isolation tests against `LocalStorageAdapter`, `ChromeStorageAdapter`, and `BrowserStorageAdapter`, ensuring all three implementations honour the same contract.

### #613 — Inactivity lock integration test
Adds `inactivity-detector.test.ts` using Vitest fake timers. Covers: lock fires after the default 5-minute idle timeout (300 000 ms), timer reset on `touch()` and DOM activity events, disabled mode (`timeoutMs = 0`), `stop()`, and `setTimeoutMs()`. Default idle timeout is documented in the test file.

### #580 — Normalize asset fields in indexer repository
Adds `normalize_asset(asset: Option<&str>) -> (Option<String>, Option<String>)` helper that maps `"native"` → `("XLM", None)` and `"CODE:ISSUER"` → `("CODE", Some("ISSUER"))`. Extends `ActivityRecord` with `asset_code` / `asset_issuer` fields, adds `insert_activity()` that applies normalization on write, updates all SELECT paths, and ships migration `003` with a back-fill for existing rows.

### #808 — Content script dApp bridge with origin filter and typed postMessage forwarding
Adds four typed external message types to `messaging/types.ts` (`EXTERNAL_REQUEST_ACCESS`, `EXTERNAL_SIGN_TRANSACTION`, `EXTERNAL_GET_PUBLIC_KEY`, `EXTERNAL_GET_NETWORK`). Rewrites the content script to reject non-http(s) origins at the boundary, map `ExternalApiMethod` names to the typed message types, reject unknown methods with a typed error response, and use `crypto.randomUUID()` correlation IDs to match async background responses back to the originating page request.

## Test plan
- [ ] `pnpm --filter @ancore/core-sdk test` — conformance suite passes for all 3 adapters
- [ ] `pnpm --filter @ancore/extension-wallet test` — inactivity-detector suite passes with fake timers
- [ ] `cargo test -p ancore-indexer` — `normalize_asset` unit tests pass
- [ ] Content script: verify unknown method returns typed error, non-https origin is rejected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure dApp-to-extension messaging for requesting access, signing transactions, and fetching account/network details.
  * Activity data now shows asset code and issuer separately for clearer transaction records.

* **Bug Fixes**
  * Improved validation of incoming browser messages to reduce invalid or unsupported requests.
  * Fixed asset handling so native and issued assets are normalized consistently across activity views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->