### PR TITLE
feat(extension): add session key expiry countdown in list rows

### DIFF
--- a/apps/extension-wallet/src/features/session-keys/SessionKeyRow.tsx
+++ b/apps/extension-wallet/src/features/session-keys/SessionKeyRow.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import type { SessionKey } from '@ancore/types';
+import { permissionsToLabels } from '@ancore/core-sdk';
+import { ExpiryCountdown, useExpiryCountdown, useToast } from '@ancore/ui-kit';
+
+import { refreshSessionKeyTtl } from './refreshSessionKeyTtl';
+
+export interface SessionKeyRowProps {
+  sessionKey: SessionKey;
+  onRevoke: (publicKey: string) => Promise<void>;
+  onRefresh: (publicKey: string, newExpiresAt: number) => Promise<void>;
+}
+
+function truncatePublicKey(publicKey: string): string {
+  return `${publicKey.slice(0, 8)}…${publicKey.slice(-6)}`;
+}
+
+export const SessionKeyRow: React.FC<SessionKeyRowProps> = ({
+  sessionKey,
+  onRevoke,
+  onRefresh,
+}) => {
+  const { showSuccess, showError } = useToast();
+  const [refreshLoading, setRefreshLoading] = useState(false);
+  const { status } = useExpiryCountdown(sessionKey.expiresAt);
+  const isRevoked = sessionKey.expiresAt === 0;
+
+  const badgeLabel =
+    status === 'revoked' ? 'Revoked' : status === 'expired' ? 'Expired' : 'Active';
+  const badgeClass =
+    status === 'active' || status === 'expiring-soon'
+      ? 'bg-green-100 text-green-700'
+      : 'bg-gray-200 text-gray-500';
+
+  const handleRefresh = async (): Promise<void> => {
+    setRefreshLoading(true);
+    try {
+      await refreshSessionKeyTtl(sessionKey, onRefresh);
+      showSuccess('Session key expiry refreshed');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to refresh session key';
+      showError(message);
+    } finally {
+      setRefreshLoading(false);
+    }
+  };
+
+  return (
+    <li
+      className="flex justify-between items-start rounded border p-3"
+      data-testid="session-key-row"
+      data-status={status}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">
+          {sessionKey.label || 'Unnamed Key'}
+          <span className={`ml-2 text-xs px-1.5 py-0.5 rounded ${badgeClass}`}>{badgeLabel}</span>
+        </p>
+        <p className="text-xs text-gray-500 font-mono mt-0.5">
+          {truncatePublicKey(sessionKey.publicKey)}
+        </p>
+        <p className="text-xs text-gray-500 mt-1">
+          Permissions: {permissionsToLabels(sessionKey.permissions).join(', ')}
+        </p>
+        <ExpiryCountdown
+          className="mt-1"
+          expiresAt={sessionKey.expiresAt}
+          onRefresh={isRevoked ? undefined : handleRefresh}
+          refreshLoading={refreshLoading}
+        />
+      </div>
+      <button
+        type="button"
+        onClick={() => void onRevoke(sessionKey.publicKey)}
+        className="text-red-500 text-sm ml-4 shrink-0"
+        aria-label={`Revoke ${sessionKey.label ?? sessionKey.publicKey}`}
+        disabled={isRevoked}
+      >
+        Revoke
+      </button>
+    </li>
+  );
+};

