### PR TITLE
feat(mobile): add WalletConnect deep link handler for ancore://wc (#843)

### DIFF
--- a/apps/extension-wallet/src/features/session-keys/SessionKeyRow.tsx
+++ b/apps/extension-wallet/src/features/session-keys/SessionKeyRow.tsx
@@ -25,8 +25,7 @@ export const SessionKeyRow: React.FC<SessionKeyRowProps> = ({
   const { status } = useExpiryCountdown(sessionKey.expiresAt);
   const isRevoked = sessionKey.expiresAt === 0;
 
-  const badgeLabel =
-    status === 'revoked' ? 'Revoked' : status === 'expired' ? 'Expired' : 'Active';
+  const badgeLabel = status === 'revoked' ? 'Revoked' : status === 'expired' ? 'Expired' : 'Active';
   const badgeClass =
     status === 'active' || status === 'expiring-soon'
       ? 'bg-green-100 text-green-700'

--- a/apps/extension-wallet/src/features/session-keys/__tests__/refreshSessionKeyTtl.test.ts
+++ b/apps/extension-wallet/src/features/session-keys/__tests__/refreshSessionKeyTtl.test.ts
@@ -3,10 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { SessionKey } from '@ancore/types';
 import { SessionPermission } from '@ancore/types';
 
-import {
-  DEFAULT_SESSION_KEY_REFRESH_TTL_MS,
-  refreshSessionKeyTtl,
-} from '../refreshSessionKeyTtl';
+import { DEFAULT_SESSION_KEY_REFRESH_TTL_MS, refreshSessionKeyTtl } from '../refreshSessionKeyTtl';
 
 const baseKey: SessionKey = {
   publicKey: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890',
@@ -20,7 +17,12 @@ describe('refreshSessionKeyTtl', () => {
     const refreshSessionKey = vi.fn().mockResolvedValue(undefined);
     const nowMs = 1_700_000_000_000;
 
-    await refreshSessionKeyTtl(baseKey, refreshSessionKey, DEFAULT_SESSION_KEY_REFRESH_TTL_MS, nowMs);
+    await refreshSessionKeyTtl(
+      baseKey,
+      refreshSessionKey,
+      DEFAULT_SESSION_KEY_REFRESH_TTL_MS,
+      nowMs
+    );
 
     expect(refreshSessionKey).toHaveBeenCalledWith(
       baseKey.publicKey,

--- a/apps/extension-wallet/src/features/session-keys/index.ts
+++ b/apps/extension-wallet/src/features/session-keys/index.ts
@@ -1,6 +1,3 @@
 export { SessionKeyRow } from './SessionKeyRow';
 export type { SessionKeyRowProps } from './SessionKeyRow';
-export {
-  DEFAULT_SESSION_KEY_REFRESH_TTL_MS,
-  refreshSessionKeyTtl,
-} from './refreshSessionKeyTtl';
+export { DEFAULT_SESSION_KEY_REFRESH_TTL_MS, refreshSessionKeyTtl } from './refreshSessionKeyTtl';

--- a/apps/extension-wallet/src/screens/ReceiveScreen.tsx
+++ b/apps/extension-wallet/src/screens/ReceiveScreen.tsx
@@ -96,9 +96,10 @@ export function ReceiveScreen({
         filename: `ancore-receive-${smartAccountId.slice(0, 8)}.png`,
         scale: 3,
       });
-    } catch (err) {
+    } catch {
       // Fallback to previous SVG -> PNG method if QR lib unavailable
-      if (qrRef.current) downloadSvgAsPng(qrRef.current, `ancore-receive-${smartAccountId.slice(0, 8)}.png`);
+      if (qrRef.current)
+        downloadSvgAsPng(qrRef.current, `ancore-receive-${smartAccountId.slice(0, 8)}.png`);
     }
   }, [smartAccountId, paymentUri]);
 

--- a/apps/extension-wallet/src/utils/__tests__/export-qr.test.ts
+++ b/apps/extension-wallet/src/utils/__tests__/export-qr.test.ts
@@ -20,20 +20,21 @@ function createMockCanvas() {
 
 describe('downloadQrPng', () => {
   beforeAll(() => {
-    // @ts-ignore
+    // @ts-expect-error jsdom canvas mock
     global.document.createElement = (tag: string) => {
       if (tag === 'canvas') return createMockCanvas();
       const el: any = { style: {}, setAttribute: () => {}, appendChild: () => {} };
       return el;
     };
-    // Mock dynamic import of 'qrcode'
-    // @ts-ignore
+    // @ts-expect-error jest mock for qrcode dynamic import
     jest.mock('qrcode', () => ({
       toCanvas: (_canvas: HTMLCanvasElement, _data: string, _opts: any, cb: any) => cb(null),
     }));
   });
 
   test('calls toBlob and resolves', async () => {
-    await expect(downloadQrPng('GTESTADDRESS', { filename: 'foo.png', scale: 2 })).resolves.toBeUndefined();
+    await expect(
+      downloadQrPng('GTESTADDRESS', { filename: 'foo.png', scale: 2 })
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/mobile-wallet/native/android/deep-link-intent-filter.xml
+++ b/apps/mobile-wallet/native/android/deep-link-intent-filter.xml
@@ -1,0 +1,10 @@
+<!--
+  Merge into the host app AndroidManifest.xml inside the main <activity> element
+  to register the ancore://wc deep link intent filter for WalletConnect pairing.
+-->
+<intent-filter>
+  <action android:name="android.intent.action.VIEW" />
+  <category android:name="android.intent.category.DEFAULT" />
+  <category android:name="android.intent.category.BROWSABLE" />
+  <data android:scheme="ancore" android:host="wc" />
+</intent-filter>

--- a/apps/mobile-wallet/native/ios/URLScheme-Info.plist.xml
+++ b/apps/mobile-wallet/native/ios/URLScheme-Info.plist.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Merge into the host app Info.plist to register the ancore:// URL scheme.
+
+  Add the CFBundleURLTypes entry below inside the top-level <dict> of Info.plist.
+-->
+<plist version="1.0">
+  <dict>
+    <key>CFBundleURLTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleURLName</key>
+        <string>org.ancore.wallet</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>ancore</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/apps/mobile-wallet/package.json
+++ b/apps/mobile-wallet/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@ancore/core-sdk": "workspace:*",
     "@ancore/crypto": "workspace:*",
-    "@ancore/types": "workspace:*",
+    "@ancore/stellar": "workspace:*",
     "@ancore/types": "workspace:*",
     "@reown/walletkit": "^1.5.5",
     "@walletconnect/types": "^2.23.9",

--- a/apps/mobile-wallet/src/index.ts
+++ b/apps/mobile-wallet/src/index.ts
@@ -27,4 +27,7 @@ export type { StellarRpcHandlers } from './providers/stellar-handlers';
 export { SessionApprovalSheet } from './components/SessionApprovalSheet';
 export type { SessionProposal } from './components/SessionApprovalSheet';
 export { WCPairingScreen } from './screens/walletconnect/WCPairingScreen';
-export type { WCPairingScreenProps, WCPairingStatus } from './screens/walletconnect/WCPairingScreen';
+export type {
+  WCPairingScreenProps,
+  WCPairingStatus,
+} from './screens/walletconnect/WCPairingScreen';

--- a/apps/mobile-wallet/src/index.ts
+++ b/apps/mobile-wallet/src/index.ts
@@ -26,9 +26,5 @@ export { createStellarRpcHandlers, handleStellarRpcRequest } from './providers/s
 export type { StellarRpcHandlers } from './providers/stellar-handlers';
 export { SessionApprovalSheet } from './components/SessionApprovalSheet';
 export type { SessionProposal } from './components/SessionApprovalSheet';
-export {
-  parseWalletConnectDeepLink,
-  isWalletConnectDeepLink,
-  extractPairingUri,
-} from './linking/walletconnect';
-export type { WalletConnectDeepLinkParams } from './linking/walletconnect';
+export { WCPairingScreen } from './screens/walletconnect/WCPairingScreen';
+export type { WCPairingScreenProps, WCPairingStatus } from './screens/walletconnect/WCPairingScreen';

--- a/apps/mobile-wallet/src/linking/__tests__/deepLinkConfig.test.ts
+++ b/apps/mobile-wallet/src/linking/__tests__/deepLinkConfig.test.ts
@@ -1,0 +1,46 @@
+import {
+  ANCORE_DEEP_LINK_PREFIX,
+  getWalletConnectNavigationState,
+  mobileWalletDeepLinking,
+} from '../deepLinkConfig';
+
+describe('mobileWalletDeepLinking', () => {
+  it('registers the ancore:// prefix and WCPairing screen path', () => {
+    expect(mobileWalletDeepLinking.prefixes).toEqual([ANCORE_DEEP_LINK_PREFIX]);
+    expect(mobileWalletDeepLinking.config.screens.WCPairing).toBe('wc');
+  });
+
+  it('resolves navigation state from a full deep link URL', () => {
+    const url = 'ancore://wc?uri=wc:abc123def456';
+
+    expect(getWalletConnectNavigationState(url)).toEqual({
+      routes: [{ name: 'WCPairing', params: { uri: 'wc:abc123def456' } }],
+    });
+  });
+
+  it('resolves navigation state for complex pairing URIs', () => {
+    const url = 'ancore://wc?uri=wc:abc123@2?relay-protocol=irn&symKey=xyz789';
+
+    expect(getWalletConnectNavigationState(url)).toEqual({
+      routes: [
+        {
+          name: 'WCPairing',
+          params: { uri: 'wc:abc123@2?relay-protocol=irn&symKey=xyz789' },
+        },
+      ],
+    });
+  });
+
+  it('uses getStateFromPath for path-only deep links', () => {
+    const path = 'wc?uri=wc:abc123def456';
+
+    expect(mobileWalletDeepLinking.getStateFromPath(path)).toEqual({
+      routes: [{ name: 'WCPairing', params: { uri: 'wc:abc123def456' } }],
+    });
+  });
+
+  it('returns undefined for unrelated paths', () => {
+    expect(getWalletConnectNavigationState('ancore://payment?amount=100')).toBeUndefined();
+    expect(mobileWalletDeepLinking.getStateFromPath('payment?amount=100')).toBeUndefined();
+  });
+});

--- a/apps/mobile-wallet/src/linking/__tests__/walletConnectLinking.test.ts
+++ b/apps/mobile-wallet/src/linking/__tests__/walletConnectLinking.test.ts
@@ -1,0 +1,76 @@
+import { subscribeToWalletConnectDeepLinks } from '../walletConnectLinking';
+
+const mockGetInitialURL = jest.fn<Promise<string | null>, []>();
+const mockAddEventListener = jest.fn();
+
+jest.mock(
+  'react-native',
+  () => ({
+    Linking: {
+      getInitialURL: (...args: []) => mockGetInitialURL(...args),
+      addEventListener: (...args: unknown[]) => mockAddEventListener(...args),
+    },
+  }),
+  { virtual: true }
+);
+
+describe('subscribeToWalletConnectDeepLinks', () => {
+  let urlHandler: ((event: { url: string }) => void) | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    urlHandler = undefined;
+
+    mockAddEventListener.mockImplementation((_type, handler) => {
+      urlHandler = handler as (event: { url: string }) => void;
+      return { remove: jest.fn() };
+    });
+  });
+
+  it('handles cold-start deep links from Linking.getInitialURL', async () => {
+    const mockUri = 'ancore://wc?uri=wc:abc123def456';
+    mockGetInitialURL.mockResolvedValue(mockUri);
+
+    const onDeepLink = jest.fn();
+    subscribeToWalletConnectDeepLinks(onDeepLink);
+
+    await Promise.resolve();
+
+    expect(mockGetInitialURL).toHaveBeenCalled();
+    expect(onDeepLink).toHaveBeenCalledWith({ uri: 'wc:abc123def456' });
+  });
+
+  it('handles warm-start deep links from Linking url events', () => {
+    const onDeepLink = jest.fn();
+    subscribeToWalletConnectDeepLinks(onDeepLink);
+
+    const mockUri = 'ancore://wc?uri=wc:abc123@2?relay-protocol=irn&symKey=xyz789';
+    urlHandler?.({ url: mockUri });
+
+    expect(mockAddEventListener).toHaveBeenCalledWith('url', expect.any(Function));
+    expect(onDeepLink).toHaveBeenCalledWith({
+      uri: 'wc:abc123@2?relay-protocol=irn&symKey=xyz789',
+    });
+  });
+
+  it('ignores non-WalletConnect URLs', async () => {
+    mockGetInitialURL.mockResolvedValue('ancore://payment?amount=100');
+
+    const onDeepLink = jest.fn();
+    subscribeToWalletConnectDeepLinks(onDeepLink);
+
+    await Promise.resolve();
+
+    expect(onDeepLink).not.toHaveBeenCalled();
+  });
+
+  it('removes the url event listener on unsubscribe', () => {
+    const remove = jest.fn();
+    mockAddEventListener.mockReturnValue({ remove });
+
+    const subscription = subscribeToWalletConnectDeepLinks(jest.fn());
+    subscription.remove();
+
+    expect(remove).toHaveBeenCalled();
+  });
+});

--- a/apps/mobile-wallet/src/linking/deepLinkConfig.ts
+++ b/apps/mobile-wallet/src/linking/deepLinkConfig.ts
@@ -1,0 +1,70 @@
+import { parseWalletConnectDeepLink } from './walletconnect';
+
+/** Custom URL scheme registered in the host app (see `native/` snippets). */
+export const ANCORE_URL_SCHEME = 'ancore';
+
+/** Deep link prefix for React Navigation `linking.prefixes`. */
+export const ANCORE_DEEP_LINK_PREFIX = `${ANCORE_URL_SCHEME}://`;
+
+/**
+ * React Navigation linking config for WalletConnect pairing deep links.
+ *
+ * Maps `ancore://wc?uri=<wc-pairing-uri>` to the `WCPairing` screen.
+ * Use with `NavigationContainer` in the host app:
+ *
+ * ```tsx
+ * <NavigationContainer linking={mobileWalletDeepLinking}>
+ * ```
+ */
+export const mobileWalletDeepLinking = {
+  prefixes: [ANCORE_DEEP_LINK_PREFIX],
+  config: {
+    screens: {
+      WCPairing: 'wc',
+    },
+  },
+  getStateFromPath(path: string) {
+    const candidates = [
+      path,
+      path.startsWith(ANCORE_DEEP_LINK_PREFIX) ? path : `${ANCORE_DEEP_LINK_PREFIX}${path}`,
+    ];
+
+    for (const candidate of candidates) {
+      const navigationState = getWalletConnectNavigationState(candidate);
+      if (navigationState) {
+        return navigationState;
+      }
+    }
+
+    return undefined;
+  },
+};
+
+export type WalletConnectNavigationState = {
+  routes: Array<{ name: 'WCPairing'; params: { uri: string } }>;
+};
+
+/**
+ * Resolve a WalletConnect deep link URL into a React Navigation state object.
+ * Handles complex pairing URIs that contain nested query parameters.
+ */
+export function getWalletConnectNavigationState(
+  url: string
+): WalletConnectNavigationState | undefined {
+  const parsed = parseWalletConnectDeepLink(normalizeDeepLinkUrl(url));
+  if (!parsed) {
+    return undefined;
+  }
+
+  return {
+    routes: [{ name: 'WCPairing', params: { uri: parsed.uri } }],
+  };
+}
+
+function normalizeDeepLinkUrl(input: string): string {
+  if (input.startsWith(ANCORE_DEEP_LINK_PREFIX)) {
+    return input;
+  }
+
+  return `${ANCORE_DEEP_LINK_PREFIX}${input}`;
+}

--- a/apps/mobile-wallet/src/linking/index.ts
+++ b/apps/mobile-wallet/src/linking/index.ts
@@ -1,2 +1,20 @@
 export { parsePaymentUri } from './paymentUri';
 export type { ParsedPaymentUri } from './paymentUri';
+export {
+  ANCORE_URL_SCHEME,
+  ANCORE_DEEP_LINK_PREFIX,
+  mobileWalletDeepLinking,
+  getWalletConnectNavigationState,
+} from './deepLinkConfig';
+export type { WalletConnectNavigationState } from './deepLinkConfig';
+export { subscribeToWalletConnectDeepLinks } from './walletConnectLinking';
+export type {
+  WalletConnectDeepLinkHandler,
+  WalletConnectDeepLinkSubscription,
+} from './walletConnectLinking';
+export {
+  parseWalletConnectDeepLink,
+  isWalletConnectDeepLink,
+  extractPairingUri,
+} from './walletconnect';
+export type { WalletConnectDeepLinkParams } from './walletconnect';

--- a/apps/mobile-wallet/src/linking/walletConnectLinking.ts
+++ b/apps/mobile-wallet/src/linking/walletConnectLinking.ts
@@ -1,0 +1,40 @@
+import { Linking } from 'react-native';
+
+import { parseWalletConnectDeepLink } from './walletconnect';
+
+export type WalletConnectDeepLinkHandler = (params: { uri: string }) => void;
+
+export type WalletConnectDeepLinkSubscription = {
+  remove: () => void;
+};
+
+/**
+ * Subscribe to WalletConnect deep links via React Native `Linking`.
+ *
+ * Invokes `onDeepLink` for cold-start (`getInitialURL`) and warm-start (`url` events)
+ * when the URL matches `ancore://wc?uri=<wc-pairing-uri>`.
+ */
+export function subscribeToWalletConnectDeepLinks(
+  onDeepLink: WalletConnectDeepLinkHandler
+): WalletConnectDeepLinkSubscription {
+  const handleUrl = (url: string | null) => {
+    if (!url) {
+      return;
+    }
+
+    const params = parseWalletConnectDeepLink(url);
+    if (params) {
+      onDeepLink(params);
+    }
+  };
+
+  void Linking.getInitialURL().then(handleUrl);
+
+  const subscription = Linking.addEventListener('url', (event) => {
+    handleUrl(event.url);
+  });
+
+  return {
+    remove: () => subscription.remove(),
+  };
+}

--- a/apps/mobile-wallet/src/screens/walletconnect/WCPairingScreen.tsx
+++ b/apps/mobile-wallet/src/screens/walletconnect/WCPairingScreen.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { useWalletConnect } from '../../providers/WalletKitProvider';
+
+export type WCPairingStatus = 'pairing' | 'awaiting_proposal' | 'proposal_received' | 'error';
+
+export interface WCPairingScreenProps {
+  /** WalletConnect pairing URI from the `ancore://wc?uri=` deep link. */
+  uri: string;
+  onSessionProposal?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export const WCPairingScreen = ({ uri, onSessionProposal, onError }: WCPairingScreenProps) => {
+  const { pair, walletKit, isInitialized } = useWalletConnect();
+  const [status, setStatus] = useState<WCPairingStatus>('pairing');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const hasStartedPairing = useRef(false);
+
+  useEffect(() => {
+    if (!isInitialized || !walletKit || hasStartedPairing.current) {
+      return;
+    }
+
+    hasStartedPairing.current = true;
+
+    const handleSessionProposal = () => {
+      setStatus('proposal_received');
+      onSessionProposal?.();
+    };
+
+    walletKit.on('session_proposal', handleSessionProposal);
+
+    setStatus('pairing');
+    void pair(uri)
+      .then(() => {
+        setStatus('awaiting_proposal');
+      })
+      .catch((error: unknown) => {
+        const pairingError = error instanceof Error ? error : new Error('Pairing failed');
+        setStatus('error');
+        setErrorMessage(pairingError.message);
+        onError?.(pairingError);
+      });
+
+    return () => {
+      walletKit.off('session_proposal', handleSessionProposal);
+    };
+  }, [isInitialized, walletKit, uri, pair, onSessionProposal, onError]);
+
+  if (status === 'error') {
+    return (
+      <section aria-label="WalletConnect pairing">
+        <p role="alert">{errorMessage ?? 'Pairing failed'}</p>
+      </section>
+    );
+  }
+
+  if (status === 'proposal_received') {
+    return (
+      <section aria-label="WalletConnect pairing">
+        <p>Session proposal received</p>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="WalletConnect pairing">
+      <p aria-live="polite" aria-busy="true">
+        {status === 'pairing' ? 'Connecting to dApp…' : 'Waiting for session proposal…'}
+      </p>
+    </section>
+  );
+};

--- a/apps/mobile-wallet/src/screens/walletconnect/__tests__/WCPairingScreen.test.tsx
+++ b/apps/mobile-wallet/src/screens/walletconnect/__tests__/WCPairingScreen.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SessionTypes } from '@walletconnect/types';
+
+import { WalletKitProvider } from '../../../providers/WalletKitProvider';
+import { WCPairingScreen } from '../WCPairingScreen';
+
+const createMockWalletKit = () => {
+  const listeners: Record<string, Array<() => void>> = {};
+
+  return {
+    init: jest.fn().mockResolvedValue(undefined),
+    pair: jest.fn().mockResolvedValue(undefined),
+    approveSession: jest.fn().mockResolvedValue(undefined),
+    rejectSession: jest.fn().mockResolvedValue(undefined),
+    disconnectSession: jest.fn().mockResolvedValue(undefined),
+    getActiveSessions: jest.fn(() => [] as SessionTypes.Struct[]),
+    on: jest.fn((event: string, callback: () => void) => {
+      listeners[event] = listeners[event] ?? [];
+      listeners[event].push(callback);
+    }),
+    off: jest.fn((event: string, callback: () => void) => {
+      listeners[event] = (listeners[event] ?? []).filter((cb) => cb !== callback);
+    }),
+    triggerEvent: (event: string) => {
+      listeners[event]?.forEach((callback) => callback());
+    },
+  };
+};
+
+describe('WCPairingScreen', () => {
+  it('calls walletKit.pair with the deep link uri on mount', async () => {
+    const mockWalletKit = createMockWalletKit();
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit}>
+        <WCPairingScreen uri="wc:abc123def456" />
+      </WalletKitProvider>
+    );
+
+    await waitFor(() => {
+      expect(mockWalletKit.pair).toHaveBeenCalledWith({ uri: 'wc:abc123def456' });
+    });
+  });
+
+  it('shows pairing progress while waiting for session_proposal', async () => {
+    const mockWalletKit = createMockWalletKit();
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit}>
+        <WCPairingScreen uri="wc:abc123def456" />
+      </WalletKitProvider>
+    );
+
+    expect(screen.getByText('Connecting to dApp…')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Waiting for session proposal…')).toBeInTheDocument();
+    });
+  });
+
+  it('shows proposal received after session_proposal event', async () => {
+    const mockWalletKit = createMockWalletKit();
+    const onSessionProposal = jest.fn();
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit}>
+        <WCPairingScreen uri="wc:abc123def456" onSessionProposal={onSessionProposal} />
+      </WalletKitProvider>
+    );
+
+    await waitFor(() => {
+      expect(mockWalletKit.pair).toHaveBeenCalled();
+    });
+
+    mockWalletKit.triggerEvent('session_proposal');
+
+    await waitFor(() => {
+      expect(screen.getByText('Session proposal received')).toBeInTheDocument();
+    });
+    expect(onSessionProposal).toHaveBeenCalled();
+  });
+
+  it('shows an error when pairing fails', async () => {
+    const mockWalletKit = createMockWalletKit();
+    mockWalletKit.pair.mockRejectedValue(new Error('Pairing rejected'));
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit}>
+        <WCPairingScreen uri="wc:abc123def456" />
+      </WalletKitProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Pairing rejected');
+    });
+  });
+});

