### PR TITLE
feat(extension): vault persistence, session queue, C-address storage, and dApp handlers

### DIFF
--- a/apps/extension-wallet/src/background/handlers/external/__tests__/handlers.test.ts
+++ b/apps/extension-wallet/src/background/handlers/external/__tests__/handlers.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for handleGetPublicKey and handleGetNetwork (#809)
+ */
+
+import { handleGetPublicKey, handleGetNetwork } from '../handlers';
+import type { ExternalHandlerContext } from '@ancore/types';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const CONTRACT_ADDRESS = 'CABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890';
+
+const localStore: Record<string, unknown> = {};
+
+const mockLocalStorage = {
+  get: vi.fn((key: string, cb: (result: Record<string, unknown>) => void) => {
+    cb({ [key]: localStore[key] ?? null });
+  }),
+  set: vi.fn((data: Record<string, unknown>, cb?: () => void) => {
+    Object.assign(localStore, data);
+    cb?.();
+  }),
+};
+
+vi.mock('@/stores/settings', () => ({
+  getSettingsState: () => ({ network: 'testnet' }),
+}));
+
+vi.mock('../allowlist', () => ({
+  isAllowed: vi.fn().mockResolvedValue(true),
+  addToAllowlist: vi.fn(),
+}));
+
+// Re-set globalThis.chrome in beforeEach because vitest.setup.ts deletes it
+// before every test to prevent leakage between files.
+beforeEach(() => {
+  (globalThis as any).chrome = { storage: { local: mockLocalStorage } };
+  Object.keys(localStore).forEach((k) => delete localStore[k]);
+  mockLocalStorage.get.mockClear();
+});
+
+function makeCtx(origin = 'https://dapp.example'): ExternalHandlerContext {
+  return {
+    origin,
+    params: {},
+    requestId: 'test-req-id',
+    sender: {},
+  };
+}
+
+// ── handleGetPublicKey ────────────────────────────────────────────────────────
+
+describe('handleGetPublicKey', () => {
+  it('returns the stored contract address as publicKey', async () => {
+    localStore['ancore_contract_address'] = CONTRACT_ADDRESS;
+
+    const result = await handleGetPublicKey(makeCtx());
+    expect(result.publicKey).toBe(CONTRACT_ADDRESS);
+  });
+
+  it('throws when wallet is not onboarded (no stored address)', async () => {
+    await expect(handleGetPublicKey(makeCtx())).rejects.toThrow('Wallet not set up');
+  });
+
+  it('throws when origin is not in the allowlist', async () => {
+    const { isAllowed } = await import('../allowlist');
+    vi.mocked(isAllowed).mockResolvedValueOnce(false);
+    localStore['ancore_contract_address'] = CONTRACT_ADDRESS;
+
+    await expect(handleGetPublicKey(makeCtx('https://untrusted.example'))).rejects.toThrow(
+      'Origin not allowed'
+    );
+  });
+});
+
+// ── handleGetNetwork ──────────────────────────────────────────────────────────
+
+describe('handleGetNetwork', () => {
+  it('returns network and passphrase for testnet', async () => {
+    const result = await handleGetNetwork(makeCtx());
+    expect(result.network).toBe('testnet');
+    expect(result.networkPassphrase).toBe('Test SDF Network ; September 2015');
+  });
+
+  it('throws when origin is not in the allowlist', async () => {
+    const { isAllowed } = await import('../allowlist');
+    vi.mocked(isAllowed).mockResolvedValueOnce(false);
+
+    await expect(handleGetNetwork(makeCtx('https://untrusted.example'))).rejects.toThrow(
+      'Origin not allowed'
+    );
+  });
+});

--- a/apps/extension-wallet/src/background/handlers/external/__tests__/response-queue.test.ts
+++ b/apps/extension-wallet/src/background/handlers/external/__tests__/response-queue.test.ts
@@ -12,7 +12,33 @@ import {
   resolveRequest,
   rejectRequest,
   clearResponseCallbacks,
+  getSessionEntry,
 } from '../response-queue';
+
+// ── chrome.storage.session mock ───────────────────────────────────────────────
+
+const sessionStore: Record<string, unknown> = {};
+const mockSession = {
+  set: vi.fn((data: Record<string, unknown>, _cb?: () => void) => {
+    Object.assign(sessionStore, data);
+  }),
+  get: vi.fn((key: string, cb: (result: Record<string, unknown>) => void) => {
+    cb({ [key]: sessionStore[key] });
+  }),
+  remove: vi.fn((key: string) => {
+    delete sessionStore[key];
+  }),
+};
+
+// Re-set globalThis.chrome in beforeEach because vitest.setup.ts deletes it
+// before every test to prevent leakage between files.
+beforeEach(() => {
+  (globalThis as any).chrome = { storage: { session: mockSession } };
+  Object.keys(sessionStore).forEach((k) => delete sessionStore[k]);
+  mockSession.set.mockClear();
+  mockSession.get.mockClear();
+  mockSession.remove.mockClear();
+});
 
 describe('response queue', () => {
   beforeEach(() => {
@@ -234,6 +260,57 @@ describe('response queue', () => {
         resolveRequest('123', { result: 'test' });
         resolveRequest('456', { result: 'test' });
       });
+    });
+  });
+
+  // ── Session storage (chrome.storage.session) ────────────────────────────────
+
+  describe('session storage', () => {
+    it('enqueueApproval writes pending status to session storage', () => {
+      enqueueApproval('req-1', 'https://dapp.example', 'signTransaction', {});
+
+      expect(mockSession.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'req-1': expect.objectContaining({ requestId: 'req-1', status: 'pending' }),
+        })
+      );
+    });
+
+    it('resolveRequest updates session entry to resolved', async () => {
+      registerResponseCallbacks(
+        'req-2',
+        () => {},
+        () => {}
+      );
+      resolveRequest('req-2', { signedXdr: 'abc' });
+
+      const entry = await getSessionEntry('req-2');
+      expect(entry).toEqual(
+        expect.objectContaining({
+          requestId: 'req-2',
+          status: 'resolved',
+          result: { signedXdr: 'abc' },
+        })
+      );
+    });
+
+    it('rejectRequest updates session entry to rejected with error message', async () => {
+      registerResponseCallbacks(
+        'req-3',
+        () => {},
+        () => {}
+      );
+      rejectRequest('req-3', new Error('user rejected'));
+
+      const entry = await getSessionEntry('req-3');
+      expect(entry).toEqual(
+        expect.objectContaining({ requestId: 'req-3', status: 'rejected', error: 'user rejected' })
+      );
+    });
+
+    it('getSessionEntry returns null for unknown requestId', async () => {
+      const entry = await getSessionEntry('no-such-id');
+      expect(entry).toBeNull();
     });
   });
 });