--- a/apps/extension-wallet/src/features/session-keys/__tests__/SessionKeyRow.test.tsx
+++ b/apps/extension-wallet/src/features/session-keys/__tests__/SessionKeyRow.test.tsx
@@ -1,0 +1,107 @@
+import type { ComponentProps } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NotificationProvider } from '@ancore/ui-kit';
+import { SessionPermission } from '@ancore/types';
+import type { SessionKey } from '@ancore/types';
+
+import { SessionKeyRow } from '../SessionKeyRow';
+
+const showSuccess = vi.fn();
+const showError = vi.fn();
+
+vi.mock('@ancore/ui-kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@ancore/ui-kit')>();
+  return {
+    ...actual,
+    useToast: () => ({ showSuccess, showError, toast: vi.fn() }),
+  };
+});
+
+const baseKey: SessionKey = {
+  publicKey: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890',
+  permissions: [SessionPermission.SEND_PAYMENT],
+  expiresAt: Date.now() + 2 * 86_400_000,
+  label: 'Trading bot',
+};
+
+function renderRow(
+  props: Partial<ComponentProps<typeof SessionKeyRow>> = {},
+  keyOverrides: Partial<SessionKey> = {}
+) {
+  const onRevoke = vi.fn().mockResolvedValue(undefined);
+  const onRefresh = vi.fn().mockResolvedValue(undefined);
+
+  render(
+    <NotificationProvider>
+      <ul>
+        <SessionKeyRow
+          sessionKey={{ ...baseKey, ...keyOverrides }}
+          onRevoke={onRevoke}
+          onRefresh={onRefresh}
+          {...props}
+        />
+      </ul>
+    </NotificationProvider>
+  );
+
+  return { onRevoke, onRefresh };
+}
+
+describe('SessionKeyRow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders countdown label and permissions', () => {
+    renderRow();
+    expect(screen.getByText(/Trading bot/)).toBeInTheDocument();
+    expect(screen.getByText(/Send Payment/)).toBeInTheDocument();
+    expect(screen.getByTestId('expiry-countdown-label')).toHaveTextContent(/remaining/);
+  });
+
+  it('shows success toast after refresh', async () => {
+    const user = userEvent.setup();
+    renderRow();
+
+    await user.click(screen.getByTestId('expiry-refresh-button'));
+
+    await waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith('Session key expiry refreshed');
+    });
+  });
+
+  it('shows error toast when refresh fails', async () => {
+    const user = userEvent.setup();
+    const onRefresh = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    render(
+      <NotificationProvider>
+        <ul>
+          <SessionKeyRow sessionKey={baseKey} onRevoke={vi.fn()} onRefresh={onRefresh} />
+        </ul>
+      </NotificationProvider>
+    );
+
+    await user.click(screen.getByTestId('expiry-refresh-button'));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith('Network error');
+    });
+  });
+
+  it('disables refresh for revoked keys', () => {
+    renderRow({}, { expiresAt: 0 });
+    expect(screen.queryByTestId('expiry-refresh-button')).not.toBeInTheDocument();
+    expect(screen.getByTestId('session-key-row')).toHaveAttribute('data-status', 'revoked');
+    expect(screen.getByTestId('expiry-countdown-label')).toHaveTextContent('Revoked');
+  });
+
+  it('styles expired keys distinctly', () => {
+    renderRow({}, { expiresAt: Date.now() - 60_000 });
+    expect(screen.getByTestId('session-key-row')).toHaveAttribute('data-status', 'expired');
+    expect(screen.getByTestId('expiry-countdown-label')).toHaveTextContent('Expired');
+  });
+});

--- a/apps/extension-wallet/src/features/session-keys/__tests__/refreshSessionKeyTtl.test.ts
+++ b/apps/extension-wallet/src/features/session-keys/__tests__/refreshSessionKeyTtl.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SessionKey } from '@ancore/types';
+import { SessionPermission } from '@ancore/types';
+
+import {
+  DEFAULT_SESSION_KEY_REFRESH_TTL_MS,
+  refreshSessionKeyTtl,
+} from '../refreshSessionKeyTtl';
+
+const baseKey: SessionKey = {
+  publicKey: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890',
+  permissions: [SessionPermission.SEND_PAYMENT],
+  expiresAt: Date.now() + 86_400_000,
+  label: 'Trading bot',
+};
+
+describe('refreshSessionKeyTtl', () => {
+  it('extends expiry by the default TTL', async () => {
+    const refreshSessionKey = vi.fn().mockResolvedValue(undefined);
+    const nowMs = 1_700_000_000_000;
+
+    await refreshSessionKeyTtl(baseKey, refreshSessionKey, DEFAULT_SESSION_KEY_REFRESH_TTL_MS, nowMs);
+
+    expect(refreshSessionKey).toHaveBeenCalledWith(
+      baseKey.publicKey,
+      nowMs + DEFAULT_SESSION_KEY_REFRESH_TTL_MS
+    );
+  });
+
+  it('rejects refresh for revoked keys', async () => {
+    const refreshSessionKey = vi.fn();
+
+    await expect(
+      refreshSessionKeyTtl({ ...baseKey, expiresAt: 0 }, refreshSessionKey)
+    ).rejects.toThrow('Cannot refresh a revoked session key');
+
+    expect(refreshSessionKey).not.toHaveBeenCalled();
+  });
+});

