### PR TITLE
feat(ai-agent): add risk score field to intent validation response

### DIFF
--- a/services/ai-agent/src/risk.test.ts
+++ b/services/ai-agent/src/risk.test.ts
@@ -1,0 +1,65 @@
+import { scoreRisk } from './risk';
+import type { DraftIntent } from './types';
+
+function payment(amount: string, asset: 'XLM' | 'USDC' = 'XLM', destination = 'GDEST'): DraftIntent {
+  return { type: 'payment', amount, asset, destination };
+}
+
+describe('scoreRisk', () => {
+  it('returns low risk for a small XLM payment', () => {
+    const result = scoreRisk(payment('10'));
+    expect(result.level).toBe('low');
+    expect(result.reasons).toHaveLength(0);
+  });
+
+  it('returns medium risk for XLM >= 10000', () => {
+    const result = scoreRisk(payment('10000'));
+    expect(result.level).toBe('medium');
+    expect(result.reasons.some((r) => r.includes('Large transfer'))).toBe(true);
+  });
+
+  it('returns high risk for XLM >= 100000', () => {
+    const result = scoreRisk(payment('100000'));
+    expect(result.level).toBe('high');
+    expect(result.reasons.some((r) => r.includes('High-value'))).toBe(true);
+  });
+
+  it('returns medium risk for USDC >= 1000', () => {
+    const result = scoreRisk(payment('1000', 'USDC'));
+    expect(result.level).toBe('medium');
+  });
+
+  it('returns high risk for USDC >= 10000', () => {
+    const result = scoreRisk(payment('10000', 'USDC'));
+    expect(result.level).toBe('high');
+  });
+
+  it('flags first-time recipient when not in known set', () => {
+    const result = scoreRisk(payment('10'), { knownRecipients: new Set(['GOTHER']) });
+    expect(result.reasons.some((r) => r.includes('First-time'))).toBe(true);
+  });
+
+  it('does not flag known recipient', () => {
+    const result = scoreRisk(payment('10', 'XLM', 'GDEST'), {
+      knownRecipients: new Set(['GDEST']),
+    });
+    expect(result.reasons.some((r) => r.includes('First-time'))).toBe(false);
+  });
+
+  it('adds round-number reason for large round amounts', () => {
+    const result = scoreRisk(payment('10000'));
+    expect(result.reasons.some((r) => r.includes('Round number'))).toBe(true);
+  });
+
+  it('returns low risk for invoice intents', () => {
+    const invoice: DraftIntent = {
+      type: 'invoice',
+      requestedBy: 'GCREQ',
+      amount: '99999',
+      asset: 'XLM',
+    };
+    const result = scoreRisk(invoice);
+    expect(result.level).toBe('low');
+    expect(result.reasons).toHaveLength(0);
+  });
+});

--- a/services/ai-agent/src/risk.ts
+++ b/services/ai-agent/src/risk.ts
@@ -1,0 +1,44 @@
+import type { DraftIntent, RiskLevel, RiskScore } from './types';
+
+const MEDIUM_THRESHOLD_USDC = 1000;
+const HIGH_THRESHOLD_USDC = 10_000;
+const MEDIUM_THRESHOLD_XLM = 10_000;
+const HIGH_THRESHOLD_XLM = 100_000;
+
+interface RiskContext {
+  /** Set of addresses the sender has transacted with before */
+  knownRecipients?: Set<string>;
+}
+
+export function scoreRisk(intent: DraftIntent, ctx: RiskContext = {}): RiskScore {
+  const reasons: string[] = [];
+
+  if (intent.type === 'payment') {
+    const amount = parseFloat(intent.amount);
+    const isUsdc = intent.asset === 'USDC';
+    const mediumThreshold = isUsdc ? MEDIUM_THRESHOLD_USDC : MEDIUM_THRESHOLD_XLM;
+    const highThreshold = isUsdc ? HIGH_THRESHOLD_USDC : HIGH_THRESHOLD_XLM;
+
+    if (amount >= highThreshold) {
+      reasons.push(`High-value transfer: ${amount} ${intent.asset} exceeds ${highThreshold}`);
+    } else if (amount >= mediumThreshold) {
+      reasons.push(`Large transfer: ${amount} ${intent.asset} exceeds ${mediumThreshold}`);
+    }
+
+    if (ctx.knownRecipients && !ctx.knownRecipients.has(intent.destination)) {
+      reasons.push('First-time recipient: this address has not been paid before');
+    }
+
+    if (amount >= mediumThreshold && Number.isInteger(amount)) {
+      reasons.push('Round number above threshold may indicate manual high-value entry');
+    }
+  }
+
+  let level: RiskLevel = 'low';
+  if (reasons.length > 0) {
+    const hasHigh = reasons.some((r) => r.startsWith('High-value'));
+    level = hasHigh ? 'high' : 'medium';
+  }
+
+  return { level, reasons };
+}

