### PR TITLE
feat(response-queue): persist approval status to chrome.storage.session (#812)

### DIFF
--- a/apps/extension-wallet/src/background/handlers/external/__tests__/response-queue.test.ts
+++ b/apps/extension-wallet/src/background/handlers/external/__tests__/response-queue.test.ts
@@ -12,7 +12,33 @@ import {
   resolveRequest,
   rejectRequest,
   clearResponseCallbacks,
+  getSessionEntry,
 } from '../response-queue';
+
+// ── chrome.storage.session mock ───────────────────────────────────────────────
+
+const sessionStore: Record<string, unknown> = {};
+const mockSession = {
+  set: vi.fn((data: Record<string, unknown>, _cb?: () => void) => {
+    Object.assign(sessionStore, data);
+  }),
+  get: vi.fn((key: string, cb: (result: Record<string, unknown>) => void) => {
+    cb({ [key]: sessionStore[key] });
+  }),
+  remove: vi.fn((key: string) => {
+    delete sessionStore[key];
+  }),
+};
+
+// Re-set globalThis.chrome in beforeEach because vitest.setup.ts deletes it
+// before every test to prevent leakage between files.
+beforeEach(() => {
+  (globalThis as any).chrome = { storage: { session: mockSession } };
+  Object.keys(sessionStore).forEach((k) => delete sessionStore[k]);
+  mockSession.set.mockClear();
+  mockSession.get.mockClear();
+  mockSession.remove.mockClear();
+});
 
 describe('response queue', () => {
   beforeEach(() => {
@@ -234,6 +260,57 @@ describe('response queue', () => {
         resolveRequest('123', { result: 'test' });
         resolveRequest('456', { result: 'test' });
       });
+    });
+  });
+
+  // ── Session storage (chrome.storage.session) ────────────────────────────────
+
+  describe('session storage', () => {
+    it('enqueueApproval writes pending status to session storage', () => {
+      enqueueApproval('req-1', 'https://dapp.example', 'signTransaction', {});
+
+      expect(mockSession.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'req-1': expect.objectContaining({ requestId: 'req-1', status: 'pending' }),
+        })
+      );
+    });
+
+    it('resolveRequest updates session entry to resolved', async () => {
+      registerResponseCallbacks(
+        'req-2',
+        () => {},
+        () => {}
+      );
+      resolveRequest('req-2', { signedXdr: 'abc' });
+
+      const entry = await getSessionEntry('req-2');
+      expect(entry).toEqual(
+        expect.objectContaining({
+          requestId: 'req-2',
+          status: 'resolved',
+          result: { signedXdr: 'abc' },
+        })
+      );
+    });
+
+    it('rejectRequest updates session entry to rejected with error message', async () => {
+      registerResponseCallbacks(
+        'req-3',
+        () => {},
+        () => {}
+      );
+      rejectRequest('req-3', new Error('user rejected'));
+
+      const entry = await getSessionEntry('req-3');
+      expect(entry).toEqual(
+        expect.objectContaining({ requestId: 'req-3', status: 'rejected', error: 'user rejected' })
+      );
+    });
+
+    it('getSessionEntry returns null for unknown requestId', async () => {
+      const entry = await getSessionEntry('no-such-id');
+      expect(entry).toBeNull();
     });
   });
 });

--- a/apps/extension-wallet/src/background/handlers/external/response-queue.ts
+++ b/apps/extension-wallet/src/background/handlers/external/response-queue.ts
@@ -7,10 +7,60 @@
 
 import type { ApprovalQueueEntry } from '@ancore/types';
 