--- a/apps/extension-wallet/src/features/session-keys/index.ts
+++ b/apps/extension-wallet/src/features/session-keys/index.ts
@@ -1,0 +1,6 @@
+export { SessionKeyRow } from './SessionKeyRow';
+export type { SessionKeyRowProps } from './SessionKeyRow';
+export {
+  DEFAULT_SESSION_KEY_REFRESH_TTL_MS,
+  refreshSessionKeyTtl,
+} from './refreshSessionKeyTtl';

--- a/apps/extension-wallet/src/features/session-keys/refreshSessionKeyTtl.ts
+++ b/apps/extension-wallet/src/features/session-keys/refreshSessionKeyTtl.ts
@@ -1,0 +1,16 @@
+import type { SessionKey } from '@ancore/types';
+
+export const DEFAULT_SESSION_KEY_REFRESH_TTL_MS = 24 * 60 * 60 * 1000;
+
+export async function refreshSessionKeyTtl(
+  key: SessionKey,
+  refreshSessionKey: (publicKey: string, newExpiresAt: number) => Promise<void>,
+  ttlMs: number = DEFAULT_SESSION_KEY_REFRESH_TTL_MS,
+  nowMs: number = Date.now()
+): Promise<void> {
+  if (key.expiresAt === 0) {
+    throw new Error('Cannot refresh a revoked session key');
+  }
+
+  await refreshSessionKey(key.publicKey, nowMs + ttlMs);
+}

--- a/apps/extension-wallet/src/hooks/useSessionKeys.ts
+++ b/apps/extension-wallet/src/hooks/useSessionKeys.ts
@@ -103,7 +103,6 @@ export function useSessionKeys(): UseSessionKeysReturn {
 
   const refreshSessionKey = useCallback(
     async (publicKey: string, newExpiresAt: number): Promise<void> => {
-      setIsLoading(true);
       setError(null);
 
       const snapshot = keys.find((k: SessionKey) => k.publicKey === publicKey);
@@ -120,8 +119,6 @@ export function useSessionKeys(): UseSessionKeysReturn {
         const msg = err instanceof Error ? err.message : 'Failed to refresh session key';
         setError(msg);
         throw err;
-      } finally {
-        setIsLoading(false);
       }
     },
     [keys, updateKey]

--- a/apps/extension-wallet/src/router/__tests__/router.test.tsx
+++ b/apps/extension-wallet/src/router/__tests__/router.test.tsx
@@ -122,7 +122,7 @@ describe('extension router', () => {
       isUnlocked: true,
     });
 
-    expect(screen.getByRole('heading', { name: /session keys/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'Session Keys' })).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /go back/i }));
 

--- a/apps/extension-wallet/src/router/index.tsx
+++ b/apps/extension-wallet/src/router/index.tsx
@@ -28,6 +28,7 @@ import { ReceiveScreen as ReceiveScreenComponent } from '../screens/ReceiveScree
 import { SettingsScreen } from '../screens/Settings/SettingsScreen';
 import { SendScreen as SendFlowScreen } from '../screens/Send/SendScreen';
 import { ScheduledTransfersScreen } from '../screens/ScheduledTransfers/ScheduledTransfersScreen';
+import { SessionKeysScreen } from '../screens/SessionKeys/SessionKeysScreen';
 import { useDashboardSettingsStore } from '../state/dashboard-settings';
 import { EmptyTransactions } from '../components/EmptyTransactions';
 import { ErrorBoundary } from '../components/ErrorBoundary/ErrorBoundary';
@@ -756,37 +757,6 @@ function HistoryScreen() {
           )}
         </>
       )}
-    </PageScaffold>
-  );
-}
-
-function SessionKeysScreen() {
-  return (
-    <PageScaffold
-      backTo="/settings"
-      eyebrow="Security"
-      title="Session Keys"
-      description="Manage temporary signing permissions without leaving the extension flow."
-    >
-      <Card
-        title="Active keys"
-        description="Session keys can be rotated or revoked without affecting the primary wallet."
-      >
-        <div className="space-y-3">
-          <div className="rounded-xl border border-border px-4 py-3">
-            <p className="text-sm font-medium text-foreground">Trading bot</p>
-            <p className="mt-1 text-xs text-muted-foreground">Valid for 12 more hours</p>
-          </div>
-          <div className="rounded-xl border border-border px-4 py-3">
-            <p className="text-sm font-medium text-foreground">Automation script</p>
-            <p className="mt-1 text-xs text-muted-foreground">Read-only access, expires tomorrow</p>
-          </div>
-        </div>
-      </Card>
-      <PrimaryButton>
-        <PlusCircle className="mr-2 h-4 w-4" />
-        Add session key
-      </PrimaryButton>
     </PageScaffold>
   );
 }

