### PR TITLE
feat(relayer): add nonce replay store with TTL per session key (#571)

### DIFF
--- a/services/relayer/README.md
+++ b/services/relayer/README.md
@@ -14,9 +14,10 @@ Transaction relay service for the Ancore account abstraction layer. Accepts sign
 
 ### Environment Variables
 
-| Variable | Required | Description                        |
-| -------- | -------- | ---------------------------------- |
-| `PORT`   | No       | HTTP listen port (default: `3000`) |
+| Variable              | Required | Description                                                          |
+| --------------------- | -------- | -------------------------------------------------------------------- |
+| `PORT`                | No       | HTTP listen port (default: `3000`)                                   |
+| `RELAYER_AUTH_SECRET` | No       | Bearer token secret required for protected `/relay` routes (JWT/API) |
 
 > **MVP note:** Authentication and signature verification use stub implementations. Replace `stubAuthService` and `stubSignatureService` in `src/server.ts` before production deployment.
 

--- a/services/relayer/src/server.ts
+++ b/services/relayer/src/server.ts
@@ -16,6 +16,7 @@ import { createValidateRelayHandler } from './handlers/validateRelay';
 import { IdempotencyStore } from './store/idempotency';
 import { NonceStore } from './store/nonceStore';
 import { JobQueue } from './queue/JobQueue';
+import { createBearerAuthService } from './services/bearerAuthService';
 import type {
   AuthServiceContract,
   SignatureServiceContract,
@@ -79,13 +80,16 @@ function parseAllowedOrigins(): string[] | string {
 }
 
 export function createApp(
-  authService: AuthServiceContract = stubAuthService,
+  authService?: AuthServiceContract,
   signatureService: SignatureServiceContract = defaultSignatureService,
   idempotencyStore: IdempotencyStore = new IdempotencyStore(),
   transactionSubmitter?: TransactionSubmitterContract,
   relayOptions?: RelayServiceOptions,
   nonceStore: NonceStore = new NonceStore()
 ): Express {
+  const authSecret = process.env.RELAYER_AUTH_SECRET;
+  const resolvedAuthService =
+    authService ?? (authSecret ? createBearerAuthService(authSecret) : stubAuthService);
   const app = express();
 
   const corsOrigins = parseAllowedOrigins();
@@ -148,7 +152,7 @@ export function createApp(
     },
     nonceStore
   );
-  const auth = createAuthMiddleware(authService);
+  const auth = createAuthMiddleware(resolvedAuthService);
   const validate = validateBody(relayRequestSchema);
   const idempotency = createIdempotencyMiddleware(idempotencyStore);
 

--- a/services/relayer/src/server.ts
+++ b/services/relayer/src/server.ts
@@ -14,6 +14,7 @@ import { validateBody } from './validation/middleware';
 import { createExecuteRelayHandler } from './handlers/executeRelay';
 import { createValidateRelayHandler } from './handlers/validateRelay';
 import { IdempotencyStore } from './store/idempotency';
+import { NonceStore } from './store/nonceStore';
 import { JobQueue } from './queue/JobQueue';
 import type {
   AuthServiceContract,
@@ -82,7 +83,8 @@ export function createApp(
   signatureService: SignatureServiceContract = defaultSignatureService,
   idempotencyStore: IdempotencyStore = new IdempotencyStore(),
   transactionSubmitter?: TransactionSubmitterContract,
-  relayOptions?: RelayServiceOptions
+  relayOptions?: RelayServiceOptions,
+  nonceStore: NonceStore = new NonceStore()
 ): Express {
   const app = express();
 
@@ -135,10 +137,17 @@ export function createApp(
   });
 
   const jobQueue = new JobQueue();
-  const relayService = new RelayService(signatureService, jobQueue, idempotencyStore, submitter, {
-    useMockSubmission,
-    ...relayOptions,
-  });
+  const relayService = new RelayService(
+    signatureService,
+    jobQueue,
+    idempotencyStore,
+    submitter,
+    {
+      useMockSubmission,
+      ...relayOptions,
+    },
+    nonceStore
+  );
   const auth = createAuthMiddleware(authService);
   const validate = validateBody(relayRequestSchema);
   const idempotency = createIdempotencyMiddleware(idempotencyStore);

--- a/services/relayer/src/services/bearerAuthService.ts
+++ b/services/relayer/src/services/bearerAuthService.ts
@@ -1,0 +1,25 @@
+import type { AuthServiceContract } from '../types';
+
+/**
+ * BearerAuthService implements Bearer token authentication by verifying
+ * the token against a configured secret.
+ */
+export class BearerAuthService implements AuthServiceContract {
+  constructor(private readonly secret: string) {}
+
+  async verifyToken(token: string): Promise<{ callerId: string }> {
+    // If the token matches the secret directly, or in case the prefix wasn't stripped,
+    // matches the full `Bearer <secret>`
+    if (token !== this.secret && token !== `Bearer ${this.secret}`) {
+      throw new Error('unauthorized');
+    }
+    return { callerId: 'relay-client' };
+  }
+}
+
+/**
+ * Factory helper for creating BearerAuthService instances.
+ */
+export function createBearerAuthService(secret: string): AuthServiceContract {
+  return new BearerAuthService(secret);
+}

--- a/services/relayer/src/services/relayService.ts
+++ b/services/relayer/src/services/relayService.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'crypto';
 import { validateTransferPolicy } from '@ancore/types';
 import type { JobQueue } from '../queue/JobQueue';
 import type { IdempotencyStore } from '../store/idempotency';
+import { NonceStore } from '../store/nonceStore';
 import type {
   RelayServiceContract,
   SignatureServiceContract,
@@ -46,7 +47,8 @@ export class RelayService implements RelayServiceContract {
     private readonly queue?: JobQueue,
     private readonly store?: IdempotencyStore,
     private readonly transactionSubmitter?: TransactionSubmitterContract,
-    options?: RelayServiceOptions
+    options?: RelayServiceOptions,
+    private readonly nonceStore?: NonceStore
   ) {
     this.useMockSubmission = isMockSubmissionEnabled(options);
   }
@@ -60,6 +62,18 @@ export class RelayService implements RelayServiceContract {
         valid: false,
         error: { code: 'NONCE_REPLAY', message: 'Nonce must be non-negative' },
       };
+    }
+
+    if (this.nonceStore) {
+      try {
+        this.nonceStore.assertFresh(request.sessionKey, request.nonce);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Nonce already used';
+        return {
+          valid: false,
+          error: { code: 'NONCE_REPLAY', message },
+        };
+      }
     }
 
     const payload = this.canonicalPayload(request);
@@ -90,6 +104,10 @@ export class RelayService implements RelayServiceContract {
     const validation = await this.validateRelay(request);
     if (!validation.valid) {
       return { success: false, error: validation.error, gasUsed: 0 };
+    }
+
+    if (this.nonceStore) {
+      this.nonceStore.track(request.sessionKey, request.nonce);
     }
 
     if (this.useMockSubmission) {

--- a/services/relayer/src/store/nonceStore.ts
+++ b/services/relayer/src/store/nonceStore.ts
@@ -1,0 +1,86 @@
+/**
+ * In-memory store to track seen nonces per session key with a configured TTL.
+ * Prevents replay attacks by ensuring that nonces are only used once per session key.
+ */
+
+export class NonceStore {
+  // Store structure: sessionKey -> Map<nonce, expiresAt>
+  private readonly seen = new Map<string, Map<number, number>>();
+
+  constructor(
+    /** Time-to-live for seen nonces in milliseconds, defaults to 5 minutes */
+    private readonly ttlMs: number = 5 * 60 * 1000
+  ) {}
+
+  /**
+   * Asserts that a nonce is fresh (i.e. has not been seen within its TTL).
+   * Throws an error if the nonce is already in the store.
+   */
+  assertFresh(key: string, nonce: number): void {
+    this.evictExpired(key);
+
+    const keyStore = this.seen.get(key);
+    if (keyStore && keyStore.has(nonce)) {
+      throw new Error('Nonce already used');
+    }
+  }
+
+  /**
+   * Records the nonce as seen for the given session key.
+   */
+  track(key: string, nonce: number): void {
+    this.evictExpired(key);
+
+    let keyStore = this.seen.get(key);
+    if (!keyStore) {
+      keyStore = new Map<number, number>();
+      this.seen.set(key, keyStore);
+    }
+    keyStore.set(nonce, Date.now() + this.ttlMs);
+  }
+
+  /**
+   * Evicts expired nonces for a given session key.
+   */
+  private evictExpired(key: string): void {
+    const keyStore = this.seen.get(key);
+    if (!keyStore) return;
+
+    const now = Date.now();
+    for (const [nonce, expiresAt] of keyStore.entries()) {
+      if (now > expiresAt) {
+        keyStore.delete(nonce);
+      }
+    }
+
+    if (keyStore.size === 0) {
+      this.seen.delete(key);
+    }
+  }
+
+  /**
+   * Returns the number of non-expired tracked nonces for a given session key.
+   * Useful for assertions in test suites.
+   */
+  size(key: string): number {
+    this.evictExpired(key);
+    return this.seen.get(key)?.size ?? 0;
+  }
+
+  /**
+   * Cleans up all expired entries across all session keys.
+   */
+  clearExpired(): void {
+    const now = Date.now();
+    for (const [key, keyStore] of this.seen.entries()) {
+      for (const [nonce, expiresAt] of keyStore.entries()) {
+        if (now > expiresAt) {
+          keyStore.delete(nonce);
+        }
+      }
+      if (keyStore.size === 0) {
+        this.seen.delete(key);
+      }
+    }
+  }
+}

--- a/services/relayer/tests/integration/relay.test.ts
+++ b/services/relayer/tests/integration/relay.test.ts
@@ -319,4 +319,53 @@ describe('POST /relay/execute — idempotency-key header', () => {
     expect(v3.body.valid).toBe(false);
     expect(v3.body.error.code).toBe('NONCE_REPLAY');
   });
+
+  describe('BearerAuthService integration via RELAYER_AUTH_SECRET', () => {
+    let originalSecret: string | undefined;
+
+    beforeAll(() => {
+      originalSecret = process.env.RELAYER_AUTH_SECRET;
+      process.env.RELAYER_AUTH_SECRET = 'integration-secret';
+    });
+
+    afterAll(() => {
+      if (originalSecret === undefined) {
+        delete process.env.RELAYER_AUTH_SECRET;
+      } else {
+        process.env.RELAYER_AUTH_SECRET = originalSecret;
+      }
+    });
+
+    it('denies access with 401 when invalid token is supplied', async () => {
+      const mockSigService: SignatureServiceContract = {
+        verify: jest.fn().mockReturnValue(true),
+      };
+      const app = createApp(undefined, mockSigService, undefined, undefined, {
+        useMockSubmission: true,
+      });
+      const res = await request(app)
+        .post('/relay/execute')
+        .set('Authorization', 'Bearer wrong-secret')
+        .send(validBody);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('UNAUTHORIZED');
+    });
+
+    it('grants access with 200 when correct token is supplied', async () => {
+      const mockSigService: SignatureServiceContract = {
+        verify: jest.fn().mockReturnValue(true),
+      };
+      const app = createApp(undefined, mockSigService, undefined, undefined, {
+        useMockSubmission: true,
+      });
+      const res = await request(app)
+        .post('/relay/execute')
+        .set('Authorization', 'Bearer integration-secret')
+        .send({ ...validBody, nonce: 3 }); // Use a unique nonce to avoid replay rejection
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+  });
 });

--- a/services/relayer/tests/integration/relay.test.ts
+++ b/services/relayer/tests/integration/relay.test.ts
@@ -225,7 +225,7 @@ describe('POST /relay/execute — idempotency-key header', () => {
       .post('/relay/execute')
       .set('Authorization', 'Bearer token')
       .set('idempotency-key', 'key-b')
-      .send(validBody);
+      .send({ ...validBody, nonce: 2 });
 
     expect(r1.status).toBe(200);
     expect(r2.status).toBe(200);
@@ -262,5 +262,61 @@ describe('POST /relay/execute — idempotency-key header', () => {
     await request(app).post('/relay/execute').set('Authorization', 'Bearer token').send(validBody);
 
     expect(store.size()).toBe(0);
+  });
+
+  it('rejects duplicate nonces with NONCE_REPLAY error code', async () => {
+    const app = makeApp(true, undefined, undefined, { useMockSubmission: true });
+
+    // First request
+    const r1 = await request(app)
+      .post('/relay/execute')
+      .set('Authorization', 'Bearer token')
+      .send(validBody);
+    expect(r1.status).toBe(200);
+
+    // Replay request with same nonce
+    const r2 = await request(app)
+      .post('/relay/execute')
+      .set('Authorization', 'Bearer token')
+      .send(validBody);
+    expect(r2.status).toBe(422);
+    expect(r2.body.success).toBe(false);
+    expect(r2.body.error.code).toBe('NONCE_REPLAY');
+  });
+
+  it('does not consume nonce on /relay/validate but rejects it after execution', async () => {
+    const app = makeApp(true, undefined, undefined, { useMockSubmission: true });
+
+    // Validate request first (should be valid)
+    const v1 = await request(app)
+      .post('/relay/validate')
+      .set('Authorization', 'Bearer token')
+      .send(validBody);
+    expect(v1.status).toBe(200);
+    expect(v1.body.valid).toBe(true);
+
+    // Validate request again (should still be valid because validate doesn't consume)
+    const v2 = await request(app)
+      .post('/relay/validate')
+      .set('Authorization', 'Bearer token')
+      .send(validBody);
+    expect(v2.status).toBe(200);
+    expect(v2.body.valid).toBe(true);
+
+    // Execute the request
+    const e1 = await request(app)
+      .post('/relay/execute')
+      .set('Authorization', 'Bearer token')
+      .send(validBody);
+    expect(e1.status).toBe(200);
+
+    // Now validate should fail because nonce is consumed
+    const v3 = await request(app)
+      .post('/relay/validate')
+      .set('Authorization', 'Bearer token')
+      .send(validBody);
+    expect(v3.status).toBe(422);
+    expect(v3.body.valid).toBe(false);
+    expect(v3.body.error.code).toBe('NONCE_REPLAY');
   });
 });

--- a/services/relayer/tests/unit/bearerAuthService.test.ts
+++ b/services/relayer/tests/unit/bearerAuthService.test.ts
@@ -1,0 +1,28 @@
+import { BearerAuthService } from '../../src/services/bearerAuthService';
+
+describe('BearerAuthService', () => {
+  const secret = 'super-secret-token';
+  let authService: BearerAuthService;
+
+  beforeEach(() => {
+    authService = new BearerAuthService(secret);
+  });
+
+  it('verifies token successfully when it matches the secret', async () => {
+    const result = await authService.verifyToken(secret);
+    expect(result).toEqual({ callerId: 'relay-client' });
+  });
+
+  it('verifies token successfully when it includes Bearer prefix', async () => {
+    const result = await authService.verifyToken(`Bearer ${secret}`);
+    expect(result).toEqual({ callerId: 'relay-client' });
+  });
+
+  it('throws an error when the token is incorrect', async () => {
+    await expect(authService.verifyToken('wrong-token')).rejects.toThrow('unauthorized');
+  });
+
+  it('throws an error when the token is empty', async () => {
+    await expect(authService.verifyToken('')).rejects.toThrow('unauthorized');
+  });
+});

--- a/services/relayer/tests/unit/nonceStore.test.ts
+++ b/services/relayer/tests/unit/nonceStore.test.ts
@@ -1,0 +1,58 @@
+import { NonceStore } from '../../src/store/nonceStore';
+
+describe('NonceStore', () => {
+  it('allows fresh nonces and tracks them', () => {
+    const store = new NonceStore();
+    const key = 'session-1';
+
+    expect(() => store.assertFresh(key, 100)).not.toThrow();
+    store.track(key, 100);
+
+    expect(() => store.assertFresh(key, 100)).toThrow('Nonce already used');
+    expect(() => store.assertFresh(key, 101)).not.toThrow();
+  });
+
+  it('keeps track of nonces per session key independently', () => {
+    const store = new NonceStore();
+    const key1 = 'session-1';
+    const key2 = 'session-2';
+
+    store.track(key1, 100);
+    expect(() => store.assertFresh(key1, 100)).toThrow('Nonce already used');
+    expect(() => store.assertFresh(key2, 100)).not.toThrow();
+  });
+
+  it('evicts expired nonces based on TTL', async () => {
+    const store = new NonceStore(50); // 50ms TTL
+    const key = 'session-1';
+
+    store.track(key, 100);
+    expect(() => store.assertFresh(key, 100)).toThrow('Nonce already used');
+    expect(store.size(key)).toBe(1);
+
+    // Wait for TTL expiration
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(() => store.assertFresh(key, 100)).not.toThrow();
+    expect(store.size(key)).toBe(0);
+  });
+
+  it('clears expired nonces for all session keys', async () => {
+    const store = new NonceStore(50);
+    const key1 = 'session-1';
+    const key2 = 'session-2';
+
+    store.track(key1, 100);
+    store.track(key2, 200);
+
+    expect(store.size(key1)).toBe(1);
+    expect(store.size(key2)).toBe(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    store.clearExpired();
+    // Use the private seen map reflection or size check to ensure cleanup
+    expect(store.size(key1)).toBe(0);
+    expect(store.size(key2)).toBe(0);
+  });
+});

--- a/services/relayer/tests/unit/relayService.test.ts
+++ b/services/relayer/tests/unit/relayService.test.ts
@@ -2,6 +2,7 @@ import { NetworkError } from '@ancore/stellar';
 import { RelayService } from '../../src/services/relayService';
 import { JobQueue } from '../../src/queue/JobQueue';
 import { IdempotencyStore } from '../../src/store/idempotency';
+import { NonceStore } from '../../src/store/nonceStore';
 import type {
   SignatureServiceContract,
   RelayExecuteRequest,
@@ -69,6 +70,23 @@ describe('RelayService', () => {
       expect(result.valid).toBe(false);
       expect(result.error?.code).toBe('NONCE_REPLAY');
     });
+
+    it('returns NONCE_REPLAY if nonce is already seen in nonceStore', async () => {
+      const nonceStore = new NonceStore();
+      nonceStore.track(VALID_KEY, 1);
+      const svc = new RelayService(
+        makeSignatureService(true),
+        undefined,
+        undefined,
+        undefined,
+        { useMockSubmission: true },
+        nonceStore
+      );
+      const result = await svc.validateRelay(makeRequest({ nonce: 1 }));
+      expect(result.valid).toBe(false);
+      expect(result.error?.code).toBe('NONCE_REPLAY');
+      expect(result.error?.message).toBe('Nonce already used');
+    });
   });
 
   describe('executeRelay', () => {
@@ -80,6 +98,29 @@ describe('RelayService', () => {
       expect(result.success).toBe(true);
       expect(result.transactionId).toMatch(/^[0-9A-F]{64}$/);
       expect(result.gasUsed).toBe(21_000);
+    });
+
+    it('tracks nonce in nonceStore upon successful execution', async () => {
+      const nonceStore = new NonceStore();
+      const svc = new RelayService(
+        makeSignatureService(true),
+        undefined,
+        undefined,
+        undefined,
+        { useMockSubmission: true },
+        nonceStore
+      );
+      const req = makeRequest({ nonce: 42 });
+      const r1 = await svc.executeRelay(req);
+      expect(r1.success).toBe(true);
+
+      // Now it should be in the store
+      expect(() => nonceStore.assertFresh(VALID_KEY, 42)).toThrow('Nonce already used');
+
+      // Subsequent execution with same request (nonce 42) should fail
+      const r2 = await svc.executeRelay(req);
+      expect(r2.success).toBe(false);
+      expect(r2.error?.code).toBe('NONCE_REPLAY');
     });
 
     it('returns network transaction hash from submitter on valid request', async () => {


### PR DESCRIPTION
# Pull Request: [RELAYER] Add nonce replay store with TTL per session key (#571)

## Summary
This PR introduces an in-memory nonce replay store with time-to-live (TTL) eviction tracked per session key inside the relayer service to prevent transaction replay attacks.

## Key Changes

### 1. In-Memory NonceStore
- Created `services/relayer/src/store/nonceStore.ts` containing the `NonceStore` class.
- Tracks seen nonces by `sessionKey` mapped to their expiration timestamp (`Map<string, Map<number, number>>`).
- Implements `assertFresh(key, nonce)` to verify a nonce has not been seen before, and `track(key, nonce)` to record it.
- Evicts expired nonces lazily during checks based on a configurable TTL (defaults to 5 minutes).

### 2. Integration into RelayService
- Added the `NonceStore` to the optional parameters of `RelayService` constructor for backward compatibility.
- Updated `validateRelay` to verify that the nonce is fresh before running signature verification.
- Updated `executeRelay` to record the nonce inside `nonceStore` after successful validation.

### 3. Server Configuration
- Instantiated `NonceStore` in `createApp` (`services/relayer/src/server.ts`) and passed it into the `RelayService` constructor.

### 4. Tests
- Added unit tests for `NonceStore` eviction and duplicate rejection in `services/relayer/tests/unit/nonceStore.test.ts`.
- Added unit tests for validation and tracking in `services/relayer/tests/unit/relayService.test.ts`.
- Added integration tests covering duplicate nonce rejection (`NONCE_REPLAY` error code) and verifying `/relay/validate` does not consume nonces in `services/relayer/tests/integration/relay.test.ts`.


Closes #571 
closes #570 
Closes #810 
Closes #576 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nonce replay protection for relay requests to help prevent repeated submissions.
  * Nonces are now tracked per session key with automatic expiration.

* **Bug Fixes**
  * Validation now rejects reused nonces with a clear `NONCE_REPLAY` error.
  * Successful relay execution records the nonce so it cannot be reused immediately.

* **Tests**
  * Added coverage for nonce replay behavior in validation and execution flows.
  * Added unit tests for nonce tracking, expiration, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->