### PR TITLE
feat(indexer): add contract events API, repository, schema, and migra…

### DIFF
--- a/services/indexer/migrations/004_create_contract_events_table.sql
+++ b/services/indexer/migrations/004_create_contract_events_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS contract_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contract_address VARCHAR(56) NOT NULL,
+    event_type VARCHAR(50) NOT NULL,
+    ledger_seq BIGINT NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL,
+    tx_hash VARCHAR(64) NOT NULL,
+    data JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_contract_events_contract_address
+    ON contract_events (contract_address);
+CREATE INDEX IF NOT EXISTS idx_contract_events_event_type
+    ON contract_events (event_type);
+CREATE INDEX IF NOT EXISTS idx_contract_events_contract_address_event_type
+    ON contract_events (contract_address, event_type);
+CREATE INDEX IF NOT EXISTS idx_contract_events_ledger_seq
+    ON contract_events (ledger_seq DESC);
+CREATE INDEX IF NOT EXISTS idx_contract_events_timestamp
+    ON contract_events (timestamp DESC);

--- a/services/indexer/src/api/contract_events.rs
+++ b/services/indexer/src/api/contract_events.rs
@@ -1,0 +1,110 @@
+use axum::{
+    extract::{Path, Query, State},
+    response::Json,
+};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::schema::contract_event::{
+    ContractEvent, ContractEventFilter,
+};
+
+/// Query parameters for contract events list endpoint.
+#[derive(Debug, Deserialize)]
+pub struct ListContractEventsQuery {
+    contract: Option<String>,
+    #[serde(rename = "type")]
+    event_type: Option<String>,
+    ledger_min: Option<i64>,
+    ledger_max: Option<i64>,
+    limit: Option<u32>,
+    offset: Option<u64>,
+}
+
+/// Response envelope for contract events list.
+#[derive(Debug, Serialize)]
+pub struct ContractEventsListResponse {
+    pub data: Vec<ContractEvent>,
+    pub count: usize,
+}
+
+/// Response envelope for single contract event.
+#[derive(Debug, Serialize)]
+pub struct ContractEventResponse {
+    data: ContractEvent,
+}
+
+/// Response envelope for contract event types.
+#[derive(Debug, Serialize)]
+pub struct ContractEventTypesResponse {
+    data: Vec<String>,
+}
+
+/// List contract events with optional filters.
+pub async fn list_handler(
+    State(db): State<PgPool>,
+    Query(params): Query<ListContractEventsQuery>,
+) -> Result<Json<ContractEventsListResponse>> {
+    // Validate ledger range
+    if let (Some(min), Some(max)) = (params.ledger_min, params.ledger_max) {
+        if min > max {
+            return Err(crate::error::ApiError::InvalidFilter(
+                "ledger_min must be <= ledger_max".to_string(),
+            ));
+        }
+    }
+
+    let filter = ContractEventFilter {
+        contract_address: params.contract,
+        event_type: params.event_type,
+        ledger_min: params.ledger_min,
+        ledger_max: params.ledger_max,
+        limit: params.limit,
+        offset: params.offset,
+    };
+
+    let events =
+        crate::repositories::contract_events::get_contract_events(&db, &filter).await?;
+
+    let count = events.len();
+    Ok(Json(ContractEventsListResponse { data: events, count }))
+}
+
+/// Get a single contract event by ID.
+pub async fn get_by_id_handler(
+    State(db): State<PgPool>,
+    Path(event_id): Path<String>,
+) -> Result<Json<ContractEventResponse>> {
+    let event_uuid = Uuid::parse_str(&event_id).map_err(|_| {
+        crate::error::ApiError::InvalidFilter("event_id must be a valid UUID".to_string())
+    })?;
+
+    let event =
+        crate::repositories::contract_events::get_contract_event_by_id(&db, &event_uuid)
+            .await?;
+
+    match event {
+        Some(record) => Ok(Json(ContractEventResponse { data: record })),
+        None => Err(crate::error::ApiError::NotFound),
+    }
+}
+
+/// Get distinct event types for a contract address.
+pub async fn list_types_handler(
+    State(db): State<PgPool>,
+    Query(params): Query<ListContractEventsQuery>,
+) -> Result<Json<ContractEventTypesResponse>> {
+    let contract_address = params.contract.ok_or_else(|| {
+        crate::error::ApiError::InvalidFilter(
+            "contract query parameter is required".to_string(),
+        )
+    })?;
+
+    let types =
+        crate::repositories::contract_events::get_contract_event_types(&db, &contract_address)
+            .await?;
+
+    Ok(Json(ContractEventTypesResponse { data: types }))
+}