--- a/apps/extension-wallet/src/screens/SessionKeys/SessionKeysScreen.tsx
+++ b/apps/extension-wallet/src/screens/SessionKeys/SessionKeysScreen.tsx
@@ -1,26 +1,31 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { AddSessionKeyDialog } from './AddSessionKeyDialog';
-import { useSessionKeys, SessionPermission } from '../../hooks/useSessionKeys';
-
-const PERMISSION_LABELS: Record<SessionPermission, string> = {
-  [SessionPermission.SEND_PAYMENT]: 'Send Payment',
-  [SessionPermission.MANAGE_DATA]: 'Manage Data',
-  [SessionPermission.INVOKE_CONTRACT]: 'Invoke Contract',
-};
-
-function isExpired(expiresAt: number): boolean {
-  return Date.now() > expiresAt;
-}
+import { useSessionKeys } from '../../hooks/useSessionKeys';
+import { SessionKeyRow } from '../../features/session-keys';
 
 export const SessionKeysScreen: React.FC = () => {
-  const { sessionKeys, isLoading, error, addSessionKey, revokeSessionKey, clearError } =
-    useSessionKeys();
+  const navigate = useNavigate();
+  const {
+    sessionKeys,
+    isLoading,
+    error,
+    addSessionKey,
+    revokeSessionKey,
+    refreshSessionKey,
+    clearError,
+  } = useSessionKeys();
   const [isDialogOpen, setDialogOpen] = useState(false);
 
   return (
     <div className="p-4">
       <header className="flex justify-between items-center mb-4">
-        <button onClick={() => window.history.back()} className="text-blue-500">
+        <button
+          type="button"
+          onClick={() => navigate('/settings')}
+          className="text-blue-500"
+          aria-label="Go back"
+        >
           ← Back
         </button>
         <h1 className="text-xl font-bold">Session Keys</h1>
@@ -64,45 +69,14 @@ export const SessionKeysScreen: React.FC = () => {
 
         {!isLoading && sessionKeys.length > 0 && (
           <ul className="space-y-3">
-            {sessionKeys.map((key) => {
-              const expired = isExpired(key.expiresAt);
-              return (
-                <li
-                  key={key.publicKey}
-                  className="flex justify-between items-start rounded border p-3"
-                >
-                  <div>
-                    <p className="font-medium">
-                      {key.label || 'Unnamed Key'}
-                      <span
-                        className={`ml-2 text-xs px-1.5 py-0.5 rounded ${
-                          expired ? 'bg-gray-200 text-gray-500' : 'bg-green-100 text-green-700'
-                        }`}
-                      >
-                        {expired ? 'Expired' : 'Active'}
-                      </span>
-                    </p>
-                    <p className="text-xs text-gray-500 font-mono mt-0.5">
-                      {key.publicKey.slice(0, 8)}…{key.publicKey.slice(-6)}
-                    </p>
-                    <p className="text-xs text-gray-500 mt-1">
-                      Permissions:{' '}
-                      {key.permissions.map((p) => PERMISSION_LABELS[p] ?? String(p)).join(', ')}
-                    </p>
-                    <p className="text-xs text-gray-500">
-                      Expires: {new Date(key.expiresAt).toLocaleString()}
-                    </p>
-                  </div>
-                  <button
-                    onClick={() => revokeSessionKey(key.publicKey)}
-                    className="text-red-500 text-sm ml-4"
-                    aria-label={`Revoke ${key.label ?? key.publicKey}`}
-                  >
-                    Revoke
-                  </button>
-                </li>
-              );
-            })}
+            {sessionKeys.map((key) => (
+              <SessionKeyRow
+                key={key.publicKey}
+                sessionKey={key}
+                onRevoke={revokeSessionKey}
+                onRefresh={refreshSessionKey}
+              />
+            ))}
           </ul>
         )}
       </section>

--- a/apps/extension-wallet/tests/e2e/session-keys.spec.ts
+++ b/apps/extension-wallet/tests/e2e/session-keys.spec.ts
@@ -13,19 +13,15 @@ test.describe('Session key management', () => {
     await expect(page).toHaveURL(/\/session-keys/);
   });
 
-  test('session keys screen shows active keys list', async ({ page }) => {
-    await expect(page.getByText('Active keys')).toBeVisible();
-    await expect(page.getByText('Trading bot')).toBeVisible();
-    await expect(page.getByText('Automation script')).toBeVisible();
+  test('session keys screen shows list section and empty state', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Session Keys' })).toBeVisible();
+    await expect(page.getByText('Active Keys')).toBeVisible();
+    await expect(page.getByText('No session keys yet.')).toBeVisible();
   });
 
-  test('session keys screen shows key validity info', async ({ page }) => {
-    await expect(page.getByText(/Valid for 12 more hours/)).toBeVisible();
-    await expect(page.getByText(/expires tomorrow/i)).toBeVisible();
-  });
-
-  test('add session key button is present', async ({ page }) => {
-    await expect(page.getByRole('button', { name: /Add session key/i })).toBeVisible();
+  test('session keys screen exposes add session key actions', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /add session key/i }).first()).toBeVisible();
+    await expect(page.getByText('+ Add Session Key')).toBeVisible();
   });
 
   test('unauthenticated user cannot access session keys', async ({ page, clearWallet }) => {

--- a/apps/extension-wallet/tests/e2e/smoke.spec.ts
+++ b/apps/extension-wallet/tests/e2e/smoke.spec.ts
@@ -57,7 +57,8 @@ test.describe('Extension release-candidate smoke @smoke', () => {
     await seedWallet('onboarded-unlocked');
     await navigateTo(page, '/session-keys');
 
-    await expect(page.getByText('Active keys')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Session Keys' })).toBeVisible();
+    await expect(page.getByText('Active Keys')).toBeVisible();
     await expect(page.getByRole('button', { name: /Add session key/i })).toBeVisible();
 
     await clearWallet();

--- a/packages/ui-kit/src/components/ExpiryCountdown/ExpiryCountdown.stories.tsx
+++ b/packages/ui-kit/src/components/ExpiryCountdown/ExpiryCountdown.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ExpiryCountdown } from './ExpiryCountdown';
+
+const now = Date.now();
+
+const meta = {
+  title: 'Components/ExpiryCountdown',
+  component: ExpiryCountdown,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Relative session-key expiry countdown with optional refresh CTA, polite live-region announcements, and per-minute updates.',
+      },
+    },
+  },
+  args: {
+    onRefresh: () => undefined,
+  },
+} satisfies Meta<typeof ExpiryCountdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Active: Story = {
+  args: {
+    expiresAt: now + 3 * 86_400_000,
+  },
+};
+
+export const ExpiringSoon: Story = {
+  args: {
+    expiresAt: now + 30 * 60_000,
+  },
+};
+
+export const Expired: Story = {
+  args: {
+    expiresAt: now - 60_000,
+  },
+};
+
+export const Revoked: Story = {
+  args: {
+    expiresAt: 0,
+  },
+};
+
+export const RefreshLoading: Story = {
+  args: {
+    expiresAt: now + 2 * 86_400_000,
+    refreshLoading: true,
+  },
+};

--- a/packages/ui-kit/src/components/ExpiryCountdown/ExpiryCountdown.test.tsx
+++ b/packages/ui-kit/src/components/ExpiryCountdown/ExpiryCountdown.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExpiryCountdown } from './ExpiryCountdown';
+import {
+  COUNTDOWN_UPDATE_INTERVAL_MS,
+  EXPIRING_SOON_THRESHOLD_MS,
+  formatExpiryRemaining,
+  getExpiryStatus,
+  getExpiryThreshold,
+} from './format-expiry';
+
+describe('formatExpiryRemaining', () => {
+  const now = new Date('2026-06-25T12:00:00.000Z').getTime();
+
+  it('returns Revoked for sentinel expiry', () => {
+    expect(formatExpiryRemaining(0, now)).toBe('Revoked');
+  });
+
+  it('returns Expired for past timestamps', () => {
+    expect(formatExpiryRemaining(now - 1, now)).toBe('Expired');
+  });
+
+  it('formats minutes remaining under one hour', () => {
+    expect(formatExpiryRemaining(now + 45 * 60_000, now)).toBe('45 minutes remaining');
+    expect(formatExpiryRemaining(now + 60_000, now)).toBe('1 minute remaining');
+  });
+
+  it('formats hours remaining under one day', () => {
+    expect(formatExpiryRemaining(now + 5 * 3_600_000, now)).toBe('5 hours remaining');
+  });
+
+  it('formats days remaining', () => {
+    expect(formatExpiryRemaining(now + 3 * 86_400_000, now)).toBe('3 days remaining');
+  });
+});
+
+describe('getExpiryStatus', () => {
+  const now = new Date('2026-06-25T12:00:00.000Z').getTime();
+
+  it('detects revoked, expired, expiring-soon, and active states', () => {
+    expect(getExpiryStatus(0, now)).toBe('revoked');
+    expect(getExpiryStatus(now - 1, now)).toBe('expired');
+    expect(getExpiryStatus(now + EXPIRING_SOON_THRESHOLD_MS, now)).toBe('expiring-soon');
+    expect(getExpiryStatus(now + EXPIRING_SOON_THRESHOLD_MS + 1, now)).toBe('active');
+  });
+});
+
+describe('getExpiryThreshold', () => {
+  const now = new Date('2026-06-25T12:00:00.000Z').getTime();
+
+  it('returns null for keys with more than one day remaining', () => {
+    expect(getExpiryThreshold(now + 2 * 86_400_000, now)).toBeNull();
+  });
+
+  it('returns less-than-one-day inside the final day', () => {
+    expect(getExpiryThreshold(now + 12 * 3_600_000, now)).toBe('less-than-one-day');
+  });
+});
+
+describe('ExpiryCountdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-25T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders human-readable remaining time for an active key', () => {
+    render(<ExpiryCountdown expiresAt={Date.now() + 2 * 86_400_000} />);
+    expect(screen.getByTestId('expiry-countdown-label')).toHaveTextContent('2 days remaining');
+    expect(screen.getByTestId('expiry-countdown-label')).toHaveAttribute('data-status', 'active');
+  });
+
+  it('updates the label each minute', () => {
+    render(<ExpiryCountdown expiresAt={Date.now() + 90 * 60_000} />);
+    expect(screen.getByTestId('expiry-countdown-label')).toHaveTextContent('1 hour remaining');
+
+    act(() => {
+      vi.advanceTimersByTime(COUNTDOWN_UPDATE_INTERVAL_MS);
+    });
+
+    expect(screen.getByTestId('expiry-countdown-label')).toHaveTextContent('1 hour remaining');
+  });
+
+  it('styles expired keys distinctly and keeps refresh enabled', () => {
+    const onRefresh = vi.fn();
+
+    render(<ExpiryCountdown expiresAt={Date.now() - 60_000} onRefresh={onRefresh} />);
+
+    expect(screen.getByTestId('expiry-countdown-label')).toHaveTextContent('Expired');
+    expect(screen.getByTestId('expiry-countdown-label')).toHaveAttribute('data-status', 'expired');
+
+    fireEvent.click(screen.getByTestId('expiry-refresh-button'));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables refresh for revoked keys', () => {
+    render(<ExpiryCountdown expiresAt={0} onRefresh={vi.fn()} />);
+
+    expect(screen.getByTestId('expiry-countdown-label')).toHaveTextContent('Revoked');
+    expect(screen.getByTestId('expiry-refresh-button')).toBeDisabled();
+  });
+
+  it('announces significant threshold crossings via aria-live region', () => {
+    const expiresAt = Date.now() + 30 * 60_000;
+
+    render(<ExpiryCountdown expiresAt={expiresAt} />);
+    expect(screen.getByTestId('expiry-countdown-announcement')).toHaveTextContent(
+      'Session key expiring in less than one hour'
+    );
+
+    act(() => {
+      vi.setSystemTime(new Date(expiresAt + 1));
+      vi.advanceTimersByTime(COUNTDOWN_UPDATE_INTERVAL_MS);
+    });
+
+    expect(screen.getByTestId('expiry-countdown-announcement')).toHaveTextContent(
+      'Session key has expired'
+    );
+  });
+
+  it('shows loading state on refresh button', () => {
+    render(<ExpiryCountdown expiresAt={Date.now() + 86_400_000} onRefresh={vi.fn()} refreshLoading />);
+
+    expect(screen.getByTestId('expiry-refresh-button')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByTestId('expiry-refresh-button')).toBeDisabled();
+  });
+});

