### PR TITLE
feat(extension-wallet): add memo-required check for mainnet sends to exchange addresses

### DIFF
--- a/apps/extension-wallet/src/screens/Send/SendScreen.tsx
+++ b/apps/extension-wallet/src/screens/Send/SendScreen.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { isMemoRequired } from '@/utils/memoCheck';
 import {
   AddressInput,
   Button,
@@ -53,6 +54,21 @@ export function SendScreen({ balance, assetDecimals, service, pollIntervalMs }: 
 
   const send = useSendTransaction({ balance, assetDecimals, service, pollIntervalMs });
   const { recipients, addRecipient } = useRecentRecipients();
+  const [memoWarning, setMemoWarning] = useState<string | null>(null);
+
+  const isMainnet = send.tx?.fee?.network === 'mainnet' || !send.tx;
+
+  useEffect(() => {
+    setMemoWarning(null);
+    if (!form.to || !isMainnet) return;
+    isMemoRequired(form.to).then((required) => {
+      if (required && !form.note) {
+        setMemoWarning(
+          'This address belongs to an exchange and requires a memo. Add a memo or funds may be lost.'
+        );
+      }
+    });
+  }, [form.to, form.note, isMainnet]);
 
   const balanceDisplay = balance !== undefined ? balance.toString() : undefined;
   const maxDisabled = balance === undefined || balance <= BASE_SEND_RESERVE + DEFAULT_SEND_FEE;
@@ -63,6 +79,7 @@ export function SendScreen({ balance, assetDecimals, service, pollIntervalMs }: 
   };
 
   const handleReview = async () => {
+    if (memoWarning) return;
     const success = await send.goToReview(form);
     if (success) {
       await addRecipient({ address: send.tx?.to ?? form.to });
@@ -171,6 +188,16 @@ export function SendScreen({ balance, assetDecimals, service, pollIntervalMs }: 
           />
         </div>
 
+        {memoWarning && (
+          <div className="p-4 rounded-2xl bg-amber-500/10 border border-amber-500/20 text-[10px] text-amber-400 animate-in fade-in slide-in-from-top-2 duration-300 flex items-start gap-3">
+            <AlertCircle className="w-4 h-4 shrink-0" />
+            <div className="space-y-1">
+              <strong className="block uppercase tracking-wider font-black">Memo Required</strong>
+              <p className="font-medium leading-relaxed">{memoWarning}</p>
+            </div>
+          </div>
+        )}
+
         {send.errors.simulation && (
           <div className="p-4 rounded-2xl bg-red-500/10 border border-red-500/20 text-[10px] text-red-400 mb-4 animate-in fade-in slide-in-from-top-2 duration-300 flex items-start gap-3">
             <AlertCircle className="w-4 h-4 shrink-0" />
@@ -193,7 +220,7 @@ export function SendScreen({ balance, assetDecimals, service, pollIntervalMs }: 
             )}
             onClick={handleReview}
             loading={send.submitting}
-            disabled={send.submitting}
+            disabled={send.submitting || !!memoWarning}
           >
             {send.submitting ? 'Calculating...' : 'Review Transaction'}
           </Button>

--- a/apps/extension-wallet/src/utils/__tests__/memoCheck.test.ts
+++ b/apps/extension-wallet/src/utils/__tests__/memoCheck.test.ts
@@ -1,0 +1,62 @@
+import { isMemoRequired } from '../memoCheck';
+
+const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  // Clear module-level cache between tests by reimporting
+  vi.resetModules();
+});
+
+describe('isMemoRequired', () => {
+  it('returns true when API reports require_memo', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ require_memo: true }),
+    } as Response);
+
+    const { isMemoRequired: check } = await import('../memoCheck');
+    const result = await check('GCEXCHANGE000000000000000000000000000000000000000000000000');
+    expect(result).toBe(true);
+  });
+
+  it('returns false when require_memo is absent', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    const { isMemoRequired: check } = await import('../memoCheck');
+    const result = await check('GCREGULAR0000000000000000000000000000000000000000000000000');
+    expect(result).toBe(false);
+  });
+
+  it('returns false on network error', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('network'));
+
+    const { isMemoRequired: check } = await import('../memoCheck');
+    const result = await check('GCFAILURE000000000000000000000000000000000000000000000000');
+    expect(result).toBe(false);
+  });
+
+  it('returns false on non-200 response', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: false } as Response);
+
+    const { isMemoRequired: check } = await import('../memoCheck');
+    const result = await check('GCNOTFOUND00000000000000000000000000000000000000000000000');
+    expect(result).toBe(false);
+  });
+
+  it('caches results to avoid duplicate API calls', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ require_memo: true }),
+    } as Response);
+
+    const { isMemoRequired: check } = await import('../memoCheck');
+    const addr = 'GCEXCHANGE111111111111111111111111111111111111111111111111';
+    await check(addr);
+    await check(addr);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/extension-wallet/src/utils/memoCheck.ts
+++ b/apps/extension-wallet/src/utils/memoCheck.ts
@@ -1,0 +1,28 @@
+const cache = new Map<string, boolean>();
+
+interface StellarExpertDirectoryEntry {
+  require_memo?: boolean;
+}
+
+export async function isMemoRequired(destination: string): Promise<boolean> {
+  if (cache.has(destination)) {
+    return cache.get(destination)!;
+  }
+
+  try {
+    const res = await fetch(
+      `https://api.stellar.expert/explorer/public/directory/${destination}`
+    );
+    if (!res.ok) {
+      cache.set(destination, false);
+      return false;
+    }
+    const data: StellarExpertDirectoryEntry = await res.json();
+    const required = data.require_memo === true;
+    cache.set(destination, required);
+    return required;
+  } catch {
+    cache.set(destination, false);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `memoCheck.ts` utility that queries `https://api.stellar.expert/explorer/public/directory/{destination}` to detect exchange deposit addresses requiring a memo
- Blocks navigation to the review screen and disables the "Review Transaction" button when a memo-required address is detected but the memo field is empty
- Shows a blocking amber warning banner with user-actionable copy
- Skips the check entirely on testnet; caches results per session to avoid duplicate API calls
- Unit tests cover: memo required, memo not required, network error, non-200 response, and cache dedup

## Test plan

- [ ] Enter an exchange address (e.g. Kraken, Binance) on mainnet with no memo — warning banner appears, button disabled
- [ ] Add a memo — warning clears, button re-enables
- [ ] Same address checked twice — only one network request fires (verify in devtools)
- [ ] Testnet send — no warning regardless of address
- [ ] `pnpm --filter @ancore/extension-wallet test` passes

Closes ancore-org/ancore#823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memo requirement checks during send flows to warn users when a destination needs a memo.
  * Displayed an in-app “Memo Required” warning and prevented review until a note is added.

* **Bug Fixes**
  * Disabled the review action when memo information is missing, reducing failed transfers caused by omitted memos.

* **Tests**
  * Added coverage for memo requirement detection, including caching and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->