--- a/services/indexer/src/api/mod.rs
+++ b/services/indexer/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod account_activity;
+pub mod contract_events;
 pub mod health;
 pub mod metrics;
 pub mod statements;

--- a/services/indexer/src/main.rs
+++ b/services/indexer/src/main.rs
@@ -12,10 +12,12 @@ mod api;
 mod error;
 mod metrics;
 mod repositories;
+mod schema;
 
 use ancore_indexer::ingest::CheckpointStore;
 
 use api::account_activity;
+use api::contract_events;
 use api::health;
 use api::metrics::{metrics_handler, prometheus_metrics_handler};
 use api::statements;
@@ -123,6 +125,19 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/api/v1/accounts/:account_id/statements/rows",
             get(statements::rows_handler),
+        )
+        // Contract events API
+        .route(
+            "/api/v1/contract-events",
+            get(contract_events::list_handler),
+        )
+        .route(
+            "/api/v1/contract-events/:event_id",
+            get(contract_events::get_by_id_handler),
+        )
+        .route(
+            "/api/v1/contract-events/types",
+            get(contract_events::list_types_handler),
         )
         .route("/health", get(health::health_handler))
         .route("/metrics", get(metrics_handler))

--- a/services/indexer/src/repositories/contract_events.rs
+++ b/services/indexer/src/repositories/contract_events.rs
@@ -1,0 +1,139 @@
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+use crate::error::{ApiError, Result};
+use crate::schema::contract_event::{ContractEvent, ContractEventFilter, InsertContractEvent};
+
+const DEFAULT_LIMIT: u32 = 50;
+const MAX_LIMIT: u32 = 200;
+
+/// Insert a single contract event record.
+pub async fn insert_contract_event(
+    db: &PgPool,
+    params: &InsertContractEvent,
+) -> Result<Uuid> {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO contract_events \
+         (id, contract_address, event_type, ledger_seq, timestamp, tx_hash, data) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind(id)
+    .bind(&params.contract_address)
+    .bind(&params.event_type)
+    .bind(params.ledger_seq)
+    .bind(params.timestamp)
+    .bind(&params.tx_hash)
+    .bind(&params.data)
+    .execute(db)
+    .await?;
+
+    Ok(id)
+}
+
+/// Query contract events with optional filters.
+pub async fn get_contract_events(
+    db: &PgPool,
+    filter: &ContractEventFilter,
+) -> Result<Vec<ContractEvent>> {
+    let limit = filter
+        .limit
+        .unwrap_or(DEFAULT_LIMIT)
+        .clamp(1, MAX_LIMIT) as i64;
+
+    let mut query = sqlx::query_builder::QueryBuilder::new(
+        "SELECT id, contract_address, event_type, ledger_seq, timestamp, tx_hash, data \
+         FROM contract_events WHERE 1=1",
+    );
+
+    if let Some(ref addr) = filter.contract_address {
+        query.push(" AND contract_address = ");
+        query.push_bind(addr);
+    }
+
+    if let Some(ref event_type) = filter.event_type {
+        query.push(" AND event_type = ");
+        query.push_bind(event_type);
+    }
+
+    if let Some(ledger_min) = filter.ledger_min {
+        query.push(" AND ledger_seq >= ");
+        query.push_bind(ledger_min);
+    }
+
+    if let Some(ledger_max) = filter.ledger_max {
+        query.push(" AND ledger_seq <= ");
+        query.push_bind(ledger_max);
+    }
+
+    query.push(" ORDER BY timestamp DESC, id DESC LIMIT ");
+    query.push(limit);
+
+    if let Some(offset) = filter.offset {
+        query.push(" OFFSET ");
+        query.push_bind(offset as i64);
+    }
+
+    let rows = query.build().fetch_all(db).await?;
+
+    let events: Vec<ContractEvent> = rows
+        .iter()
+        .map(|row| ContractEvent {
+            id: row.get("id"),
+            contract_address: row.get("contract_address"),
+            event_type: row.get("event_type"),
+            ledger_seq: row.get("ledger_seq"),
+            timestamp: row.get("timestamp"),
+            tx_hash: row.get("tx_hash"),
+            data: row.get("data"),
+        })
+        .collect();
+
+    Ok(events)
+}
+
+/// Get a single contract event by ID.
+pub async fn get_contract_event_by_id(
+    db: &PgPool,
+    event_id: &Uuid,
+) -> Result<Option<ContractEvent>> {
+    let row = sqlx::query(
+        "SELECT id, contract_address, event_type, ledger_seq, timestamp, tx_hash, data \
+         FROM contract_events WHERE id = $1",
+    )
+    .bind(event_id)
+    .fetch_optional(db)
+    .await?;
+
+    Ok(row.map(|r| ContractEvent {
+        id: r.get("id"),
+        contract_address: r.get("contract_address"),
+        event_type: r.get("event_type"),
+        ledger_seq: r.get("ledger_seq"),
+        timestamp: r.get("timestamp"),
+        tx_hash: r.get("tx_hash"),
+        data: r.get("data"),
+    }))
+}
+
+/// Get distinct event types for a contract address.
+pub async fn get_contract_event_types(
+    db: &PgPool,
+    contract_address: &str,
+) -> Result<Vec<String>> {
+    let rows = sqlx::query(
+        "SELECT DISTINCT event_type FROM contract_events \
+         WHERE contract_address = $1 ORDER BY event_type",
+    )
+    .bind(contract_address)
+    .fetch_all(db)
+    .await?;
+
+    let types: Vec<String> = rows.iter().map(|r| r.get("event_type")).collect();
+
+    if types.is_empty() {
+        return Err(ApiError::NotFound);
+    }
+
+    Ok(types)
+}