--- a/packages/ui-kit/src/components/ExpiryCountdown/ExpiryCountdown.tsx
+++ b/packages/ui-kit/src/components/ExpiryCountdown/ExpiryCountdown.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { RefreshCw } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Button } from '../ui/button';
+import {
+  COUNTDOWN_UPDATE_INTERVAL_MS,
+  formatExpiryRemaining,
+  getExpiryStatus,
+  getExpiryThreshold,
+  getThresholdAnnouncement,
+  isRevokedExpiry,
+  type ExpiryStatus,
+  type ExpiryThreshold,
+} from './format-expiry';
+
+export interface ExpiryCountdownProps {
+  expiresAt: number;
+  onRefresh?: () => void | Promise<void>;
+  refreshLoading?: boolean;
+  className?: string;
+}
+
+const STATUS_STYLES: Record<ExpiryStatus, string> = {
+  active: 'text-muted-foreground',
+  'expiring-soon': 'text-warning font-medium',
+  expired: 'text-destructive font-medium',
+  revoked: 'text-destructive font-medium',
+};
+
+function useExpiryCountdown(expiresAt: number) {
+  const [nowMs, setNowMs] = React.useState(() => Date.now());
+  const announcedThresholdRef = React.useRef<ExpiryThreshold | null>(null);
+  const [announcement, setAnnouncement] = React.useState('');
+
+  React.useEffect(() => {
+    setNowMs(Date.now());
+    announcedThresholdRef.current = null;
+    setAnnouncement('');
+  }, [expiresAt]);
+
+  React.useEffect(() => {
+    if (isRevokedExpiry(expiresAt)) {
+      return undefined;
+    }
+
+    const tick = () => {
+      const nextNow = Date.now();
+      setNowMs(nextNow);
+
+      const threshold = getExpiryThreshold(expiresAt, nextNow);
+      if (threshold && announcedThresholdRef.current !== threshold) {
+        announcedThresholdRef.current = threshold;
+        setAnnouncement(getThresholdAnnouncement(threshold));
+      }
+    };
+
+    tick();
+    const intervalId = window.setInterval(tick, COUNTDOWN_UPDATE_INTERVAL_MS);
+    return () => window.clearInterval(intervalId);
+  }, [expiresAt]);
+
+  const status = getExpiryStatus(expiresAt, nowMs);
+  const label = formatExpiryRemaining(expiresAt, nowMs);
+
+  return { status, label, announcement };
+}
+
+export { useExpiryCountdown };
+
+export const ExpiryCountdown: React.FC<ExpiryCountdownProps> = ({
+  expiresAt,
+  onRefresh,
+  refreshLoading = false,
+  className,
+}) => {
+  const { status, label, announcement } = useExpiryCountdown(expiresAt);
+  const refreshDisabled = isRevokedExpiry(expiresAt) || !onRefresh;
+
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <span
+        className={cn('text-sm', STATUS_STYLES[status])}
+        data-testid="expiry-countdown-label"
+        data-status={status}
+      >
+        {label}
+      </span>
+
+      {onRefresh && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2"
+          onClick={() => void onRefresh()}
+          disabled={refreshDisabled || refreshLoading}
+          loading={refreshLoading}
+          aria-label="Refresh session key expiry"
+          data-testid="expiry-refresh-button"
+        >
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+        </Button>
+      )}
+
+      <span
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+        data-testid="expiry-countdown-announcement"
+      >
+        {announcement}
+      </span>
+    </div>
+  );
+};