--- a/apps/extension-wallet/src/background/handlers/external/handlers.ts
+++ b/apps/extension-wallet/src/background/handlers/external/handlers.ts
@@ -9,12 +9,36 @@ import type {
   RequestAccessResult,
   GetAddressResult,
   GetSmartAccountResult,
+  GetPublicKeyResult,
+  GetNetworkResult,
   SignTransactionResult,
 } from '@ancore/types';
 import { ExternalApiMethodName as MethodName } from '@ancore/types';
 import { isAllowed, addToAllowlist } from './allowlist';
 import { enqueueApproval } from './response-queue';
 import { openApprovalWindow } from '../../approval-window';
+import { getSettingsState } from '@/stores/settings';
+import { CONTRACT_ADDRESS_KEY } from '@/hooks/useOnboarding';
+
+/** Stellar network passphrases keyed by NetworkMode. */
+const NETWORK_PASSPHRASES: Record<string, string> = {
+  mainnet: 'Public Global Stellar Network ; September 2015',
+  testnet: 'Test SDF Network ; September 2015',
+  futurenet: 'Test SDF Future Network ; October 2022',
+};
+
+async function readFromChromeLocal(key: string): Promise<string | null> {
+  const chromeRef = (globalThis as { chrome?: any }).chrome;
+  if (chromeRef?.storage?.local) {
+    return new Promise((resolve) => {
+      chromeRef.storage.local.get(key, (result: Record<string, unknown>) => {
+        const value = result[key];
+        resolve(typeof value === 'string' ? value : null);
+      });
+    });
+  }
+  return localStorage.getItem(key);
+}
 
 /**
  * requestAccess handler
@@ -190,4 +214,47 @@ export async function handleSignMessage(
   return {
     signature: 'mock_signature_' + Date.now(),
   };
+}
+
+/**
+ * getPublicKey handler (#809)
+ * Reads the deployed smart-account C-address from chrome.storage.local and
+ * returns it as the wallet's public key. Requires prior requestAccess approval.
+ */
+export async function handleGetPublicKey(ctx: ExternalHandlerContext): Promise<GetPublicKeyResult> {
+  const { origin } = ctx;
+
+  const publicKey = await readFromChromeLocal(CONTRACT_ADDRESS_KEY);
+  if (!publicKey) {
+    throw new Error('Wallet not set up. Complete onboarding first.');
+  }
+
+  const { network } = getSettingsState();
+  const allowed = await isAllowed(network, publicKey, origin);
+  if (!allowed) {
+    throw new Error('Origin not allowed. Call requestAccess first.');
+  }
+
+  return { publicKey };
+}
+
+/**
+ * getNetwork handler (#809)
+ * Returns the active Stellar network and its passphrase.
+ * Requires prior requestAccess approval.
+ */
+export async function handleGetNetwork(ctx: ExternalHandlerContext): Promise<GetNetworkResult> {
+  const { origin } = ctx;
+
+  const publicKey = await readFromChromeLocal(CONTRACT_ADDRESS_KEY);
+  const { network } = getSettingsState();
+
+  const smartAccountId = publicKey ?? 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+  const allowed = await isAllowed(network, smartAccountId, origin);
+  if (!allowed) {
+    throw new Error('Origin not allowed. Call requestAccess first.');
+  }
+
+  const networkPassphrase = NETWORK_PASSPHRASES[network] ?? NETWORK_PASSPHRASES['testnet'];
+  return { network, networkPassphrase };
 }

