### PR TITLE
feat(handlers): add getPublicKey and getNetwork dApp API handlers (#809)

### DIFF
--- a/apps/extension-wallet/src/background/handlers/external/__tests__/handlers.test.ts
+++ b/apps/extension-wallet/src/background/handlers/external/__tests__/handlers.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for handleGetPublicKey and handleGetNetwork (#809)
+ */
+
+import { handleGetPublicKey, handleGetNetwork } from '../handlers';
+import type { ExternalHandlerContext } from '@ancore/types';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const CONTRACT_ADDRESS = 'CABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890';
+
+const localStore: Record<string, unknown> = {};
+
+const mockLocalStorage = {
+  get: vi.fn((key: string, cb: (result: Record<string, unknown>) => void) => {
+    cb({ [key]: localStore[key] ?? null });
+  }),
+  set: vi.fn((data: Record<string, unknown>, cb?: () => void) => {
+    Object.assign(localStore, data);
+    cb?.();
+  }),
+};
+
+vi.mock('@/stores/settings', () => ({
+  getSettingsState: () => ({ network: 'testnet' }),
+}));
+
+vi.mock('../allowlist', () => ({
+  isAllowed: vi.fn().mockResolvedValue(true),
+  addToAllowlist: vi.fn(),
+}));
+
+// Re-set globalThis.chrome in beforeEach because vitest.setup.ts deletes it
+// before every test to prevent leakage between files.
+beforeEach(() => {
+  (globalThis as any).chrome = { storage: { local: mockLocalStorage } };
+  Object.keys(localStore).forEach((k) => delete localStore[k]);
+  mockLocalStorage.get.mockClear();
+});
+
+function makeCtx(origin = 'https://dapp.example'): ExternalHandlerContext {
+  return {
+    origin,
+    params: {},
+    requestId: 'test-req-id',
+    sender: {},
+  };
+}
+
+// ── handleGetPublicKey ────────────────────────────────────────────────────────
+
+describe('handleGetPublicKey', () => {
+  it('returns the stored contract address as publicKey', async () => {
+    localStore['ancore_contract_address'] = CONTRACT_ADDRESS;
+
+    const result = await handleGetPublicKey(makeCtx());
+    expect(result.publicKey).toBe(CONTRACT_ADDRESS);
+  });
+
+  it('throws when wallet is not onboarded (no stored address)', async () => {
+    await expect(handleGetPublicKey(makeCtx())).rejects.toThrow('Wallet not set up');
+  });
+
+  it('throws when origin is not in the allowlist', async () => {
+    const { isAllowed } = await import('../allowlist');
+    vi.mocked(isAllowed).mockResolvedValueOnce(false);
+    localStore['ancore_contract_address'] = CONTRACT_ADDRESS;
+
+    await expect(handleGetPublicKey(makeCtx('https://untrusted.example'))).rejects.toThrow(
+      'Origin not allowed'
+    );
+  });
+});
+
+// ── handleGetNetwork ──────────────────────────────────────────────────────────
+
+describe('handleGetNetwork', () => {
+  it('returns network and passphrase for testnet', async () => {
+    const result = await handleGetNetwork(makeCtx());
+    expect(result.network).toBe('testnet');
+    expect(result.networkPassphrase).toBe('Test SDF Network ; September 2015');
+  });
+
+  it('throws when origin is not in the allowlist', async () => {
+    const { isAllowed } = await import('../allowlist');
+    vi.mocked(isAllowed).mockResolvedValueOnce(false);
+
+    await expect(handleGetNetwork(makeCtx('https://untrusted.example'))).rejects.toThrow(
+      'Origin not allowed'
+    );
+  });
+});

--- a/apps/extension-wallet/src/background/handlers/external/handlers.ts
+++ b/apps/extension-wallet/src/background/handlers/external/handlers.ts
@@ -9,12 +9,38 @@ import type {
   RequestAccessResult,
   GetAddressResult,
   GetSmartAccountResult,
+  GetPublicKeyResult,
+  GetNetworkResult,
   SignTransactionResult,
 } from '@ancore/types';
 import { ExternalApiMethodName as MethodName } from '@ancore/types';
 import { isAllowed, addToAllowlist } from './allowlist';
 import { enqueueApproval } from './response-queue';
 import { openApprovalWindow } from '../../approval-window';
+import { getSettingsState } from '@/stores/settings';
+
+/** chrome.storage.local key for the deployed smart-account C-address. */
+const CONTRACT_ADDRESS_KEY = 'ancore_contract_address';
+
+/** Stellar network passphrases keyed by NetworkMode. */
+const NETWORK_PASSPHRASES: Record<string, string> = {
+  mainnet: 'Public Global Stellar Network ; September 2015',
+  testnet: 'Test SDF Network ; September 2015',
+  futurenet: 'Test SDF Future Network ; October 2022',
+};
+
+async function readFromChromeLocal(key: string): Promise<string | null> {
+  const chromeRef = (globalThis as { chrome?: any }).chrome;
+  if (chromeRef?.storage?.local) {
+    return new Promise((resolve) => {
+      chromeRef.storage.local.get(key, (result: Record<string, unknown>) => {
+        const value = result[key];
+        resolve(typeof value === 'string' ? value : null);
+      });
+    });
+  }
+  return localStorage.getItem(key);
+}
 
 /**
  * requestAccess handler
@@ -190,4 +216,47 @@ export async function handleSignMessage(
   return {
     signature: 'mock_signature_' + Date.now(),
   };
+}
+
+/**
+ * getPublicKey handler (#809)
+ * Reads the deployed smart-account C-address from chrome.storage.local and
+ * returns it as the wallet's public key. Requires prior requestAccess approval.
+ */
+export async function handleGetPublicKey(ctx: ExternalHandlerContext): Promise<GetPublicKeyResult> {
+  const { origin } = ctx;
+
+  const publicKey = await readFromChromeLocal(CONTRACT_ADDRESS_KEY);
+  if (!publicKey) {
+    throw new Error('Wallet not set up. Complete onboarding first.');
+  }
+
+  const { network } = getSettingsState();
+  const allowed = await isAllowed(network, publicKey, origin);
+  if (!allowed) {
+    throw new Error('Origin not allowed. Call requestAccess first.');
+  }
+
+  return { publicKey };
+}
+
+/**
+ * getNetwork handler (#809)
+ * Returns the active Stellar network and its passphrase.
+ * Requires prior requestAccess approval.
+ */
+export async function handleGetNetwork(ctx: ExternalHandlerContext): Promise<GetNetworkResult> {
+  const { origin } = ctx;
+
+  const publicKey = await readFromChromeLocal(CONTRACT_ADDRESS_KEY);
+  const { network } = getSettingsState();
+
+  const smartAccountId = publicKey ?? 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+  const allowed = await isAllowed(network, smartAccountId, origin);
+  if (!allowed) {
+    throw new Error('Origin not allowed. Call requestAccess first.');
+  }
+
+  const networkPassphrase = NETWORK_PASSPHRASES[network] ?? NETWORK_PASSPHRASES['testnet'];
+  return { network, networkPassphrase };
 }

--- a/apps/extension-wallet/src/background/handlers/external/index.ts
+++ b/apps/extension-wallet/src/background/handlers/external/index.ts
@@ -9,6 +9,8 @@ import {
   handleRequestAccess,
   handleGetAddress,
   handleGetSmartAccount,
+  handleGetPublicKey,
+  handleGetNetwork,
   handleSignTransaction,
   handleSignAuthEntry,
   handleSignMessage,
@@ -22,6 +24,8 @@ export function registerAllExternalHandlers(): void {
   registerExternalHandler(ExternalApiMethodName.REQUEST_ACCESS, handleRequestAccess);
   registerExternalHandler(ExternalApiMethodName.GET_ADDRESS, handleGetAddress);
   registerExternalHandler(ExternalApiMethodName.GET_SMART_ACCOUNT, handleGetSmartAccount);
+  registerExternalHandler(ExternalApiMethodName.GET_PUBLIC_KEY, handleGetPublicKey);
+  registerExternalHandler(ExternalApiMethodName.GET_NETWORK, handleGetNetwork);
   registerExternalHandler(ExternalApiMethodName.SIGN_TRANSACTION, handleSignTransaction);
   registerExternalHandler(ExternalApiMethodName.SIGN_AUTH_ENTRY, handleSignAuthEntry);
   registerExternalHandler(ExternalApiMethodName.SIGN_MESSAGE, handleSignMessage);

--- a/packages/types/src/external-api.ts
+++ b/packages/types/src/external-api.ts
@@ -13,6 +13,8 @@ export enum ExternalApiMethodName {
   REQUEST_ACCESS = 'requestAccess',
   GET_ADDRESS = 'getAddress',
   GET_SMART_ACCOUNT = 'getSmartAccount',
+  GET_PUBLIC_KEY = 'getPublicKey',
+  GET_NETWORK = 'getNetwork',
   SIGN_TRANSACTION = 'signTransaction',
   SIGN_AUTH_ENTRY = 'signAuthEntry',
   SIGN_MESSAGE = 'signMessage',
@@ -129,4 +131,20 @@ export interface SignAuthEntryResult {
  */
 export interface SignMessageResult {
   readonly signature: string;
+}
+
+/**
+ * Result from getPublicKey handler.
+ * Returns the deployed smart-account C-address as the wallet's public identity.
+ */
+export interface GetPublicKeyResult {
+  readonly publicKey: string;
+}
+
+/**
+ * Result from getNetwork handler.
+ */
+export interface GetNetworkResult {
+  readonly network: string;
+  readonly networkPassphrase: string;
 }


### PR DESCRIPTION
Closes #809

## What changed
- Add `GET_PUBLIC_KEY = 'getPublicKey'` and `GET_NETWORK = 'getNetwork'` to `ExternalApiMethodName` enum in `@ancore/types`
- Add `GetPublicKeyResult` and `GetNetworkResult` interfaces to `@ancore/types`
- Implement `handleGetPublicKey(ctx)` in `handlers.ts`:
  - Reads `ancore_contract_address` from `chrome.storage.local` (localStorage fallback for non-extension envs)
  - Throws `'Wallet not set up'` if the address is absent (onboarding not complete)
  - Checks allowlist; throws `'Origin not allowed'` if origin has not called `requestAccess`
  - Returns `{ publicKey: contractId }`
- Implement `handleGetNetwork(ctx)` in `handlers.ts`:
  - Reads active `NetworkMode` from the settings store
  - Maps it to the correct Stellar network passphrase (mainnet / testnet / futurenet)
  - Checks allowlist; throws `'Origin not allowed'` if unapproved
  - Returns `{ network, networkPassphrase }`
- Register both handlers in `registerAllExternalHandlers()` in `index.ts`
- Add `handlers.test.ts` with 5 tests covering success and guard paths for both handlers

## Why
dApps using the Ancore wallet SDK need to query the active public key and network passphrase before building and signing transactions. Without these handlers the dApp must cache this data from `requestAccess` responses, which can become stale if the user switches networks or reimports.

## How to test
1. `pnpm test --filter extension-wallet` — all 5 new handler tests pass
2. From a dApp, call `wallet.getPublicKey()` and `wallet.getNetwork()` after `requestAccess`; confirm correct values are returned matching the active wallet and network