### PR TITLE
feat: getVersion helper, simulation types export, and migration CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,31 @@ jobs:
       - name: Check WASM size regression
         run: node scripts/check-wasm-size.js
 
+  indexer-migrations:
+    name: Indexer — Migration Check
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: ancore
+          POSTGRES_PASSWORD: ancore
+          POSTGRES_DB: ancore_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ancore"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply migrations (up smoke)
+        env:
+          DATABASE_URL: postgres://ancore:ancore@localhost:5432/ancore_test
+        run: bash services/indexer/scripts/check-migrations.sh
+
   indexer:
     name: Indexer — Build & Test
     runs-on: ubuntu-latest

--- a/docs/contract-methods.md
+++ b/docs/contract-methods.md
@@ -131,7 +131,54 @@ Return the current contract version.
 pub fn get_version(env: Env) -> u32
 ```
 
-**Returns** `u32` (0 if version key is absent)
+**Returns** `u32` — current version integer. Returns `0` if the version key is absent
+(contract deployed but not yet initialized).
+
+**Errors** none
+
+**Lifecycle**
+
+| State | Value |
+|-------|-------|
+| Deployed, not initialized | `0` |
+| After `initialize()` | `1` |
+| After each `upgrade()` | previous + 1 |
+| After `migrate(n)` | `n` (must be strictly > previous) |
+
+**SDK usage**
+
+```typescript
+import { getVersion } from '@ancore/account-abstraction';
+
+const version = await getVersion(contractId, { server, sourceAccount });
+// version === 1 after initialize, 2 after first upgrade, etc.
+```
+
+Or via `AccountContract`:
+
+```typescript
+import { AccountContract } from '@ancore/account-abstraction';
+
+const contract = new AccountContract(contractId);
+const version = await contract.getVersion({ server, sourceAccount });
+```
+
+**Compatibility matrix**
+
+Use the version to gate client-side feature flags before attempting calls that
+only exist in newer contract versions.
+
+| Contract version | Supported features |
+|------------------|--------------------|
+| `0` | Not initialized — all calls will fail with `NotInitialized (2)` |
+| `1` | Baseline: `initialize`, `execute`, `add_session_key`, `revoke_session_key`, `get_owner`, `get_nonce`, `get_version`, `get_session_key` |
+| `≥ 2` | Same as v1 plus any additions introduced by `upgrade()` / `migrate()` |
+
+> **Caching policy:** `get_version` is a read-only simulation — cache the result
+> for the duration of a session or until an `upgrade`/`migrated` event is observed.
+> Re-fetch after any transaction that calls `upgrade()` or `migrate()`.
+
+See also: [`upgrade`](#upgrade), [`migrate`](#migrate)
 
 ---
 

--- a/packages/account-abstraction/src/__tests__/get-owner-nonce.test.ts
+++ b/packages/account-abstraction/src/__tests__/get-owner-nonce.test.ts
@@ -1,11 +1,12 @@
 /**
- * Unit tests for getOwner and getNonce functions with mocked contract responses.
+ * Unit tests for getOwner, getNonce, and getVersion functions with mocked contract responses.
  */
 
 import { Address, xdr } from '@stellar/stellar-sdk';
 import {
   getOwner,
   getNonce,
+  getVersion,
   type AccountContractReadOptions,
   NotInitializedError,
   InvalidNonceError,
@@ -191,5 +192,91 @@ describe('getNonce', () => {
     });
 
     expect(result).toBe(largeNonce);
+  });
+});
+
+describe('getVersion', () => {
+  it('returns version as number from mocked u32 response', async () => {
+    const versionScVal = xdr.ScVal.scvU32(1);
+    const mockSimSuccess = { result: { retval: versionScVal } };
+    const server = {
+      getAccount: jest.fn().mockResolvedValue({ id: OWNER_ADDRESS, sequence: '1' }),
+      simulateTransaction: jest.fn().mockResolvedValue(mockSimSuccess),
+    } as AccountContractReadOptions['server'];
+
+    const result = await getVersion(CONTRACT_ID, {
+      server,
+      sourceAccount: OWNER_ADDRESS,
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    });
+
+    expect(result).toBe(1);
+    expect(typeof result).toBe('number');
+  });
+
+  it('returns 0 when version key is absent (pre-initialize)', async () => {
+    const versionScVal = xdr.ScVal.scvU32(0);
+    const mockSimSuccess = { result: { retval: versionScVal } };
+    const server = {
+      getAccount: jest.fn().mockResolvedValue({ id: OWNER_ADDRESS, sequence: '1' }),
+      simulateTransaction: jest.fn().mockResolvedValue(mockSimSuccess),
+    } as AccountContractReadOptions['server'];
+
+    const result = await getVersion(CONTRACT_ID, {
+      server,
+      sourceAccount: OWNER_ADDRESS,
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    });
+
+    expect(result).toBe(0);
+  });
+
+  it('returns incremented version after upgrade', async () => {
+    const versionScVal = xdr.ScVal.scvU32(2);
+    const mockSimSuccess = { result: { retval: versionScVal } };
+    const server = {
+      getAccount: jest.fn().mockResolvedValue({ id: OWNER_ADDRESS, sequence: '1' }),
+      simulateTransaction: jest.fn().mockResolvedValue(mockSimSuccess),
+    } as AccountContractReadOptions['server'];
+
+    const result = await getVersion(CONTRACT_ID, {
+      server,
+      sourceAccount: OWNER_ADDRESS,
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    });
+
+    expect(result).toBe(2);
+  });
+
+  it('throws TypeError when contract returns unexpected type', async () => {
+    const unexpectedScVal = new Address(OWNER_ADDRESS).toScVal();
+    const mockSimSuccess = { result: { retval: unexpectedScVal } };
+    const server = {
+      getAccount: jest.fn().mockResolvedValue({ id: OWNER_ADDRESS, sequence: '1' }),
+      simulateTransaction: jest.fn().mockResolvedValue(mockSimSuccess),
+    } as AccountContractReadOptions['server'];
+
+    await expect(
+      getVersion(CONTRACT_ID, {
+        server,
+        sourceAccount: OWNER_ADDRESS,
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      })
+    ).rejects.toThrow(TypeError);
+  });
+
+  it('throws ContractInvocationError when simulation fails', async () => {
+    const server = {
+      getAccount: jest.fn().mockResolvedValue({ id: OWNER_ADDRESS, sequence: '1' }),
+      simulateTransaction: jest.fn().mockResolvedValue({ error: 'Host function failure' }),
+    } as AccountContractReadOptions['server'];
+
+    await expect(
+      getVersion(CONTRACT_ID, {
+        server,
+        sourceAccount: OWNER_ADDRESS,
+        networkPassphrase: 'Test SDF Network ; September 2015',
+      })
+    ).rejects.toThrow(ContractInvocationError);
   });
 });

--- a/packages/account-abstraction/src/__tests__/simulation-types.test.ts
+++ b/packages/account-abstraction/src/__tests__/simulation-types.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Public surface test: SimulationResult and SimulationError must be importable
+ * directly from the package index without casting to `any`.
+ */
+
+import type { SimulationResult, SimulationError } from '../index';
+
+describe('SimulationResult public type', () => {
+  it('accepts a minimal result with required fields', () => {
+    const result: SimulationResult = {
+      fee: '100',
+      operationCount: 1,
+    };
+    expect(result.fee).toBe('100');
+    expect(result.operationCount).toBe(1);
+  });
+
+  it('accepts optional fields', () => {
+    const result: SimulationResult = {
+      fee: '500',
+      operationCount: 2,
+      minResourceFee: '100',
+    };
+    expect(result.minResourceFee).toBe('100');
+  });
+});
+
+describe('SimulationError public type', () => {
+  it('accepts an error-only shape', () => {
+    const err: SimulationError = { error: 'Host function failure' };
+    expect(err.error).toBe('Host function failure');
+  });
+
+  it('accepts a message-only shape', () => {
+    const err: SimulationError = { message: 'simulation timed out' };
+    expect(err.message).toBe('simulation timed out');
+  });
+
+  it('accepts an empty object (all fields optional)', () => {
+    const err: SimulationError = {};
+    expect(err).toBeDefined();
+  });
+});

--- a/packages/account-abstraction/src/account-contract.ts
+++ b/packages/account-abstraction/src/account-contract.ts
@@ -12,6 +12,7 @@ import {
   publicKeyToBytes32ScVal,
   scValToAddress,
   scValToOptionalSessionKey,
+  scValToU32,
   scValToU64,
   symbolToScVal,
   u64ToScVal,
@@ -22,6 +23,7 @@ import {
   type ExecuteOptions,
   type ExecuteResult,
 } from './execute';
+import type { SimulationError } from './types/simulation';
 
 /** Options for read calls (getOwner, getNonce, getSessionKey) when using a server */
 export interface AccountContractReadOptions {
@@ -45,13 +47,6 @@ export interface AccountContractWriteResult {
   operation: ReturnType<AccountContract['buildInvokeOperation']>;
 }
 
-interface SimulateErrorShape {
-  error?: string;
-  message?: string;
-  result?: {
-    retval?: xdr.ScVal;
-  };
-}
 
 /**
  * AccountContract wraps the Ancore account abstraction contract (contracts/account).
@@ -185,6 +180,13 @@ export class AccountContract {
   }
 
   /**
+   * Build invocation for get_version (read-only).
+   */
+  getVersionInvocation(): InvocationArgs {
+    return { method: 'get_version', args: [] };
+  }
+
+  /**
    * Return a Stellar operation that invokes the given method with the given args.
    */
   call(method: string, ...args: xdr.ScVal[]) {
@@ -212,6 +214,15 @@ export class AccountContract {
   async getNonce(options: AccountContractReadOptions): Promise<number> {
     const result = await this.simulateRead('get_nonce', [], options);
     return scValToU64(result);
+  }
+
+  /**
+   * Get the contract's current version. Returns 0 if the version key is absent
+   * (pre-initialize state). Requires server and source account for simulation.
+   */
+  async getVersion(options: AccountContractReadOptions): Promise<number> {
+    const result = await this.simulateRead('get_version', [], options);
+    return scValToU32(result);
   }
 
   /**
@@ -282,7 +293,7 @@ export class AccountContract {
 
     const raw = txBuilder.build();
 
-    const sim = (await server.simulateTransaction(raw)) as SimulateErrorShape;
+    const sim = (await server.simulateTransaction(raw)) as SimulationError;
 
     if (sim && typeof sim === 'object' && ('error' in sim || 'message' in sim)) {
       const errMsg =

--- a/packages/account-abstraction/src/get-owner-nonce.ts
+++ b/packages/account-abstraction/src/get-owner-nonce.ts
@@ -37,3 +37,19 @@ export async function getNonce(
   const result = await contract.getNonce(options);
   return result;
 }
+
+/**
+ * Get the current version of an account abstraction contract.
+ * Returns 0 if the version key is absent (contract not yet initialized).
+ *
+ * @param contractId - The contract ID of the account abstraction contract
+ * @param options - Server and source account for simulation
+ * @returns The current version as a number
+ */
+export async function getVersion(
+  contractId: string,
+  options: AccountContractReadOptions
+): Promise<number> {
+  const contract = new AccountContract(contractId);
+  return contract.getVersion(options);
+}

--- a/packages/account-abstraction/src/index.ts
+++ b/packages/account-abstraction/src/index.ts
@@ -9,7 +9,7 @@ export const AA_VERSION = '0.1.0';
 export { AccountContract } from './account-contract';
 export type { AccountContractReadOptions, InvocationArgs } from './account-contract';
 
-export { getOwner, getNonce } from './get-owner-nonce';
+export { getOwner, getNonce, getVersion } from './get-owner-nonce';
 
 export {
   AccountContractError,
@@ -39,6 +39,7 @@ export {
   decodeOwnerResult,
   decodeRevokeSessionKeyArgs,
   decodeSessionKeyResult,
+  decodeVersionResult,
   decodeVoidResult,
   publicKeyToBytes32ScVal,
   u64ToScVal,
@@ -50,6 +51,7 @@ export {
   encodeInitializeArgs,
   encodeRevokeSessionKeyArgs,
   scValToAddress,
+  scValToU32,
   scValToU64,
   bytes32ScValToPublicKey,
   scValToSessionKey,
@@ -84,10 +86,11 @@ export {
 } from './nonce-drift';
 export type { NonceDriftResult, NonceDriftOptions } from './nonce-drift';
 
+export type { SimulationResult, SimulationError } from './types/simulation';
+
 export { TransactionBuilder } from './transaction-builder';
 export type {
   TransactionBuilderOptions,
   ContractExecuteParams,
-  SimulationResult,
   RefreshSessionKeyTtlParams,
 } from './transaction-builder';

--- a/packages/account-abstraction/src/transaction-builder.ts
+++ b/packages/account-abstraction/src/transaction-builder.ts
@@ -8,6 +8,9 @@ import {
 } from '@stellar/stellar-sdk';
 
 import { publicKeyToBytes32ScVal } from './xdr-utils';
+import type { SimulationResult } from './types/simulation';
+
+export type { SimulationResult };
 
 type SorobanData = xdr.SorobanTransactionData;
 
@@ -46,12 +49,6 @@ export interface RefreshSessionKeyTtlParams {
   ttlSeconds: number;
 }
 
-export interface SimulationResult {
-  fee: string;
-  operationCount: number;
-  minResourceFee?: string;
-  transactionData?: SorobanData;
-}
 
 export class TransactionBuilder {
   private readonly source: string;

--- a/packages/account-abstraction/src/types/simulation.ts
+++ b/packages/account-abstraction/src/types/simulation.ts
@@ -1,0 +1,25 @@
+import type { xdr } from '@stellar/stellar-sdk';
+
+type SorobanData = xdr.SorobanTransactionData;
+
+/**
+ * Result of a successful Soroban simulation: fee estimates and resource footprint.
+ */
+export interface SimulationResult {
+  fee: string;
+  operationCount: number;
+  minResourceFee?: string;
+  transactionData?: SorobanData;
+}
+
+/**
+ * Shape of a simulation error response from the Soroban RPC server.
+ * Exposed so consumers can narrow on `error` / `message` without casting to `any`.
+ */
+export interface SimulationError {
+  error?: string;
+  message?: string;
+  result?: {
+    retval?: xdr.ScVal;
+  };
+}

--- a/packages/account-abstraction/src/xdr-utils.ts
+++ b/packages/account-abstraction/src/xdr-utils.ts
@@ -227,6 +227,16 @@ export function scValToAddress(scVal: xdr.ScVal): string {
 }
 
 /**
+ * Decode ScVal to number (u32).
+ */
+export function scValToU32(scVal: xdr.ScVal): number {
+  const native = scValToNative(scVal);
+  if (typeof native === 'number') return native;
+  if (typeof native === 'bigint') return Number(native);
+  throw new TypeError('Expected u32 number from ScVal');
+}
+
+/**
  * Decode ScVal to number (u64).
  */
 export function scValToU64(scVal: xdr.ScVal): number {
@@ -339,6 +349,13 @@ export function decodeOwnerResult(scVal: xdr.ScVal): string {
  */
 export function decodeNonceResult(scVal: xdr.ScVal): number {
   return scValToU64(scVal);
+}
+
+/**
+ * Decode get_version result.
+ */
+export function decodeVersionResult(scVal: xdr.ScVal): number {
+  return scValToU32(scVal);
 }
 
 /**

--- a/services/indexer/README.md
+++ b/services/indexer/README.md
@@ -440,9 +440,20 @@ Tests are marked with `#[ignore]` to prevent accidental execution without a test
 
 ## CI Quality Gates
 