--- a/services/indexer/src/repositories/mod.rs
+++ b/services/indexer/src/repositories/mod.rs
@@ -1,1 +1,2 @@
 pub mod account_activity;
+pub mod contract_events;

--- a/services/indexer/src/schema/contract_event.rs
+++ b/services/indexer/src/schema/contract_event.rs
@@ -1,0 +1,130 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Contract event types emitted by the account contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContractEventType {
+    Initialized,
+    Executed,
+    SessionKeyAdded,
+    SessionKeyRevoked,
+    Upgraded,
+}
+
+impl ContractEventType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ContractEventType::Initialized => "initialized",
+            ContractEventType::Executed => "executed",
+            ContractEventType::SessionKeyAdded => "session_key_added",
+            ContractEventType::SessionKeyRevoked => "session_key_revoked",
+            ContractEventType::Upgraded => "upgraded",
+        }
+    }
+}
+
+impl std::fmt::Display for ContractEventType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for ContractEventType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "initialized" => Ok(ContractEventType::Initialized),
+            "executed" => Ok(ContractEventType::Executed),
+            "session_key_added" => Ok(ContractEventType::SessionKeyAdded),
+            "session_key_revoked" => Ok(ContractEventType::SessionKeyRevoked),
+            "upgraded" => Ok(ContractEventType::Upgraded),
+            _ => Err(()),
+        }
+    }
+}
+
+/// A decoded contract event from the account contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContractEvent {
+    pub id: Uuid,
+    pub contract_address: String,
+    pub event_type: String,
+    pub ledger_seq: i64,
+    pub timestamp: DateTime<Utc>,
+    pub tx_hash: String,
+    pub data: serde_json::Value,
+}
+
+/// Parameters for inserting a new contract event.
+#[derive(Debug, Clone)]
+pub struct InsertContractEvent {
+    pub contract_address: String,
+    pub event_type: String,
+    pub ledger_seq: i64,
+    pub timestamp: DateTime<Utc>,
+    pub tx_hash: String,
+    pub data: serde_json::Value,
+}
+
+/// Filters for querying contract events.
+#[derive(Debug, Clone, Default)]
+pub struct ContractEventFilter {
+    pub contract_address: Option<String>,
+    pub event_type: Option<String>,
+    pub ledger_min: Option<i64>,
+    pub ledger_max: Option<i64>,
+    pub limit: Option<u32>,
+    pub offset: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contract_event_type_display() {
+        assert_eq!(ContractEventType::Initialized.to_string(), "initialized");
+        assert_eq!(ContractEventType::Executed.to_string(), "executed");
+        assert_eq!(
+            ContractEventType::SessionKeyAdded.to_string(),
+            "session_key_added"
+        );
+        assert_eq!(
+            ContractEventType::SessionKeyRevoked.to_string(),
+            "session_key_revoked"
+        );
+        assert_eq!(ContractEventType::Upgraded.to_string(), "upgraded");
+    }
+
+    #[test]
+    fn contract_event_type_from_str() {
+        assert_eq!(
+            "initialized".parse::<ContractEventType>().unwrap(),
+            ContractEventType::Initialized
+        );
+        assert_eq!(
+            "session_key_added".parse::<ContractEventType>().unwrap(),
+            ContractEventType::SessionKeyAdded
+        );
+        assert!("invalid".parse::<ContractEventType>().is_err());
+    }
+
+    #[test]
+    fn contract_event_type_serde_roundtrip() {
+        let kinds = vec![
+            ContractEventType::Initialized,
+            ContractEventType::Executed,
+            ContractEventType::SessionKeyAdded,
+            ContractEventType::SessionKeyRevoked,
+            ContractEventType::Upgraded,
+        ];
+        for kind in kinds {
+            let json = serde_json::to_string(&kind).unwrap();
+            let deserialized: ContractEventType = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, kind);
+        }
+    }
+}