+// ── Session storage helpers ───────────────────────────────────────────────────
+// Entries are written to chrome.storage.session so content scripts can poll for
+// results without holding an open runtime.sendMessage port (which would time out
+// during long-lived approval flows). Lost on extension restart is acceptable —
+// pending requests should not survive a service-worker lifecycle event.
+
+export interface SessionQueueEntry {
+  requestId: string;
+  status: 'pending' | 'resolved' | 'rejected';
+  result?: unknown;
+  error?: string;
+}
+
+function getChromeSession(): chrome['storage']['session'] | null {
+  const chromeRef = (globalThis as { chrome?: typeof chrome }).chrome;
+  return chromeRef?.storage?.session ?? null;
+}
+
+function writeSessionEntry(entry: SessionQueueEntry): void {
+  const session = getChromeSession();
+  if (session) {
+    session.set({ [entry.requestId]: entry });
+  }
+}
+
+export function getSessionEntry(requestId: string): Promise<SessionQueueEntry | null> {
+  return new Promise((resolve) => {
+    const session = getChromeSession();
+    if (!session) {
+      resolve(null);
+      return;
+    }
+    session.get(requestId, (result: Record<string, unknown>) => {
+      const entry = result[requestId];
+      resolve((entry as SessionQueueEntry | undefined) ?? null);
+    });
+  });
+}
+
+export function clearSessionEntry(requestId: string): void {
+  const session = getChromeSession();
+  if (session) {
+    session.remove(requestId);
+  }
+}
+
+// ── Approval queue (in-memory + session-persisted) ───────────────────────────
+
 const pendingApprovals = new Map<string, ApprovalQueueEntry>();
 
 /**
  * Enqueue a request for user approval.
+ * Also writes a `{ status: 'pending' }` entry to chrome.storage.session so
+ * content scripts can poll for the result without a long-lived message port.
  */
 export function enqueueApproval(
   requestId: string,
@@ -26,6 +76,7 @@ export function enqueueApproval(
     timestamp: Date.now(),
   };
   pendingApprovals.set(requestId, entry);
+  writeSessionEntry({ requestId, status: 'pending' });
 }
 
 /**
@@ -78,6 +129,8 @@ export function registerResponseCallbacks(
 
 /**
  * Resolve a request with a result.
+ * Updates the chrome.storage.session entry to `{ status: 'resolved', result }`
+ * so polling content scripts can detect completion.
  */
 export function resolveRequest(requestId: string, result: unknown): void {
   const callbacks = responseCallbacks.get(requestId);
@@ -85,10 +138,13 @@ export function resolveRequest(requestId: string, result: unknown): void {
     callbacks.resolve(result);
     responseCallbacks.delete(requestId);
   }
+  writeSessionEntry({ requestId, status: 'resolved', result });
 }
 
 /**
  * Reject a request with an error.
+ * Updates the chrome.storage.session entry to `{ status: 'rejected', error }`
+ * so polling content scripts can detect rejection.
  */
 export function rejectRequest(requestId: string, error: Error): void {
   const callbacks = responseCallbacks.get(requestId);
@@ -96,6 +152,7 @@ export function rejectRequest(requestId: string, error: Error): void {
     callbacks.reject(error);
     responseCallbacks.delete(requestId);
   }
+  writeSessionEntry({ requestId, status: 'rejected', error: error.message });
 }
 
 /**


### PR DESCRIPTION
Closes #812

## What changed
- Add `SessionQueueEntry` type (`{ requestId, status: 'pending'|'resolved'|'rejected', result?, error? }`)
- Add internal helpers `getChromeSession()` and `writeSessionEntry()` for safe chrome.storage.session access
- Export `getSessionEntry(requestId)` and `clearSessionEntry(requestId)` for content-script polling
- `enqueueApproval()` now writes `{ status: 'pending' }` to session storage alongside the in-memory map entry
- `resolveRequest()` updates the session entry to `{ status: 'resolved', result }`
- `rejectRequest()` updates the session entry to `{ status: 'rejected', error }`
- Add 4 tests in `response-queue.test.ts` covering all three state transitions and the null-miss case (includes a `beforeEach` chrome mock because `vitest.setup.ts` deletes `globalThis.chrome` before each test)

## Why
Without session storage, content scripts that poll for approval results require a long-lived `runtime.sendMessage` port. This port times out during long-lived approval flows (e.g. user taking >30 s to approve). Writing status to `chrome.storage.session` lets content scripts poll without holding an open port. State is intentionally lost on extension restart — pending requests should not survive a service-worker lifecycle event.

## How to test
1. `pnpm test --filter extension-wallet` — all 4 new session storage tests pass alongside existing queue tests
2. Trigger a `signTransaction` request from a dApp; open DevTools → `chrome.storage.session` and confirm a `pending` entry appears, then transitions to `resolved` or `rejected` when the user responds in the popup