--- a/services/ai-agent/src/server.ts
+++ b/services/ai-agent/src/server.ts
@@ -1,6 +1,7 @@
 import express, { Express, Request, Response } from 'express';
 import { intentSchema, HIGH_VALUE_PAYMENT_THRESHOLD } from './schemas/intent';
 import { requestLogger } from './middleware/request-logger';
+import { scoreRisk } from './risk';
 
 const startTime = Date.now();
 
@@ -50,16 +51,15 @@ export function createApp(): Express {
       return res.status(400).json({ error: 'Invalid request' });
     }
     const isInvoice = typeof prompt === 'string' && prompt.toLowerCase().includes('invoice');
+    const draftIntent = isInvoice
+      ? { type: 'invoice' as const, requestedBy: accountId, amount: '10', asset: 'XLM' }
+      : { type: 'payment' as const, destination: 'G123', amount: '10', asset: 'XLM' };
     return res.status(200).json({
       status: 'draft',
       requiresConfirmation: true,
       summary: isInvoice ? 'Drafted invoice intent' : 'Drafted payment intent',
-      intent: {
-        type: isInvoice ? 'invoice' : 'payment',
-        destination: 'G123',
-        amount: '10',
-        asset: 'XLM',
-      },
+      intent: draftIntent,
+      risk: scoreRisk(draftIntent),
     });
   });
 
@@ -83,16 +83,18 @@ export function createApp(): Express {
     const intent = parsed.data;
     let requiresConfirmation = false;
 
-    // Flag high-value payments for confirmation
     if (intent.type === 'payment') {
       const amount = parseFloat(intent.amount);
       requiresConfirmation = amount >= HIGH_VALUE_PAYMENT_THRESHOLD;
     }
 
+    const risk = scoreRisk(intent);
+
     return res.status(200).json({
       valid: true,
       intent: parsed.data,
       requiresConfirmation,
+      risk,
     });
   });
 

--- a/services/ai-agent/src/types.ts
+++ b/services/ai-agent/src/types.ts
@@ -35,6 +35,13 @@ export interface DraftInvoiceIntent {
 
 export type DraftIntent = DraftPaymentIntent | DraftInvoiceIntent;
 
+export type RiskLevel = 'low' | 'medium' | 'high';
+
+export interface RiskScore {
+  level: RiskLevel;
+  reasons: string[];
+}
+
 export interface DraftIntentResponse {
   /** Always "draft" — this intent requires explicit user confirmation before execution */
   status: 'draft';
@@ -43,4 +50,6 @@ export interface DraftIntentResponse {
   summary: string;
   /** Guardrail confirmation: service never executes autonomously */
   requiresConfirmation: true;
+  /** Risk assessment — wallet UI uses this to prompt extra confirmation for medium/high */
+  risk: RiskScore;
 }


### PR DESCRIPTION
## Summary

- Adds `risk: { level: 'low' | 'medium' | 'high', reasons: string[] }` to `DraftIntentResponse` type and both `/agent/draft-intent` and `/v1/intents/validate` responses
- `scoreRisk()` function computes risk from: amount vs asset-specific thresholds, first-time recipient flag (when `knownRecipients` context provided), and round-number detection above threshold
- Invoice intents always return `low` risk (risk only applies to outgoing payments)
- Unit tests cover all edge cases: small amounts, threshold boundaries, first-time vs known recipients, round numbers, invoice passthrough

## Test plan

- [ ] `pnpm --filter @ancore/ai-agent test` passes
- [ ] `POST /v1/intents/validate` with `{ type: 'payment', amount: '10000', asset: 'XLM', destination: '...' }` returns `risk.level: 'medium'`
- [ ] Same with `amount: '100000'` returns `risk.level: 'high'`
- [ ] Small amounts return `risk.level: 'low'` with empty `reasons`

Closes ancore-org/ancore#837