### PR TITLE
feat: Add Dialog component with focus trap and escape close

### DIFF
--- a/apps/extension-wallet/src/screens/Send/ConfirmDialog.tsx
+++ b/apps/extension-wallet/src/screens/Send/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button, Card, CardContent, CardHeader, CardTitle, PasswordInput } from '@ancore/ui-kit';
+import { Button, Card, CardContent, CardHeader, CardTitle, PasswordInput, Dialog, DialogContent } from '@ancore/ui-kit';
 import type { SendTransactionDraft } from '@/hooks/useSendTransaction';
 import { KeyRound, ArrowRight, ShieldCheck, Info } from 'lucide-react';
 
@@ -36,84 +36,88 @@ export function ConfirmDialog({
   };
 
   return (
-    <Card className="w-full max-w-md bg-slate-950 border-white/10 shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-300">
-      <CardHeader className="bg-gradient-to-br from-amber-500/10 to-orange-500/5 pb-6 border-b border-white/5">
-        <CardTitle className="text-white uppercase tracking-widest text-xs flex items-center justify-center gap-2 font-black">
-          <KeyRound className="text-amber-400 w-4 h-4" />
-          Sign Transaction
-        </CardTitle>
-      </CardHeader>
+    <Dialog open={true} onOpenChange={(open) => { if (!open) onBack(); }}>
+      <DialogContent className="p-0 border-none bg-transparent shadow-none max-w-md w-full">
+        <Card className="w-full max-w-md bg-slate-950 border-white/10 shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-300">
+          <CardHeader className="bg-gradient-to-br from-amber-500/10 to-orange-500/5 pb-6 border-b border-white/5">
+            <CardTitle className="text-white uppercase tracking-widest text-xs flex items-center justify-center gap-2 font-black">
+              <KeyRound className="text-amber-400 w-4 h-4" />
+              Sign Transaction
+            </CardTitle>
+          </CardHeader>
 
-      <CardContent className="space-y-6 pt-6 px-6 pb-8">
-        <div className="text-center space-y-2">
-          <p className="text-[10px] text-slate-500 uppercase tracking-widest font-black">
-            Authentication Required
-          </p>
-          <p className="text-sm text-slate-300 font-medium">
-            {timing === 'scheduled' ? (
-              <>
-                Approving a scheduled transfer of{' '}
-                <span className="text-white font-black">{transaction.amount} XLM</span>
-              </>
-            ) : (
-              <>
-                Sending <span className="text-white font-black">{transaction.amount} XLM</span> to
-                recipient
-              </>
-            )}
-          </p>
-        </div>
+          <CardContent className="space-y-6 pt-6 px-6 pb-8">
+            <div className="text-center space-y-2">
+              <p className="text-[10px] text-slate-500 uppercase tracking-widest font-black">
+                Authentication Required
+              </p>
+              <p className="text-sm text-slate-300 font-medium">
+                {timing === 'scheduled' ? (
+                  <>
+                    Approving a scheduled transfer of{' '}
+                    <span className="text-white font-black">{transaction.amount} XLM</span>
+                  </>
+                ) : (
+                  <>
+                    Sending <span className="text-white font-black">{transaction.amount} XLM</span> to
+                    recipient
+                  </>
+                )}
+              </p>
+            </div>
 
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <div className="space-y-2">
-            <PasswordInput
-              label="Wallet Password"
-              placeholder="Enter your password"
-              value={password}
-              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                setPassword(event.target.value)
-              }
-              error={error}
-              className="bg-white/5 border-white/10 text-white rounded-2xl h-14 focus:border-amber-400/50 transition-all"
-              autoFocus
-            />
-          </div>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="space-y-2">
+                <PasswordInput
+                  label="Wallet Password"
+                  placeholder="Enter your password"
+                  value={password}
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                    setPassword(event.target.value)
+                  }
+                  error={error}
+                  className="bg-white/5 border-white/10 text-white rounded-2xl h-14 focus:border-amber-400/50 transition-all"
+                  autoFocus
+                />
+              </div>
 
