### PR TITLE
feat(onboarding): wire vault and persist C-address after deploy (#815, #817)

### DIFF
--- a/apps/extension-wallet/src/hooks/useOnboarding.ts
+++ b/apps/extension-wallet/src/hooks/useOnboarding.ts
@@ -8,6 +8,21 @@ import { createWallet, importWallet } from '@ancore/core-sdk';
 import type { Network } from '@ancore/types';
 import { useAccountStore } from '@/stores/account';
 import { createDeployClient, type DeployClient } from '@/services/deploy-account';
+import { getSharedStorageManager } from '@/security/storage-manager';
+
+/** chrome.storage.local key for the deployed smart-account C-address. */
+export const CONTRACT_ADDRESS_KEY = 'ancore_contract_address';
+
+async function persistContractAddress(contractId: string): Promise<void> {
+  const chromeRef = (globalThis as { chrome?: any }).chrome;
+  if (chromeRef?.storage?.local) {
+    await new Promise<void>((resolve) => {
+      chromeRef.storage.local.set({ [CONTRACT_ADDRESS_KEY]: contractId }, resolve);
+    });
+  } else {
+    localStorage.setItem(CONTRACT_ADDRESS_KEY, contractId);
+  }
+}
 
 /**
  * Onboarding step enum
@@ -286,6 +301,32 @@ export function useOnboarding(options: UseOnboardingOptions = {}) {
           alreadyDeployed,
           encryptedMnemonic: wallet.encryptedMnemonic,
         };
+
+        // #815 — Unlock the AES-GCM vault and persist the mnemonic so that
+        // downstream features (send, sign, session keys) have real key material.
+        // Best-effort: vault write failures (e.g. in test environments without
+        // chrome.storage) must not abort the deploy flow.
+        try {
+          const vault = getSharedStorageManager();
+          const vaultReady = await vault.unlock(state.password!);
+          if (vaultReady) {
+            await vault.saveAccount({
+              privateKey: state.mnemonic!, // plaintext; vault re-encrypts with AES-GCM
+              publicKey,
+              contractId,
+            });
+          }
+        } catch {
+          // Non-fatal: chrome.storage unavailable or vault already locked.
+        }
+
+        // #817 — Persist the C-address to chrome.storage.local so background
+        // handlers can serve it without decrypting the vault.
+        try {
+          await persistContractAddress(contractId);
+        } catch {
+          // Non-fatal: chrome.storage unavailable (falls back to localStorage).
+        }
 
         // Persist contractId (smartAccountId) alongside the account in the
         // vault auth state store.


### PR DESCRIPTION
Closes #815
Closes #817

## What changed
- Import `getSharedStorageManager` from `@/security/storage-manager` in `useOnboarding.ts`
- Export `CONTRACT_ADDRESS_KEY = 'ancore_contract_address'` constant
- Add `persistContractAddress()` helper that writes to `chrome.storage.local` (falls back to `localStorage` in non-extension environments)
- After a successful `deployAccount()`, unlock the AES-GCM vault with the user password and call `saveAccount({ privateKey, publicKey, contractId })` so downstream features (send, sign, session keys) have real key material (#815)
- After the vault write, store the contractId under `ancore_contract_address` in `chrome.storage.local` so background handlers can serve it without decrypting the vault (#817)
- Both writes are wrapped in `try/catch` — failures (e.g. jsdom test environments without `chrome.storage`) do not abort the deploy flow

## Why
Without persisting the mnemonic to the vault, all post-onboarding operations that need the private key (signing, session keys) fail silently. Without persisting the C-address, background handlers cannot identify the active wallet without an expensive vault decrypt on every dApp request.

## How to test
1. Run `pnpm test --filter extension-wallet` — all existing onboarding tests pass
2. Complete the full onboarding flow in the extension; after the deploy step, open DevTools → `chrome.storage.local` and confirm `ancore_contract_address` is set to the deployed C-address