--- a/packages/ui-kit/src/components/ExpiryCountdown/format-expiry.ts
+++ b/packages/ui-kit/src/components/ExpiryCountdown/format-expiry.ts
@@ -1,0 +1,89 @@
+export const EXPIRING_SOON_THRESHOLD_MS = 60 * 60 * 1000;
+export const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+export const COUNTDOWN_UPDATE_INTERVAL_MS = 60 * 1000;
+
+export type ExpiryStatus = 'active' | 'expiring-soon' | 'expired' | 'revoked';
+
+export type ExpiryThreshold =
+  | 'less-than-one-day'
+  | 'expiring-soon'
+  | 'expired'
+  | 'revoked';
+
+export function isRevokedExpiry(expiresAt: number): boolean {
+  return expiresAt === 0;
+}
+
+export function getExpiryStatus(expiresAt: number, nowMs: number): ExpiryStatus {
+  if (isRevokedExpiry(expiresAt)) {
+    return 'revoked';
+  }
+
+  const remainingMs = expiresAt - nowMs;
+  if (remainingMs <= 0) {
+    return 'expired';
+  }
+
+  if (remainingMs <= EXPIRING_SOON_THRESHOLD_MS) {
+    return 'expiring-soon';
+  }
+
+  return 'active';
+}
+
+export function getExpiryThreshold(expiresAt: number, nowMs: number): ExpiryThreshold | null {
+  const status = getExpiryStatus(expiresAt, nowMs);
+  if (status === 'revoked') {
+    return 'revoked';
+  }
+  if (status === 'expired') {
+    return 'expired';
+  }
+  if (status === 'expiring-soon') {
+    return 'expiring-soon';
+  }
+
+  const remainingMs = expiresAt - nowMs;
+  if (remainingMs <= ONE_DAY_MS) {
+    return 'less-than-one-day';
+  }
+
+  return null;
+}
+
+export function formatExpiryRemaining(expiresAt: number, nowMs: number): string {
+  if (isRevokedExpiry(expiresAt)) {
+    return 'Revoked';
+  }
+
+  const remainingMs = expiresAt - nowMs;
+  if (remainingMs <= 0) {
+    return 'Expired';
+  }
+
+  const totalMinutes = Math.ceil(remainingMs / 60_000);
+  if (totalMinutes < 60) {
+    return `${totalMinutes} minute${totalMinutes === 1 ? '' : 's'} remaining`;
+  }
+
+  const totalHours = Math.floor(remainingMs / 3_600_000);
+  if (totalHours < 24) {
+    return `${totalHours} hour${totalHours === 1 ? '' : 's'} remaining`;
+  }
+
+  const totalDays = Math.floor(remainingMs / 86_400_000);
+  return `${totalDays} day${totalDays === 1 ? '' : 's'} remaining`;
+}
+
+export function getThresholdAnnouncement(threshold: ExpiryThreshold): string {
+  switch (threshold) {
+    case 'less-than-one-day':
+      return 'Session key expires in less than one day';
+    case 'expiring-soon':
+      return 'Session key expiring in less than one hour';
+    case 'expired':
+      return 'Session key has expired';
+    case 'revoked':
+      return 'Session key has been revoked';
+  }
+}