-          <div className="flex gap-3 pt-2">
-            <Button
-              type="button"
-              variant="ghost"
-              disabled={loading}
-              className="flex-1 text-slate-500 hover:text-white hover:bg-white/5 rounded-2xl border border-white/5 h-12 text-[10px] font-black uppercase tracking-widest transition-all"
-              onClick={onBack}
-            >
-              Go Back
-            </Button>
-            <Button
-              type="submit"
-              disabled={loading || !password}
-              className="flex-[2] bg-amber-400 text-slate-950 font-black uppercase tracking-widest rounded-2xl h-12 shadow-[0_10px_20px_rgba(251,191,36,0.2)] hover:bg-amber-300 disabled:opacity-50 disabled:grayscale transition-all flex items-center justify-center gap-2 text-[10px]"
-            >
-              {loading ? (
-                <span className="flex items-center gap-2">
-                  <span className="w-3 h-3 border-2 border-slate-950/20 border-t-slate-950 rounded-full animate-spin" />
-                  Signing...
-                </span>
-              ) : (
-                <>
-                  Sign & Submit
-                  <ArrowRight className="w-3.5 h-3.5" />
-                </>
-              )}
-            </Button>
-          </div>
-        </form>
+              <div className="flex gap-3 pt-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  disabled={loading}
+                  className="flex-1 text-slate-500 hover:text-white hover:bg-white/5 rounded-2xl border border-white/5 h-12 text-[10px] font-black uppercase tracking-widest transition-all"
+                  onClick={onBack}
+                >
+                  Go Back
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={loading || !password}
+                  className="flex-[2] bg-amber-400 text-slate-950 font-black uppercase tracking-widest rounded-2xl h-12 shadow-[0_10px_20px_rgba(251,191,36,0.2)] hover:bg-amber-300 disabled:opacity-50 disabled:grayscale transition-all flex items-center justify-center gap-2 text-[10px]"
+                >
+                  {loading ? (
+                    <span className="flex items-center gap-2">
+                      <span className="w-3 h-3 border-2 border-slate-950/20 border-t-slate-950 rounded-full animate-spin" />
+                      Signing...
+                    </span>
+                  ) : (
+                    <>
+                      Sign & Submit
+                      <ArrowRight className="w-3.5 h-3.5" />
+                    </>
+                  )}
+                </Button>
+              </div>
+            </form>
 
-        <div className="flex items-center justify-center gap-1.5 text-[8px] text-slate-700 uppercase tracking-widest font-black pt-2">
-          <ShieldCheck className="w-3 h-3 opacity-50" />
-          End-to-End Encrypted Authentication
-        </div>
-      </CardContent>
-    </Card>
+            <div className="flex items-center justify-center gap-1.5 text-[8px] text-slate-700 uppercase tracking-widest font-black pt-2">
+              <ShieldCheck className="w-3 h-3 opacity-50" />
+              End-to-End Encrypted Authentication
+            </div>
+          </CardContent>
+        </Card>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/ui-kit/src/components/ui/dialog.stories.tsx
+++ b/packages/ui-kit/src/components/ui/dialog.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Dialog, DialogContent } from './dialog';
+import { Button } from './button';
+import { useState } from 'react';
+
+const meta = {
+  title: 'UI/Dialog',
+  component: Dialog,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Dialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const DialogDemo = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <div className="space-y-4">
+            <h2 className="text-lg font-bold">Confirm Action</h2>
+            <p>Are you sure you want to proceed with this action?</p>
+            <div className="flex justify-end gap-2 mt-4">
+              <Button variant="outline" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={() => setOpen(false)}>Confirm</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <DialogDemo />,
+};
+
+export const LegacyAPI: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <div>
+        <Button onClick={() => setIsOpen(true)}>Open Legacy Dialog</Button>
+        <Dialog isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <div className="space-y-4">
+            <h2 className="text-lg font-bold">Legacy Dialog</h2>
+            <p>This uses isOpen and onClose</p>
+            <Button onClick={() => setIsOpen(false)}>Close</Button>
+          </div>
+        </Dialog>
+      </div>
+    );
+  },
+};