--- a/services/indexer/src/schema/mod.rs
+++ b/services/indexer/src/schema/mod.rs
@@ -1,3 +1,4 @@
 pub mod canonical;
+pub mod contract_event;
 
 pub use canonical::*;


### PR DESCRIPTION
## The new contract_events API, repository, schema, and migration 

closes #860
closes #856 
closes #857 
closes #858 
 - Fix applied: Added mod schema; to src/main.rs:14 â the api/contract_events.rs and repositories/contract_events.rs modules import from crate::schema::contract_event, but schema was only declared in lib.rs, not in main.rs. Since main.rs re-declares its own module tree (matching how repositories and error are handled), it needed the same declaration.
### What's implemented:

- schema/contract_event.rs â ContractEventType enum, ContractEvent/InsertContractEvent structs, ContractEventFilter, with serde roundtrip tests (3 tests passing)
- repositories/contract_events.rs â insert_contract_event, get_contract_events, get_contract_event_by_id, get_contract_event_types
- api/contract_events.rs â list_handler, get_by_id_handler, list_types_handler with query param validation
- Routes: GET /api/v1/contract-events, GET /api/v1/contract-events/:event_id, GET /api/v1/contract-events/types
- Migration 004_create_contract_events_table.sql with indexed columns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing contract events through new API endpoints, including listing events, fetching a single event, and retrieving available event types.
  * Added storage support for contract events, including event details, filtering, and pagination.
  * Added a new event type model with standardized formatting and parsing.
* **Bug Fixes**
  * Improved event queries with validation and better handling of missing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->