-The following checks run automatically on every PR via the `indexer` CI job:
+The following checks run automatically on every PR:
+
+**`indexer-migrations` job** — spins an ephemeral Postgres 16 container and:
+1. Applies every file in `migrations/` in filename order (up smoke)
+2. Drops all application tables, then re-applies migrations (down/up idempotency check)
+
+The job fails if any migration file errors or the schema cannot be rebuilt from scratch.
+
+**`indexer` job:**
 
 ```bash
+# Lint migration filenames and sequence numbers
+pnpm indexer:lint-migrations
+
 # Check formatting (must pass before merge)
 cargo fmt --check
 
@@ -453,7 +464,71 @@ cargo clippy -- -D warnings
 cargo test
 ```
 
-Run these locally from `services/indexer/` before pushing to avoid CI failures.
+Run locally from `services/indexer/` before pushing to avoid CI failures.
+
+### Running the migration check locally
+
+```bash
+# Start a local Postgres instance (docker example)
+docker run -d --name ancore-pg \
+  -e POSTGRES_USER=ancore -e POSTGRES_PASSWORD=ancore -e POSTGRES_DB=ancore_test \
+  -p 5432:5432 postgres:16
+
+# Run the check script
+DATABASE_URL=postgres://ancore:ancore@localhost:5432/ancore_test \
+  bash services/indexer/scripts/check-migrations.sh
+```
+
+## Rollback Procedure
+
+Migrations are **forward-only** (no auto-generated down scripts). To roll back a
+broken migration in production, follow these steps:
+
+### 1. Identify the bad migration
+
+Check which migration was last applied and which introduced the regression:
+
+```bash
+# List tables / columns to see current schema state
+psql "$DATABASE_URL" -c "\dt"
+psql "$DATABASE_URL" -c "\d account_activity"
+```
+
+### 2. Write a compensating migration
+
+Create a new migration file with the next sequence number that undoes the change:
+
+```bash
+# Example: undo migration 004 that added a NOT NULL column without a default
+touch services/indexer/migrations/005_rollback_bad_column.sql
+```
+
+```sql
+-- 005_rollback_bad_column.sql
+ALTER TABLE account_activity DROP COLUMN IF EXISTS bad_column;
+```
+
+Never edit or delete an already-applied migration file — that creates drift
+between environments.
+
+### 3. Apply the compensating migration
+
+```bash
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+  -f services/indexer/migrations/005_rollback_bad_column.sql
+```
+
+### 4. Verify the schema
+
+```bash
+DATABASE_URL="$DATABASE_URL" \
+  bash services/indexer/scripts/check-migrations.sh
+```
+
+### 5. Deploy and monitor
+
+Deploy the service revision that includes the compensating migration and monitor
+`indexer_lag_blocks` / `indexer_lag_seconds` in Prometheus to confirm recovery.
 
 ## License
 