--- a/packages/ui-kit/src/components/ExpiryCountdown/index.ts
+++ b/packages/ui-kit/src/components/ExpiryCountdown/index.ts
@@ -1,0 +1,12 @@
+export { ExpiryCountdown, useExpiryCountdown } from './ExpiryCountdown';
+export type { ExpiryCountdownProps } from './ExpiryCountdown';
+export {
+  COUNTDOWN_UPDATE_INTERVAL_MS,
+  EXPIRING_SOON_THRESHOLD_MS,
+  formatExpiryRemaining,
+  getExpiryStatus,
+  getExpiryThreshold,
+  getThresholdAnnouncement,
+  isRevokedExpiry,
+} from './format-expiry';
+export type { ExpiryStatus, ExpiryThreshold } from './format-expiry';

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -51,6 +51,19 @@ export type { IdenticonProps } from './components/Identicon';
 export { MerchantBadge } from './components/MerchantBadge';
 export type { MerchantBadgeProps, MerchantBadgeStatus } from './components/MerchantBadge';
 
+export { ExpiryCountdown, useExpiryCountdown } from './components/ExpiryCountdown';
+export type { ExpiryCountdownProps } from './components/ExpiryCountdown';
+export {
+  COUNTDOWN_UPDATE_INTERVAL_MS,
+  EXPIRING_SOON_THRESHOLD_MS,
+  formatExpiryRemaining,
+  getExpiryStatus,
+  getExpiryThreshold,
+  getThresholdAnnouncement,
+  isRevokedExpiry,
+} from './components/ExpiryCountdown';
+export type { ExpiryStatus, ExpiryThreshold } from './components/ExpiryCountdown';
+
 // Form system
 export { Form, FormSubmit, FormError } from './components/Form/Form';
 export type { FormProps, FormSubmitProps, FormErrorProps } from './components/Form/Form';


### PR DESCRIPTION
Closes #608 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a session key row view with status badges, readable permissions, truncated key display, expiry countdown, refresh, and revoke actions.
  * Added an accessible expiry countdown component with live updates and refresh support.
* **Bug Fixes**
  * Improved handling for revoked and expired session keys, including disabling refresh where appropriate.
  * Updated session key navigation to use the in-app back flow.
* **Tests**
  * Added coverage for session key row behavior, expiry refresh logic, countdown formatting, and related end-to-end flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->