--- a/packages/ui-kit/src/components/ui/dialog.test.tsx
+++ b/packages/ui-kit/src/components/ui/dialog.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Dialog, DialogContent } from './dialog';
+import { expectNoA11yViolations } from '../../__tests__/test-utils/a11y';
+
+describe('Dialog', () => {
+  it('renders children when open', () => {
+    render(
+      <Dialog open={true}>
+        <DialogContent>
+          <div data-testid="dialog-content">Test Content</div>
+        </DialogContent>
+      </Dialog>
+    );
+    expect(screen.getByTestId('dialog-content')).toBeInTheDocument();
+  });
+
+  it('has no axe violations when open', async () => {
+    const { container } = render(
+      <Dialog open={true}>
+        <DialogContent>
+          <h2>Accessible Dialog</h2>
+          <p>This dialog should pass a11y checks.</p>
+          <button>Close</button>
+        </DialogContent>
+      </Dialog>
+    );
+
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/ui-kit/src/components/ui/dialog.tsx
+++ b/packages/ui-kit/src/components/ui/dialog.tsx
@@ -1,22 +1,87 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import { cn } from '../../lib/utils';
 
-interface DialogProps {
-  isOpen: boolean;
-  onClose: () => void;
+export interface DialogProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  // Legacy props
+  isOpen?: boolean;
+  onClose?: () => void;
   children: React.ReactNode;
 }
 
-export const Dialog: React.FC<DialogProps> = ({ isOpen, onClose, children }) => {
-  if (!isOpen) return null;
+export const Dialog: React.FC<DialogProps> = ({
+  open,
+  onOpenChange,
+  isOpen,
+  onClose,
+  children,
+}) => {
+  const isDialogVisible = open !== undefined ? open : isOpen;
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const handleClose = () => {
+    if (onOpenChange) onOpenChange(false);
+    if (onClose) onClose();
+  };
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (isDialogVisible) {
+      if (!dialog.open) {
+        dialog.showModal();
+      }
+    } else {
+      if (dialog.open) {
+        dialog.close();
+      }
+    }
+  }, [isDialogVisible]);
+
+  const handleCancel = (e: React.SyntheticEvent<HTMLDialogElement>) => {
+    e.preventDefault();
+    handleClose();
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
+    if (e.target === dialogRef.current) {
+      handleClose();
+    }
+  };
+
+  if (isDialogVisible === undefined) {
+    return <>{children}</>;
+  }
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-foreground/50">
-      <div className="rounded bg-popover p-4 text-popover-foreground shadow-lg">
-        {children}
-        <button onClick={onClose} className="mt-4 text-destructive">
-          Close
-        </button>
-      </div>
+    <dialog
+      ref={dialogRef}
+      onCancel={handleCancel}
+      onClick={handleBackdropClick}
+      className={cn(
+        "backdrop:bg-foreground/50 bg-transparent p-0 m-auto overflow-visible",
+        "open:animate-in open:fade-in-0 backdrop:animate-in backdrop:fade-in-0"
+      )}
+    >
+      {children}
+    </dialog>
+  );
+};
+
+export const DialogContent: React.FC<{
+  children: React.ReactNode;
+  className?: string;
+}> = ({ children, className }) => {
+  return (
+    <div
+      className={cn(
+        'rounded bg-popover p-4 text-popover-foreground shadow-lg relative',
+        className
+      )}
+    >
+      {children}
     </div>
   );
 };

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -26,7 +26,7 @@ export type { BadgeProps } from './components/ui/badge';
 
 export { Separator } from './components/ui/separator';
 
-export { Dialog } from './components/ui/dialog';
+export { Dialog, DialogContent } from './components/ui/dialog';
 export { Tooltip } from './components/ui/tooltip';
 
 export { Skeleton } from './components/ui/skeleton';


### PR DESCRIPTION
Closes #676 

# [UI-KIT] Add Dialog component with focus trap and escape close

## Summary
Implements a reusable modal Dialog component to be used for confirm flows across the applications. 

## Changes Made
- **`@ancore/ui-kit`**
  - Updated `dialog.tsx` to utilize the native HTML5 `<dialog>` element. This intrinsically supports:
    - **Focus Trapping**: Focus remains inside the dialog natively when opened via `showModal()`.
    - **Escape to Close**: Natively handles the `Esc` key to close the dialog.
  - Added `DialogContent` alongside `Dialog` and exposed the requested `<Dialog open={open} onOpenChange={setOpen}>` API layout, while maintaining backward compatibility with the legacy `isOpen`/`onClose` properties for existing dialogs like `AddSessionKeyDialog`.
  - Exported `DialogContent` from `ui-kit/src/index.ts`.
  - Added a Storybook story (`dialog.stories.tsx`) that features an interactive demo and a legacy compatibility reference.
  - Added an accessibility (a11y) test suite (`dialog.test.tsx`) utilizing `@testing-library/react` and `expectNoA11yViolations`.

- **`extension-wallet`**
  - Updated `apps/extension-wallet/src/screens/Send/ConfirmDialog.tsx` to wrap its existing `Card` implementation seamlessly within the newly exported `<Dialog>` and `<DialogContent>` components without disrupting the layout.

## Acceptance Criteria Met
- [x] Focus trapped inside
- [x] Escape closes
- [x] Storybook + a11y test
- [x] Used in extension confirm dialog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the authentication/signing dialog to use a more polished modal experience.
  * Added a reusable dialog content container and example stories for the dialog component.

* **Bug Fixes**
  * Closing the dialog now properly returns users to the previous screen.
  * Improved support for both scheduled and immediate transfer text in the confirmation flow.

* **Tests**
  * Added automated coverage for dialog rendering and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->