--- a/apps/mobile-wallet/src/security/react-native.d.ts
+++ b/apps/mobile-wallet/src/security/react-native.d.ts
@@ -2,6 +2,7 @@
  * Minimal ambient declaration for the subset of `react-native` used by
  * {@link MobileSecureVault} and WalletConnect deep link handling.
  */
+ 
 declare module 'react-native' {
   export type AppStateEvent = 'change' | 'focus' | 'blur';
   export type AppStatus = 'active' | 'background' | 'inactive' | 'unknown' | 'extension';

--- a/apps/mobile-wallet/src/security/react-native.d.ts
+++ b/apps/mobile-wallet/src/security/react-native.d.ts
@@ -1,6 +1,6 @@
 /**
  * Minimal ambient declaration for the subset of `react-native` used by
- * {@link MobileSecureVault}.
+ * {@link MobileSecureVault} and WalletConnect deep link handling.
  */
 declare module 'react-native' {
   export type AppStateEvent = 'change' | 'focus' | 'blur';
@@ -15,4 +15,18 @@ declare module 'react-native' {
   }
 
   export const AppState: AppStateStatic;
+
+  export interface LinkingUrlEvent {
+    url: string;
+  }
+
+  export interface LinkingStatic {
+    getInitialURL(): Promise<string | null>;
+    addEventListener(
+      type: 'url',
+      handler: (event: LinkingUrlEvent) => void
+    ): { remove: () => void };
+  }
+
+  export const Linking: LinkingStatic;
 }

--- a/apps/mobile-wallet/src/security/react-native.d.ts
+++ b/apps/mobile-wallet/src/security/react-native.d.ts
@@ -2,7 +2,7 @@
  * Minimal ambient declaration for the subset of `react-native` used by
  * {@link MobileSecureVault} and WalletConnect deep link handling.
  */
- 
+
 declare module 'react-native' {
   export type AppStateEvent = 'change' | 'focus' | 'blur';
   export type AppStatus = 'active' | 'background' | 'inactive' | 'unknown' | 'extension';

--- a/packages/account-abstraction/src/__tests__/initialize.test.ts
+++ b/packages/account-abstraction/src/__tests__/initialize.test.ts
@@ -8,11 +8,7 @@
 
 import { initialize } from '../initialize';
 import { AccountContract, type AccountContractReadOptions } from '../account-contract';
-import {
-  AlreadyInitializedError,
-  ContractInvocationError,
-  UnauthorizedError,
-} from '../errors';
+import { AlreadyInitializedError, ContractInvocationError, UnauthorizedError } from '../errors';
 
 jest.mock('../account-contract', () => {
   const mockInitialize = jest.fn();
@@ -186,7 +182,11 @@ describe('initialize', () => {
       __mocks.mockInitialize.mockReturnValue(invocation);
       __mocks.mockBuildInvokeOperation.mockReturnValue(operation);
 
-      const result = await initialize(CONTRACT_ID, { owner: OWNER }, {} as AccountContractReadOptions);
+      const result = await initialize(
+        CONTRACT_ID,
+        { owner: OWNER },
+        {} as AccountContractReadOptions
+      );
 
       expect(result).toMatchSnapshot();
     });

--- a/packages/account-abstraction/src/__tests__/transaction-builder.test.ts
+++ b/packages/account-abstraction/src/__tests__/transaction-builder.test.ts
@@ -65,7 +65,12 @@ describe('TransactionBuilder', () => {
 
     // @ts-expect-no-error private buildOperation for SCVal assertion
     const operation = builder['buildOperation'](builder['ops'][0]);
-    const invokeArgs = operation.body().invokeHostFunctionOp().hostFunction().invokeContract().args();
+    const invokeArgs = operation
+      .body()
+      .invokeHostFunctionOp()
+      .hostFunction()
+      .invokeContract()
+      .args();
     expect(invokeArgs[0].switch().name).toBe('scvBytes');
     expect(invokeArgs[0]).toEqual(publicKeyToBytes32ScVal(stellarPublicKey));
   });
@@ -75,9 +80,9 @@ describe('TransactionBuilder', () => {
     expect(() => builder.refreshSessionKeyTtl({ publicKey: '', ttlSeconds: 3600 })).toThrow(
       'refreshSessionKeyTtl requires a non-empty publicKey string'
     );
-    expect(() => builder.refreshSessionKeyTtl({ publicKey: validSessionKey, ttlSeconds: 0 })).toThrow(
-      'refreshSessionKeyTtl requires ttlSeconds to be greater than zero'
-    );
+    expect(() =>
+      builder.refreshSessionKeyTtl({ publicKey: validSessionKey, ttlSeconds: 0 })
+    ).toThrow('refreshSessionKeyTtl requires ttlSeconds to be greater than zero');
   });
 
   it('should execute contract operations', () => {

--- a/packages/account-abstraction/src/__tests__/xdr-roundtrip.test.ts
+++ b/packages/account-abstraction/src/__tests__/xdr-roundtrip.test.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { publicKeyToBytes32ScVal, bytes32ScValToPublicKey } from '../xdr-utils';
 import { StrKey } from '@stellar/stellar-sdk';
-import { StrKeyValidationError } from '@ancore/core-sdk';
+import { StrKeyValidationError } from '../strkey-validation';
 
 describe('xdr-utils session key round-trip', () => {
   test('round-trips a G... public key string', () => {

--- a/packages/account-abstraction/src/__tests__/xdr-utils-invalid-keys.test.ts
+++ b/packages/account-abstraction/src/__tests__/xdr-utils-invalid-keys.test.ts
@@ -1,5 +1,5 @@
 import { publicKeyToBytes32ScVal } from '../xdr-utils';
-import { StrKeyValidationError } from '@ancore/core-sdk';
+import { StrKeyValidationError } from '../strkey-validation';
 
 describe('xdr-utils publicKey validation', () => {
   test('publicKeyToBytes32ScVal throws StrKeyValidationError for invalid public key string', () => {

--- a/packages/account-abstraction/src/strkey-validation.ts
+++ b/packages/account-abstraction/src/strkey-validation.ts
@@ -1,0 +1,29 @@
+import { StrKey } from '@stellar/stellar-sdk';
+
+export type StrKeyErrorCode = 'INVALID_G_KEY' | 'INVALID_C_KEY';
+
+export class StrKeyValidationError extends Error {
+  readonly code: StrKeyErrorCode;
+
+  constructor(
+    code: StrKeyErrorCode,
+    message: string,
+    readonly input?: string
+  ) {
+    super(message);
+    this.name = 'StrKeyValidationError';
+    this.code = code;
+  }
+}
+
+export function assertValidEd25519PublicKey(publicKey: string): void {
+  if (typeof publicKey !== 'string' || !StrKey.isValidEd25519PublicKey(publicKey)) {
+    const snippet =
+      typeof publicKey === 'string' ? `${publicKey.slice(0, 8)}...` : String(publicKey);
+    throw new StrKeyValidationError(
+      'INVALID_G_KEY',
+      `Invalid Ed25519 public key: expected G... format, got ${snippet}`,
+      typeof publicKey === 'string' ? publicKey : undefined
+    );
+  }
+}

--- a/packages/account-abstraction/src/xdr-utils.ts
+++ b/packages/account-abstraction/src/xdr-utils.ts
@@ -5,7 +5,7 @@
 
 import type { SessionKey } from '@ancore/types';
 import { Address, nativeToScVal, scValToNative, StrKey, xdr } from '@stellar/stellar-sdk';
-import { assertValidEd25519PublicKey } from '@ancore/core-sdk';
+import { assertValidEd25519PublicKey } from './strkey-validation';
 
 const BYTES_N_32_LENGTH = 32;
 

--- a/packages/core-sdk/README.md
+++ b/packages/core-sdk/README.md
@@ -181,13 +181,13 @@ const transaction = await builder.build();
 
 ### Error Types
 
-| Error                        | Code                 | When                                          |
-| ---------------------------- | -------------------- | --------------------------------------------- |
-| `BuilderValidationError`     | `BUILDER_VALIDATION` | Invalid params or no operations               |
-| `SimulationFailedError`      | `SIMULATION_FAILED`  | Soroban simulation returned an error          |
-| `SimulationExpiredError`     | `SIMULATION_EXPIRED` | Simulation result requires ledger restoration |
-| `TransactionSubmissionError` | `SUBMISSION_FAILED`  | Network submission failed                     |
-| `StrKeyValidationError`      | `INVALID_G_KEY` / `INVALID_C_KEY` | Invalid Stellar StrKey (G... public key / C... contract id)
+| Error                        | Code                              | When                                                        |
+| ---------------------------- | --------------------------------- | ----------------------------------------------------------- |
+| `BuilderValidationError`     | `BUILDER_VALIDATION`              | Invalid params or no operations                             |
+| `SimulationFailedError`      | `SIMULATION_FAILED`               | Soroban simulation returned an error                        |
+| `SimulationExpiredError`     | `SIMULATION_EXPIRED`              | Simulation result requires ledger restoration               |
+| `TransactionSubmissionError` | `SUBMISSION_FAILED`               | Network submission failed                                   |
+| `StrKeyValidationError`      | `INVALID_G_KEY` / `INVALID_C_KEY` | Invalid Stellar StrKey (G... public key / C... contract id) |
 
 ### Contract Parameter Helpers
 

--- a/packages/core-sdk/src/__tests__/refresh-session-key-ttl.test.ts
+++ b/packages/core-sdk/src/__tests__/refresh-session-key-ttl.test.ts
@@ -4,7 +4,7 @@ import {
   publicKeyToBytes32ScVal,
   u64ToScVal,
 } from '@ancore/account-abstraction';
-import { Account, Keypair, Networks, rpc, xdr } from '@stellar/stellar-sdk';
+import { Keypair, Networks, rpc, xdr } from '@stellar/stellar-sdk';
 
 import {
   refreshSessionKeyTtl,
@@ -62,7 +62,9 @@ const SESSION_PUBLIC_KEY = 'GCM5WPR4DDR24FSAX5LIEM4J7AI3KOWJYANSXEPKYXCSZOTAYXE7
 const NOW_MS = Date.now();
 const NOW_SECONDS = Math.floor(NOW_MS / 1000);
 
-function makeActiveParams(overrides: Partial<RefreshSessionKeyTtlParams> = {}): RefreshSessionKeyTtlParams {
+function makeActiveParams(
+  overrides: Partial<RefreshSessionKeyTtlParams> = {}
+): RefreshSessionKeyTtlParams {
   return {
     publicKey: SESSION_PUBLIC_KEY,
     expiresAt: NOW_SECONDS + 3600,
@@ -70,13 +72,13 @@ function makeActiveParams(overrides: Partial<RefreshSessionKeyTtlParams> = {}): 
   };
 }
 
-function makeSessionKeyTtlRefreshedEvent(publicKey: string, expiresAt: number): {
+function makeSessionKeyTtlRefreshedEvent(
+  publicKey: string,
+  expiresAt: number
+): {
   event: xdr.ContractEvent;
 } {
-  const dataScVal = xdr.ScVal.scvVec([
-    publicKeyToBytes32ScVal(publicKey),
-    u64ToScVal(expiresAt),
-  ]);
+  const dataScVal = xdr.ScVal.scvVec([publicKeyToBytes32ScVal(publicKey), u64ToScVal(expiresAt)]);
 
   const contractEvent = {
     body: () => ({
@@ -514,9 +516,7 @@ describe('parseSessionKeyTtlRefreshedEvent', () => {
   it('reads contract events from contractEvent envelopes', () => {
     const contractEvent = makeSessionKeyTtlRefreshedEvent(SESSION_PUBLIC_KEY, NOW_SECONDS + 3600);
 
-    expect(
-      parseSessionKeyTtlRefreshedEvent([{ contractEvent: contractEvent.event }])
-    ).toEqual({
+    expect(parseSessionKeyTtlRefreshedEvent([{ contractEvent: contractEvent.event }])).toEqual({
       type: 'session_key_ttl_refreshed',
       publicKey: SESSION_PUBLIC_KEY,
       expiresAt: NOW_SECONDS + 3600,

--- a/packages/core-sdk/src/__tests__/strkey-validation.test.ts
+++ b/packages/core-sdk/src/__tests__/strkey-validation.test.ts
@@ -1,4 +1,8 @@
-import { assertValidEd25519PublicKey, assertValidContractId, StrKeyValidationError } from '../errors';
+import {
+  assertValidEd25519PublicKey,
+  assertValidContractId,
+  StrKeyValidationError,
+} from '../errors';
 
 describe('StrKey validation helpers', () => {
   test('assertValidEd25519PublicKey throws StrKeyValidationError for invalid G key', () => {

--- a/packages/core-sdk/src/errors.ts
+++ b/packages/core-sdk/src/errors.ts
@@ -191,7 +191,11 @@ import { StrKey } from '@stellar/stellar-sdk';
 export type StrKeyErrorCode = 'INVALID_G_KEY' | 'INVALID_C_KEY';
 
 export class StrKeyValidationError extends AncoreSdkError {
-  constructor(public readonly code: StrKeyErrorCode, message: string, public readonly input?: string) {
+  constructor(
+    public readonly code: StrKeyErrorCode,
+    message: string,
+    public readonly input?: string
+  ) {
     super(code, message);
     this.name = 'StrKeyValidationError';
     Object.setPrototypeOf(this, new.target.prototype);
@@ -204,7 +208,8 @@ export class StrKeyValidationError extends AncoreSdkError {
  */
 export function assertValidEd25519PublicKey(publicKey: string): void {
   if (typeof publicKey !== 'string' || !StrKey.isValidEd25519PublicKey(publicKey)) {
-    const snippet = typeof publicKey === 'string' ? publicKey.slice(0, 8) + '...' : String(publicKey);
+    const snippet =
+      typeof publicKey === 'string' ? publicKey.slice(0, 8) + '...' : String(publicKey);
     throw new StrKeyValidationError(
       'INVALID_G_KEY',
       `Invalid Ed25519 public key: expected G... format, got ${snippet}`,
@@ -219,7 +224,8 @@ export function assertValidEd25519PublicKey(publicKey: string): void {
  */
 export function assertValidContractId(contractId: string): void {
   if (typeof contractId !== 'string' || !StrKey.isValidContract(contractId)) {
-    const snippet = typeof contractId === 'string' ? contractId.slice(0, 8) + '...' : String(contractId);
+    const snippet =
+      typeof contractId === 'string' ? contractId.slice(0, 8) + '...' : String(contractId);
     throw new StrKeyValidationError(
       'INVALID_C_KEY',
       `Invalid contract id: expected C... format, got ${snippet}`,

--- a/packages/core-sdk/src/execute-with-session-key.ts
+++ b/packages/core-sdk/src/execute-with-session-key.ts
@@ -6,7 +6,7 @@ import {
   UnauthorizedError,
   type InvocationArgs,
 } from '@ancore/account-abstraction';
-import { Address, StrKey, xdr } from '@stellar/stellar-sdk';
+import { Address, xdr } from '@stellar/stellar-sdk';
 
 import {
   AncoreSdkError,
@@ -164,7 +164,9 @@ function validateExecuteWithSessionKeyParams<
   }
 
   if (!signer) {
-    throw new SessionKeyExecutionValidationError('signer.publicKey must be a valid Stellar Ed25519 public key.');
+    throw new SessionKeyExecutionValidationError(
+      'signer.publicKey must be a valid Stellar Ed25519 public key.'
+    );
   }
 
   try {

--- a/packages/core-sdk/src/payment-request.ts
+++ b/packages/core-sdk/src/payment-request.ts
@@ -1,5 +1,9 @@
-import { StrKey } from '@stellar/stellar-sdk';
-import { PaymentRequestValidationError, InvalidAmountError, assertValidEd25519PublicKey, StrKeyValidationError } from './errors';
+import {
+  PaymentRequestValidationError,
+  InvalidAmountError,
+  assertValidEd25519PublicKey,
+  StrKeyValidationError,
+} from './errors';
 import { normalizeAmount } from './amount';
 
 /**
@@ -78,7 +82,9 @@ export function parsePaymentRequest(payload: unknown): PaymentRequest {
   // 1. Destination validation
   const destination = raw.destination;
   if (typeof destination !== 'string') {
-    throw new PaymentRequestValidationError('destination is required and must be a valid Stellar public key.');
+    throw new PaymentRequestValidationError(
+      'destination is required and must be a valid Stellar public key.'
+    );
   }
   try {
     assertValidEd25519PublicKey(destination);

--- a/packages/core-sdk/src/refresh-session-key-ttl.ts
+++ b/packages/core-sdk/src/refresh-session-key-ttl.ts
@@ -38,7 +38,9 @@ export interface RefreshSessionKeyTtlOptions extends AccountContractReadOptions 
 
 export interface SessionKeyTtlRefresher {
   refreshSessionKeyTtl(publicKey: string): InvocationArgs;
-  buildInvokeOperation(invocation: InvocationArgs): ReturnType<AccountContract['buildInvokeOperation']>;
+  buildInvokeOperation(
+    invocation: InvocationArgs
+  ): ReturnType<AccountContract['buildInvokeOperation']>;
 }
 
 export interface SessionKeyTtlRefreshedEvent {
@@ -87,6 +89,7 @@ const SESSION_KEY_TTL_REFRESHED_TOPIC = 'session_key_ttl_refreshed';
  * });
  * ```
  */
+/* eslint-disable no-redeclare -- TypeScript function overload signatures */
 export function refreshSessionKeyTtl(
   accountContract: SessionKeyTtlRefresher,
   params: RefreshSessionKeyTtlParams
@@ -101,6 +104,7 @@ export function refreshSessionKeyTtl(
   params: RefreshSessionKeyTtlParams,
   options?: RefreshSessionKeyTtlOptions
 ): InvocationArgs | Promise<RefreshSessionKeyTtlResult> {
+  /* eslint-enable no-redeclare */
   validateRefreshSessionKeyTtlParams(params, options?.nowMs);
 
   if (options) {
@@ -149,10 +153,14 @@ function validateRefreshSessionKeyTtlParams(
   }
 
   if (typeof params.expiresAt !== 'number' || !Number.isFinite(params.expiresAt)) {
-    throw new BuilderValidationError('refreshSessionKeyTtl requires expiresAt to be a finite number.');
+    throw new BuilderValidationError(
+      'refreshSessionKeyTtl requires expiresAt to be a finite number.'
+    );
   }
 
-  if (!isSessionKeyActive({ expiresAt: params.expiresAt, publicKey: params.publicKey }, { nowMs })) {
+  if (
+    !isSessionKeyActive({ expiresAt: params.expiresAt, publicKey: params.publicKey }, { nowMs })
+  ) {
     const reason = getSessionKeyInactiveReason(
       { expiresAt: params.expiresAt, publicKey: params.publicKey },
       { nowMs }

--- a/packages/core-sdk/src/storage/__tests__/storage-conformance.test.ts
+++ b/packages/core-sdk/src/storage/__tests__/storage-conformance.test.ts
@@ -85,10 +85,7 @@ const adapters: [string, AdapterFactory][] = [
       return new ChromeStorageAdapter(area as any);
     },
   ],
-  [
-    'BrowserStorageAdapter',
-    () => new BrowserStorageAdapter(makeBrowserArea() as any),
-  ],
+  ['BrowserStorageAdapter', () => new BrowserStorageAdapter(makeBrowserArea() as any)],
 ];
 
 // ─── Conformance suite ────────────────────────────────────────────────────────

--- a/packages/ui-kit/src/components/ExpiryCountdown/ExpiryCountdown.test.tsx
+++ b/packages/ui-kit/src/components/ExpiryCountdown/ExpiryCountdown.test.tsx
@@ -123,7 +123,9 @@ describe('ExpiryCountdown', () => {
   });
 
   it('shows loading state on refresh button', () => {
-    render(<ExpiryCountdown expiresAt={Date.now() + 86_400_000} onRefresh={vi.fn()} refreshLoading />);
+    render(
+      <ExpiryCountdown expiresAt={Date.now() + 86_400_000} onRefresh={vi.fn()} refreshLoading />
+    );
 
     expect(screen.getByTestId('expiry-refresh-button')).toHaveAttribute('aria-busy', 'true');
     expect(screen.getByTestId('expiry-refresh-button')).toBeDisabled();

--- a/packages/ui-kit/src/components/ExpiryCountdown/format-expiry.ts
+++ b/packages/ui-kit/src/components/ExpiryCountdown/format-expiry.ts
@@ -4,11 +4,7 @@ export const COUNTDOWN_UPDATE_INTERVAL_MS = 60 * 1000;
 
 export type ExpiryStatus = 'active' | 'expiring-soon' | 'expired' | 'revoked';
 
-export type ExpiryThreshold =
-  | 'less-than-one-day'
-  | 'expiring-soon'
-  | 'expired'
-  | 'revoked';
+export type ExpiryThreshold = 'less-than-one-day' | 'expiring-soon' | 'expired' | 'revoked';
 
 export function isRevokedExpiry(expiresAt: number): boolean {
   return expiresAt === 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,9 @@ importers:
 
   packages/account-abstraction:
     dependencies:
+      '@ancore/core-sdk':
+        specifier: workspace:*
+        version: link:../core-sdk
       '@ancore/crypto':
         specifier: workspace:*
         version: link:../crypto

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
       '@ancore/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
+      '@ancore/stellar':
+        specifier: workspace:*
+        version: link:../../packages/stellar
       '@ancore/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -353,9 +356,6 @@ importers:
 
   packages/account-abstraction:
     dependencies:
-      '@ancore/core-sdk':
-        specifier: workspace:*
-        version: link:../core-sdk
       '@ancore/crypto':
         specifier: workspace:*
         version: link:../crypto

--- a/services/relayer/fixtures/README.md
+++ b/services/relayer/fixtures/README.md
@@ -9,6 +9,7 @@ These fixtures ensure that the canonical payload builder produces consistent out
 ## Structure
 
 Each fixture file contains:
+
 - `description`: Human-readable description of the test case
 - `input`: The relay request fields (sessionKey, operation, nonce)
 - `expectedPayload`: The hex-encoded canonical payload
@@ -17,13 +18,13 @@ Each fixture file contains:
 
 ## Fixtures
 
-| File | Description |
-|------|-------------|
-| `canonical-payload-execute.json` | Standard relay_execute operation |
-| `canonical-payload-add-session-key.json` | Add session key operation |
-| `canonical-payload-revoke-session-key.json` | Revoke session key operation |
-| `canonical-payload-high-nonce.json` | Maximum safe integer nonce value |
-| `canonical-payload-zero-nonce.json` | Zero nonce edge case |
+| File                                        | Description                      |
+| ------------------------------------------- | -------------------------------- |
+| `canonical-payload-execute.json`            | Standard relay_execute operation |
+| `canonical-payload-add-session-key.json`    | Add session key operation        |
+| `canonical-payload-revoke-session-key.json` | Revoke session key operation     |
+| `canonical-payload-high-nonce.json`         | Maximum safe integer nonce value |
+| `canonical-payload-zero-nonce.json`         | Zero nonce edge case             |
 
 ## Versioning
 
@@ -76,6 +77,7 @@ it('matches golden fixture', () => {
 ## CI Integration
 
 The test suite runs these fixtures in CI. Any failure indicates:
+
 - Unintended change to payload construction
 - Breaking change requiring version bump
 - Need to update client SDK implementations

--- a/services/relayer/src/middleware/requestId.ts
+++ b/services/relayer/src/middleware/requestId.ts
@@ -29,8 +29,11 @@ export function createRequestIdMiddleware(): RequestHandler {
     if (!id) {
       // Prefer crypto.randomUUID when available
       try {
-        // @ts-ignore
-        id = typeof crypto !== 'undefined' && typeof (crypto as any).randomUUID === 'function' ? (crypto as any).randomUUID() : undefined;
+        // @ts-expect-error crypto may be unavailable in some runtimes
+        id =
+          typeof crypto !== 'undefined' && typeof (crypto as any).randomUUID === 'function'
+            ? (crypto as any).randomUUID()
+            : undefined;
       } catch {
         id = undefined;
       }

--- a/services/relayer/src/middleware/requestLogger.ts
+++ b/services/relayer/src/middleware/requestLogger.ts
@@ -38,7 +38,10 @@ export type LoggedRequest = Request & {
 export function createRequestLoggerMiddleware(): RequestHandler {
   return (req: Request, res: Response, next: NextFunction): void => {
     const loggedReq = req as LoggedRequest;
-    const requestId = (req as any).requestId ?? (req.headers['x-request-id'] as string | undefined) ?? generateRequestId();
+    const requestId =
+      (req as any).requestId ??
+      (req.headers['x-request-id'] as string | undefined) ??
+      generateRequestId();
 
     loggedReq.startTime = Date.now();
 

--- a/services/relayer/src/services/relayService.ts
+++ b/services/relayer/src/services/relayService.ts
@@ -220,17 +220,14 @@ export class RelayService implements RelayServiceContract {
     }
 
     const timeoutMs = parseInt(process.env.SIGNATURE_SERVICE_HEALTH_TIMEOUT_MS || '5000', 10);
-    
+
     try {
       const start = Date.now();
       const timeoutPromise = new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error('Health check timeout')), timeoutMs)
       );
 
-      const result = await Promise.race([
-        this.signatureService.isHealthy(),
-        timeoutPromise,
-      ]);
+      const result = await Promise.race([this.signatureService.isHealthy(), timeoutPromise]);
 
       const latencyMs = Date.now() - start;
 
@@ -245,7 +242,10 @@ export class RelayService implements RelayServiceContract {
       return { status: 'ok', latencyMs: result.latencyMs ?? latencyMs };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      return { status: 'degraded', message: `Signature service health check failed: ${errorMessage}` };
+      return {
+        status: 'degraded',
+        message: `Signature service health check failed: ${errorMessage}`,
+      };
     }
   }
 

--- a/services/relayer/tests/unit/health.test.ts
+++ b/services/relayer/tests/unit/health.test.ts
@@ -25,7 +25,9 @@ describe('RelayService health check with signature service', () => {
 
   describe('signature service status', () => {
     it('reports ok when signature service is healthy', async () => {
-      mockSignatureService.isHealthy = jest.fn().mockResolvedValue({ healthy: true, latencyMs: 10 });
+      mockSignatureService.isHealthy = jest
+        .fn()
+        .mockResolvedValue({ healthy: true, latencyMs: 10 });
 
       const service = new RelayService(mockSignatureService, queue, store, mockSubmitter);
       const status = await service.checkSignatureServiceHealth();
@@ -35,7 +37,9 @@ describe('RelayService health check with signature service', () => {
     });
 
     it('reports degraded when signature service is down', async () => {
-      mockSignatureService.isHealthy = jest.fn().mockResolvedValue({ healthy: false, latencyMs: 100 });
+      mockSignatureService.isHealthy = jest
+        .fn()
+        .mockResolvedValue({ healthy: false, latencyMs: 100 });
 
       const service = new RelayService(mockSignatureService, queue, store, mockSubmitter);
       const status = await service.checkSignatureServiceHealth();
@@ -46,9 +50,11 @@ describe('RelayService health check with signature service', () => {
     });
 
     it('reports degraded when signature service health check times out', async () => {
-      mockSignatureService.isHealthy = jest.fn().mockImplementation(
-        () => new Promise((resolve) => setTimeout(() => resolve({ healthy: true }), 10000))
-      );
+      mockSignatureService.isHealthy = jest
+        .fn()
+        .mockImplementation(
+          () => new Promise((resolve) => setTimeout(() => resolve({ healthy: true }), 10000))
+        );
 
       process.env.SIGNATURE_SERVICE_HEALTH_TIMEOUT_MS = '100';
 
@@ -113,7 +119,9 @@ describe('RelayService health check with signature service', () => {
     it('uses configurable timeout from environment', async () => {
       process.env.SIGNATURE_SERVICE_HEALTH_TIMEOUT_MS = '2000';
 
-      mockSignatureService.isHealthy = jest.fn().mockResolvedValue({ healthy: true, latencyMs: 50 });
+      mockSignatureService.isHealthy = jest
+        .fn()
+        .mockResolvedValue({ healthy: true, latencyMs: 50 });
 
       const service = new RelayService(mockSignatureService, queue, store, mockSubmitter);
       const status = await service.checkSignatureServiceHealth();


### PR DESCRIPTION
## Summary

- Handle \ncore://wc?uri=\ WalletConnect pairing deep links so scanning a dApp QR opens the mobile wallet and starts pairing
- Add \WCPairingScreen\ (calls \walletKit.pair\, shows progress until \session_proposal\), React Navigation \mobileWalletDeepLinking\ config, and \subscribeToWalletConnectDeepLinks\ for cold/warm starts
- Include native URL scheme snippets for the future host app (\
ative/ios\, \
ative/android\)

## Test plan

- [x] \pnpm --filter @ancore/mobile-wallet test\ — deep link parser, Linking subscription, navigation config, and WCPairingScreen tests (27 passing)
- [ ] Wire \mobileWalletDeepLinking\ into host app \NavigationContainer\ and verify \ncore://wc?uri=wc:...\ routes to \WCPairing\
- [ ] Merge native URL scheme snippets into host app \Info.plist\ / \AndroidManifest.xml\ when #780 lands

Closes #843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WalletConnect deep-link support for the mobile wallet, including app launch handling and navigation into the pairing flow.
  * Introduced a pairing screen that shows connection progress, waits for session proposals, and surfaces errors clearly.

* **Bug Fixes**
  * Improved QR download fallback handling on the receive screen.
  * Added clearer validation feedback for invalid key inputs.

* **Documentation**
  * Updated developer-facing docs and reference tables for clearer formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->