--- a/apps/extension-wallet/src/background/handlers/external/index.ts
+++ b/apps/extension-wallet/src/background/handlers/external/index.ts
@@ -9,6 +9,8 @@ import {
   handleRequestAccess,
   handleGetAddress,
   handleGetSmartAccount,
+  handleGetPublicKey,
+  handleGetNetwork,
   handleSignTransaction,
   handleSignAuthEntry,
   handleSignMessage,
@@ -22,6 +24,8 @@ export function registerAllExternalHandlers(): void {
   registerExternalHandler(ExternalApiMethodName.REQUEST_ACCESS, handleRequestAccess);
   registerExternalHandler(ExternalApiMethodName.GET_ADDRESS, handleGetAddress);
   registerExternalHandler(ExternalApiMethodName.GET_SMART_ACCOUNT, handleGetSmartAccount);
+  registerExternalHandler(ExternalApiMethodName.GET_PUBLIC_KEY, handleGetPublicKey);
+  registerExternalHandler(ExternalApiMethodName.GET_NETWORK, handleGetNetwork);
   registerExternalHandler(ExternalApiMethodName.SIGN_TRANSACTION, handleSignTransaction);
   registerExternalHandler(ExternalApiMethodName.SIGN_AUTH_ENTRY, handleSignAuthEntry);
   registerExternalHandler(ExternalApiMethodName.SIGN_MESSAGE, handleSignMessage);

--- a/apps/extension-wallet/src/background/handlers/external/response-queue.ts
+++ b/apps/extension-wallet/src/background/handlers/external/response-queue.ts
@@ -7,10 +7,60 @@
 
 import type { ApprovalQueueEntry } from '@ancore/types';
 
+// ── Session storage helpers ───────────────────────────────────────────────────
+// Entries are written to chrome.storage.session so content scripts can poll for
+// results without holding an open runtime.sendMessage port (which would time out
+// during long-lived approval flows). Lost on extension restart is acceptable —
+// pending requests should not survive a service-worker lifecycle event.
+
+export interface SessionQueueEntry {
+  requestId: string;
+  status: 'pending' | 'resolved' | 'rejected';
+  result?: unknown;
+  error?: string;
+}
+
+function getChromeSession(): chrome['storage']['session'] | null {
+  const chromeRef = (globalThis as { chrome?: typeof chrome }).chrome;
+  return chromeRef?.storage?.session ?? null;
+}
+
+function writeSessionEntry(entry: SessionQueueEntry): void {
+  const session = getChromeSession();
+  if (session) {
+    session.set({ [entry.requestId]: entry });
+  }
+}
+
+export function getSessionEntry(requestId: string): Promise<SessionQueueEntry | null> {
+  return new Promise((resolve) => {
+    const session = getChromeSession();
+    if (!session) {
+      resolve(null);
+      return;
+    }
+    session.get(requestId, (result: Record<string, unknown>) => {
+      const entry = result[requestId];
+      resolve((entry as SessionQueueEntry | undefined) ?? null);
+    });
+  });
+}
+
+export function clearSessionEntry(requestId: string): void {
+  const session = getChromeSession();
+  if (session) {
+    session.remove(requestId);
+  }
+}
+
+// ── Approval queue (in-memory + session-persisted) ───────────────────────────
+
 const pendingApprovals = new Map<string, ApprovalQueueEntry>();
 
 /**
  * Enqueue a request for user approval.
+ * Also writes a `{ status: 'pending' }` entry to chrome.storage.session so
+ * content scripts can poll for the result without a long-lived message port.
  */
 export function enqueueApproval(
   requestId: string,
@@ -26,6 +76,7 @@ export function enqueueApproval(
     timestamp: Date.now(),
   };
   pendingApprovals.set(requestId, entry);
+  writeSessionEntry({ requestId, status: 'pending' });
 }
 
 /**
@@ -78,6 +129,8 @@ export function registerResponseCallbacks(
 
 /**
  * Resolve a request with a result.
+ * Updates the chrome.storage.session entry to `{ status: 'resolved', result }`
+ * so polling content scripts can detect completion.
  */
 export function resolveRequest(requestId: string, result: unknown): void {
   const callbacks = responseCallbacks.get(requestId);
@@ -85,10 +138,13 @@ export function resolveRequest(requestId: string, result: unknown): void {
     callbacks.resolve(result);
     responseCallbacks.delete(requestId);
   }
+  writeSessionEntry({ requestId, status: 'resolved', result });
 }
 
 /**
  * Reject a request with an error.
+ * Updates the chrome.storage.session entry to `{ status: 'rejected', error }`
+ * so polling content scripts can detect rejection.
  */
 export function rejectRequest(requestId: string, error: Error): void {
   const callbacks = responseCallbacks.get(requestId);
@@ -96,6 +152,7 @@ export function rejectRequest(requestId: string, error: Error): void {
     callbacks.reject(error);
     responseCallbacks.delete(requestId);
   }
+  writeSessionEntry({ requestId, status: 'rejected', error: error.message });
 }
 
 /**

--- a/apps/extension-wallet/src/hooks/useOnboarding.ts
+++ b/apps/extension-wallet/src/hooks/useOnboarding.ts
@@ -8,6 +8,21 @@ import { createWallet, importWallet } from '@ancore/core-sdk';
 import type { Network } from '@ancore/types';
 import { useAccountStore } from '@/stores/account';
 import { createDeployClient, type DeployClient } from '@/services/deploy-account';
+import { getSharedStorageManager } from '@/security/storage-manager';
+
+/** chrome.storage.local key for the deployed smart-account C-address. */
+export const CONTRACT_ADDRESS_KEY = 'ancore_contract_address';
+
+async function persistContractAddress(contractId: string): Promise<void> {
+  const chromeRef = (globalThis as { chrome?: any }).chrome;
+  if (chromeRef?.storage?.local) {
+    await new Promise<void>((resolve) => {
+      chromeRef.storage.local.set({ [CONTRACT_ADDRESS_KEY]: contractId }, resolve);
+    });
+  } else {
+    localStorage.setItem(CONTRACT_ADDRESS_KEY, contractId);
+  }
+}
 
 /**
  * Onboarding step enum
@@ -286,6 +301,32 @@ export function useOnboarding(options: UseOnboardingOptions = {}) {
           alreadyDeployed,
           encryptedMnemonic: wallet.encryptedMnemonic,
         };
+
+        // #815 — Unlock the AES-GCM vault and persist the mnemonic so that
+        // downstream features (send, sign, session keys) have real key material.
+        // Best-effort: vault write failures (e.g. in test environments without
+        // chrome.storage) must not abort the deploy flow.
+        try {
+          const vault = getSharedStorageManager();
+          const vaultReady = await vault.unlock(state.password!);
+          if (vaultReady) {
+            await vault.saveAccount({
+              privateKey: state.mnemonic!, // plaintext; vault re-encrypts with AES-GCM
+              publicKey,
+              contractId,
+            });
+          }
+        } catch {
+          // Non-fatal: chrome.storage unavailable or vault already locked.
+        }
+
+        // #817 — Persist the C-address to chrome.storage.local so background
+        // handlers can serve it without decrypting the vault.
+        try {
+          await persistContractAddress(contractId);
+        } catch {
+          // Non-fatal: chrome.storage unavailable (falls back to localStorage).
+        }
 
         // Persist contractId (smartAccountId) alongside the account in the
         // vault auth state store.

--- a/packages/types/src/external-api.ts
+++ b/packages/types/src/external-api.ts
@@ -13,6 +13,8 @@ export enum ExternalApiMethodName {
   REQUEST_ACCESS = 'requestAccess',
   GET_ADDRESS = 'getAddress',
   GET_SMART_ACCOUNT = 'getSmartAccount',
+  GET_PUBLIC_KEY = 'getPublicKey',
+  GET_NETWORK = 'getNetwork',
   SIGN_TRANSACTION = 'signTransaction',
   SIGN_AUTH_ENTRY = 'signAuthEntry',
   SIGN_MESSAGE = 'signMessage',
@@ -129,4 +131,20 @@ export interface SignAuthEntryResult {
  */
 export interface SignMessageResult {
   readonly signature: string;
+}
+
+/**
+ * Result from getPublicKey handler.
+ * Returns the deployed smart-account C-address as the wallet's public identity.
+ */
+export interface GetPublicKeyResult {
+  readonly publicKey: string;
+}
+
+/**
+ * Result from getNetwork handler.
+ */
+export interface GetNetworkResult {
+  readonly network: string;
+  readonly networkPassphrase: string;
 }


### PR DESCRIPTION
## What changed

- **#815** — Wire onboarding to real AES-GCM vault: after successful deploy, unlock `SecureStorageManager` with the user's password and persist the plaintext mnemonic (re-encrypted by PBKDF2-stretched AES-GCM vault) via `saveAccount()`. Adds `CONTRACT_ADDRESS_KEY` constant and a `persistContractAddress()` helper.
- **#817** — Persist C-address: store the deployed smart-account `contractId` in `chrome.storage.local` under key `ancore_contract_address` after onboarding so background handlers can read it without decrypting the vault.
- **#812** — Session queue: extend `response-queue.ts` with `chrome.storage.session` persistence. `enqueueApproval()` writes `{ status: 'pending' }`, `resolveRequest()` updates to `{ status: 'resolved', result }`, `rejectRequest()` updates to `{ status: 'rejected', error }`. Exports `getSessionEntry()` and `clearSessionEntry()` for content-script polling. Adds `SessionQueueEntry` type.
- **#809** — `GET_PUBLIC_KEY` and `GET_NETWORK` handlers: add both to `ExternalApiMethodName` enum and add `GetPublicKeyResult`/`GetNetworkResult` interfaces in `@ancore/types`. Implement `handleGetPublicKey()` (reads `ancore_contract_address`, allowlist-guarded) and `handleGetNetwork()` (reads settings store, maps to Stellar passphrase, allowlist-guarded) in `handlers.ts`. Register both in `registerAllExternalHandlers()`.

## Why

These four issues are the foundational pieces of the dApp connectivity epic. Without real vault persistence, no downstream feature (send, sign, session keys) has key material to work with. Without `GET_PUBLIC_KEY`/`GET_NETWORK` handlers, dApps cannot construct transactions. The session queue is required because `runtime.sendMessage` responses cannot survive the duration of a user approval flow.

## How to test

- **#815/#817**: Complete onboarding in the extension popup on testnet. After the `success` step, inspect `chrome.storage.local` — `ancore_contract_address` must contain the deployed C-address. The encrypted vault should be present under the `account` key.
- **#812**: Trigger a sign-transaction request from a dApp that has already called `requestAccess`. Inspect `chrome.storage.session` — the entry for the `requestId` should transition from `pending` → `resolved`/`rejected` after the popup responds.
- **#809**: From a dApp context, call `wallet.getPublicKey()` and `wallet.getNetwork()`. Both must resolve after `requestAccess` has been approved.
- Run `pnpm --filter @ancore/extension-wallet run test` — all new tests pass.

Closes #809
Closes #812
Closes #815
Closes #817

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new external wallet actions: one to return the wallet’s public key and another to return the active network details.
  * The wallet now stores the deployed account address so these requests can be handled after setup.

* **Bug Fixes**
  * Improved approval-request handling so pending, completed, and failed states are preserved more reliably across background session changes.
  * Added stronger checks to reject requests from unapproved origins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->