--- a/services/indexer/scripts/check-migrations.sh
+++ b/services/indexer/scripts/check-migrations.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Run all SQL migrations against a local Postgres instance and optionally compare
+# the resulting schema to a golden dump for drift detection.
+#
+# Usage:
+#   DATABASE_URL=postgres://user:pass@localhost:5432/ancore_test \
+#     bash services/indexer/scripts/check-migrations.sh
+#
+# Options (env vars):
+#   DATABASE_URL      Connection string (required)
+#   SCHEMA_DUMP_FILE  Path to golden schema dump to diff against (optional)
+#   SKIP_DOWN         Set to 1 to skip the down-migration smoke check
+
+set -euo pipefail
+
+MIGRATIONS_DIR="$(cd "$(dirname "$0")/../migrations" && pwd)"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "ERROR: DATABASE_URL is not set." >&2
+  exit 1
+fi
+
+echo "==> Running migrations from $MIGRATIONS_DIR"
+
+for file in "$MIGRATIONS_DIR"/*.sql; do
+  echo "    Applying $(basename "$file") ..."
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
+done
+
+echo "==> All migrations applied successfully"
+
+# Optional schema drift check
+if [[ -n "${SCHEMA_DUMP_FILE:-}" ]]; then
+  echo "==> Comparing schema to golden dump: $SCHEMA_DUMP_FILE"
+  ACTUAL=$(pg_dump "$DATABASE_URL" --schema-only --no-owner --no-acl 2>/dev/null)
+  GOLDEN=$(cat "$SCHEMA_DUMP_FILE")
+  if diff <(echo "$ACTUAL") <(echo "$GOLDEN") > /dev/null 2>&1; then
+    echo "    Schema matches golden dump — no drift detected"
+  else
+    echo "ERROR: Schema drift detected. Diff:" >&2
+    diff <(echo "$ACTUAL") <(echo "$GOLDEN") >&2
+    exit 1
+  fi
+fi
+
+# Down-migration smoke: drop all application tables and reapply to verify
+# migrations are idempotent and the schema is fully reproducible.
+if [[ "${SKIP_DOWN:-0}" != "1" ]]; then
+  echo "==> Down-migration smoke: dropping application tables"
+  psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
+    DROP TABLE IF EXISTS account_activity CASCADE;
+    DROP TABLE IF EXISTS ingest_checkpoints CASCADE;
+  "
+  echo "==> Re-applying migrations after teardown"
+  for file in "$MIGRATIONS_DIR"/*.sql; do
+    echo "    Applying $(basename "$file") ..."
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
+  done
+  echo "==> Down/up smoke passed"
+fi
+
+echo "==> Migration check complete"


### PR DESCRIPTION
## Summary

  Three medium-scope changes shipped in one PR:

  ### #583 — `getVersion` read helper for account contract

  The `get_version` contract entrypoint had no TypeScript counterpart, forcing
  consumers to raw-simulate manually. This adds the full read helper stack:

  - `scValToU32()` and `decodeVersionResult()` in `xdr-utils.ts`
  - `getVersionInvocation()` and `async getVersion()` on `AccountContract`
  - Standalone `getVersion(contractId, options)` in `get-owner-nonce.ts`
  - All three exported from the `@ancore/account-abstraction` package index
  - Unit tests covering: v0 (pre-init), v1 (post-init), v2 (post-upgrade),
    wrong return type (TypeError), and simulation failure (ContractInvocationError)
  - `docs/contract-methods.md` expanded with lifecycle table, SDK usage examples,
    caching policy, and a compatibility matrix

  ### #589 — Export `SimulationResult` and `SimulationError` from package

  `SimulationResult` lived in `transaction-builder.ts` as a package-internal type.
  `SimulateErrorShape` (the simulation error structure) was never exported at all,
  forcing consumers to cast to `any` when inspecting failures.

  - Extracted both into `packages/account-abstraction/src/types/simulation.ts`
  - `transaction-builder.ts` re-exports `SimulationResult` from the new types file
  - `account-contract.ts` uses `SimulationError` (was private `SimulateErrorShape`)
  - Both types exported from the package index — importable as:
    `import type { SimulationResult, SimulationError } from '@ancore/account-abstraction'`
  - `simulation-types.test.ts` guards the public surface against regressions

  ### #579 — SQL migration CI check job

  The existing `indexer` CI job ran `sqlx`/clippy/tests but never touched a real
  database. Unapplied or divergent migrations could merge without detection.

  - New `indexer-migrations` CI job spins an ephemeral Postgres 16 service and:
    1. Applies every file in `migrations/` in filename order (up smoke)
    2. Drops application tables and re-applies from scratch (idempotency check)
    3. Fails the PR if any migration errors or the schema cannot be rebuilt
  - `services/indexer/scripts/check-migrations.sh` — local parity script with
    optional schema dump diff (`SCHEMA_DUMP_FILE`) and skippable down-smoke (`SKIP_DOWN=1`)
  - `services/indexer/README.md` — rollback procedure documented: compensating
    migrations, verification steps, and post-deploy monitoring via Prometheus metrics

  ## Test plan

  - [ ] `pnpm turbo run test --filter='@ancore/account-abstraction'` — all new tests pass
  - [ ] `pnpm turbo run lint --filter='@ancore/account-abstraction'` — no TypeScript errors
  - [ ] CI `indexer-migrations` job passes on this PR (Postgres 16 service + migration smoke)
  - [ ] `DATABASE_URL=... bash services/indexer/scripts/check-migrations.sh` passes locally
  - [ ] `SimulationResult` and `SimulationError` are importable from `@ancore/account-abstraction` without casting to `any`
  - [ ] `getVersion` returns `0` before init, `1` after init, increments after upgrade

  Closes #583
  Closes #589
  Closes #579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading an account contract’s version, including both SDK helpers and contract invocation builders.
  * Introduced migration validation in CI to catch schema issues earlier.

* **Documentation**
  * Expanded contract version docs with lifecycle details, usage examples, compatibility guidance, and caching notes.
  * Improved indexer migration and rollback instructions, including local verification steps.

* **Bug Fixes**
  * Tightened simulation result handling and type safety for contract read responses.
  * Added broader test coverage for version reads and simulation response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->