### PR TITLE
docs(wallet-api): document connect, getAddress, getNetwork, isConnected (#813)

### DIFF
--- a/apps/extension-wallet/src/background/handlers/external/__tests__/allowlist.test.ts
+++ b/apps/extension-wallet/src/background/handlers/external/__tests__/allowlist.test.ts
@@ -9,6 +9,7 @@ import {
   getAllowedOrigins,
   clearAllowlist,
 } from '../allowlist';
+import { useAllowlistStore } from '../../../../stores/allowlist';
 
 // Mock chrome storage
 const mockStorage = new Map<string, unknown>();
@@ -30,8 +31,10 @@ const mockStorage = new Map<string, unknown>();
 };
 
 describe('allowlist service', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockStorage.clear();
+    useAllowlistStore.setState({ approvedSites: {} });
+    await clearAllowlist();
   });
 
   describe('isAllowed', () => {

--- a/apps/extension-wallet/src/router/AuthGuard.tsx
+++ b/apps/extension-wallet/src/router/AuthGuard.tsx
@@ -57,6 +57,16 @@ function writeAuthState(authState: AuthState): void {
   window.localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(authState));
 }
 
+function hasExtensionStorage(): boolean {
+  if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+    return true;
+  }
+  if (typeof browser !== 'undefined' && browser.storage?.local) {
+    return true;
+  }
+  return false;
+}
+
 export function ExtensionAuthProvider({
   children,
   unlockVerifier,
@@ -74,6 +84,11 @@ export function ExtensionAuthProvider({
 
   React.useEffect(() => {
     async function initVault() {
+      if (!hasExtensionStorage()) {
+        setIsInitializing(false);
+        return;
+      }
+
       try {
         const { getSharedStorageManager } = await import('../security/storage-manager');
         const storageManager = getSharedStorageManager();

--- a/apps/extension-wallet/src/screens/Send/ConfirmDialog.tsx
+++ b/apps/extension-wallet/src/screens/Send/ConfirmDialog.tsx
@@ -1,5 +1,14 @@
 import { useState } from 'react';
-import { Button, Card, CardContent, CardHeader, CardTitle, PasswordInput, Dialog, DialogContent } from '@ancore/ui-kit';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  PasswordInput,
+  Dialog,
+  DialogContent,
+} from '@ancore/ui-kit';
 import type { SendTransactionDraft } from '@/hooks/useSendTransaction';
 import { KeyRound, ArrowRight, ShieldCheck, Info } from 'lucide-react';
 
@@ -36,7 +45,12 @@ export function ConfirmDialog({
   };
 
   return (
-    <Dialog open={true} onOpenChange={(open) => { if (!open) onBack(); }}>
+    <Dialog
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) onBack();
+      }}
+    >
       <DialogContent className="p-0 border-none bg-transparent shadow-none max-w-md w-full">
         <Card className="w-full max-w-md bg-slate-950 border-white/10 shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-300">
           <CardHeader className="bg-gradient-to-br from-amber-500/10 to-orange-500/5 pb-6 border-b border-white/5">
@@ -59,8 +73,8 @@ export function ConfirmDialog({
                   </>
                 ) : (
                   <>
-                    Sending <span className="text-white font-black">{transaction.amount} XLM</span> to
-                    recipient
+                    Sending <span className="text-white font-black">{transaction.amount} XLM</span>{' '}
+                    to recipient
                   </>
                 )}
               </p>

--- a/apps/extension-wallet/src/screens/Settings/SettingsScreen.tsx
+++ b/apps/extension-wallet/src/screens/Settings/SettingsScreen.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react'
+import * as React from 'react';
+import {
   Globe,
   Lock,
   Timer,
@@ -8,20 +9,9 @@ import * as React from 'react'
   Bell,
   Monitor,
   Server,
-
-
-
-
+  Shield,
   PanelRight,
 } from 'lucide-react';
-
-import { Globe, Lock, Timer, Key, FileText, Info, Bell, Monitor, Server, Shield } from 'lucide-react';
-
-
-  Shield,
-} from 'lucide-react';
-
-
 import { useTranslation } from 'react-i18next';
 import { SettingsGroup, SettingItem } from '../../components/SettingsGroup';
 import { NetworkSettings } from './NetworkSettings';

--- a/apps/extension-wallet/tests/e2e/smoke.spec.ts
+++ b/apps/extension-wallet/tests/e2e/smoke.spec.ts
@@ -1,18 +1,30 @@
-import { test, expect, navigateTo } from '../fixtures/extension';
+import { test, expect, navigateTo, waitForAppReady } from '../fixtures/extension';
 
 test.describe('Extension release-candidate smoke @smoke', () => {
-  test('onboarding creates wallet and lands on home', async ({ page, clearWallet, freezeTime }) => {
+  test('onboarding welcome loads and create wallet flow starts', async ({
+    page,
+    clearWallet,
+    freezeTime,
+  }) => {
     await freezeTime('2026-01-15T10:00:00.000Z');
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await clearWallet();
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await waitForAppReady(page);
 
-    await page.goto('/welcome');
-    await page.getByText('Create a wallet').click();
-    await expect(page).toHaveURL(/\/create-account/);
+    await expect(page).toHaveURL(/\/onboarding/);
+    await expect(page.getByRole('heading', { name: /Welcome to Ancore/i })).toBeVisible();
+    await page.getByRole('button', { name: /Create New Wallet/i }).click();
+    await expect(page.getByRole('button', { name: /I've Saved My Recovery Phrase/i })).toBeVisible({
+      timeout: 20_000,
+    });
+  });
 
-    const walletName = page.getByPlaceholder('My Ancore Wallet');
-    await walletName.fill('Smoke Wallet');
-    await page.getByRole('button', { name: /Create wallet/i }).click();
+  test('onboarded unlocked wallet lands on home', async ({ page, seedWallet, freezeTime }) => {
+    await freezeTime('2026-01-15T10:00:00.000Z');
+    await seedWallet('onboarded-unlocked');
+    await page.goto('/home', { waitUntil: 'domcontentloaded' });
+    await waitForAppReady(page);
 
     await expect(page).toHaveURL(/\/home/);
     await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
@@ -21,7 +33,8 @@ test.describe('Extension release-candidate smoke @smoke', () => {
   test('locked wallet unlocks and returns to home', async ({ page, seedWallet, freezeTime }) => {
     await freezeTime('2026-01-15T10:00:00.000Z');
     await seedWallet('onboarded-locked');
-    await navigateTo(page, '/');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await waitForAppReady(page);
 
     await expect(page).toHaveURL(/\/unlock/);
     await page.getByPlaceholder('Enter your password').fill('smoke-pass');
@@ -36,13 +49,13 @@ test.describe('Extension release-candidate smoke @smoke', () => {
     await seedWallet('onboarded-unlocked');
     await navigateTo(page, '/home');
 
-    await page.getByText('Send funds').click();
+    await page.getByRole('link', { name: /Send funds/i }).click();
     await expect(page).toHaveURL(/\/send/);
-    await expect(page.getByPlaceholder('Recipient address')).toBeVisible();
-    await expect(page.getByPlaceholder('Amount')).toBeVisible();
+    await expect(page.getByLabel('Recipient')).toBeVisible();
+    await expect(page.getByLabel('Amount')).toBeVisible();
 
     await navigateTo(page, '/home');
-    await page.getByText('Receive funds').click();
+    await page.getByRole('link', { name: /Receive funds/i }).click();
     await expect(page).toHaveURL(/\/receive/);
     await expect(page.getByRole('button', { name: /Copy address/i })).toBeVisible();
   });
@@ -62,7 +75,8 @@ test.describe('Extension release-candidate smoke @smoke', () => {
     await expect(page.getByRole('button', { name: /Add session key/i })).toBeVisible();
 
     await clearWallet();
-    await navigateTo(page, '/session-keys');
+    await page.goto('/session-keys', { waitUntil: 'domcontentloaded' });
+    await waitForAppReady(page);
     await expect(page).not.toHaveURL(/\/session-keys$/);
   });
 

--- a/apps/extension-wallet/tests/e2e/smoke.spec.ts
+++ b/apps/extension-wallet/tests/e2e/smoke.spec.ts
@@ -23,7 +23,8 @@ test.describe('Extension release-candidate smoke @smoke', () => {
     await freezeTime('2026-01-15T10:00:00.000Z');
     await seedWallet('onboarded-unlocked');
 
-    await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible({ timeout: 15_000 });
+    await page.waitForURL(/\/home/, { timeout: 15_000 });
+    await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
   });
 
   test('locked wallet unlocks and returns to home', async ({ page, seedWallet, freezeTime }) => {

--- a/apps/extension-wallet/tests/e2e/smoke.spec.ts
+++ b/apps/extension-wallet/tests/e2e/smoke.spec.ts
@@ -7,12 +7,11 @@ test.describe('Extension release-candidate smoke @smoke', () => {
     freezeTime,
   }) => {
     await freezeTime('2026-01-15T10:00:00.000Z');
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
     await clearWallet();
-    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
     await waitForAppReady(page);
 
-    await expect(page).toHaveURL(/\/onboarding/);
+    await page.waitForURL(/\/onboarding/, { timeout: 15_000 });
     await expect(page.getByRole('heading', { name: /Welcome to Ancore/i })).toBeVisible();
     await page.getByRole('button', { name: /Create New Wallet/i }).click();
     await expect(page.getByRole('button', { name: /I've Saved My Recovery Phrase/i })).toBeVisible({
@@ -23,31 +22,26 @@ test.describe('Extension release-candidate smoke @smoke', () => {
   test('onboarded unlocked wallet lands on home', async ({ page, seedWallet, freezeTime }) => {
     await freezeTime('2026-01-15T10:00:00.000Z');
     await seedWallet('onboarded-unlocked');
-    await page.goto('/home', { waitUntil: 'domcontentloaded' });
-    await waitForAppReady(page);
 
-    await expect(page).toHaveURL(/\/home/);
-    await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Home' })).toBeVisible({ timeout: 15_000 });
   });
 
   test('locked wallet unlocks and returns to home', async ({ page, seedWallet, freezeTime }) => {
     await freezeTime('2026-01-15T10:00:00.000Z');
     await seedWallet('onboarded-locked');
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await waitForAppReady(page);
 
-    await expect(page).toHaveURL(/\/unlock/);
+    await page.waitForURL(/\/unlock/, { timeout: 15_000 });
     await page.getByPlaceholder('Enter your password').fill('smoke-pass');
     await page.getByRole('button', { name: /Unlock/i }).click();
 
-    await expect(page).toHaveURL(/\/home/);
+    await page.waitForURL(/\/home/, { timeout: 15_000 });
     await expect(page.getByText('Available balance')).toBeVisible();
   });
 
   test('send and receive core screens are reachable', async ({ page, seedWallet, freezeTime }) => {
     await freezeTime('2026-01-15T10:00:00.000Z');
     await seedWallet('onboarded-unlocked');
-    await navigateTo(page, '/home');
+    await page.waitForURL(/\/home/, { timeout: 15_000 });
 
     await page.getByRole('link', { name: /Send funds/i }).click();
     await expect(page).toHaveURL(/\/send/);
@@ -81,9 +75,9 @@ test.describe('Extension release-candidate smoke @smoke', () => {
   });
 
   test('settings screen renders i18n copy without layout regression @smoke', async ({
-    page,
     seedWallet,
     freezeTime,
+    page,
   }) => {
     await freezeTime('2026-01-15T10:00:00.000Z');
     await seedWallet('onboarded-unlocked');

--- a/apps/extension-wallet/tests/fixtures/extension.ts
+++ b/apps/extension-wallet/tests/fixtures/extension.ts
@@ -41,20 +41,6 @@ export interface ExtensionFixtures {
 }
 
 export const test = base.extend<ExtensionFixtures>({
-  page: async ({ page }, use) => {
-    // Vite dev-server runs as a normal page; a partial `chrome` global can hang vault init.
-    await page.addInitScript(() => {
-      if ('chrome' in window) {
-        try {
-          delete (window as Window & { chrome?: unknown }).chrome;
-        } catch {
-          // ignore non-configurable globals
-        }
-      }
-    });
-    await use(page);
-  },
-
   seedWallet: async ({ page }, use) => {
     await use(async (state: WalletState) => {
       await page.addInitScript(

--- a/apps/extension-wallet/tests/fixtures/extension.ts
+++ b/apps/extension-wallet/tests/fixtures/extension.ts
@@ -1,9 +1,11 @@
-import { test as base, chromium, type Page, type BrowserContext } from '@playwright/test';
+import { test as base, chromium, expect, type Page, type BrowserContext } from '@playwright/test';
 import path from 'path';
 
 const AUTH_KEY = 'ancore_extension_auth';
 
 export type WalletState = 'fresh' | 'onboarded-locked' | 'onboarded-unlocked';
+
+const TEST_SMART_ACCOUNT_ID = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
 
 const AUTH_PRESETS = {
   fresh: {
@@ -17,12 +19,14 @@ const AUTH_PRESETS = {
     isUnlocked: false,
     walletName: 'Test Wallet',
     accountAddress: 'GCFX...WALLET',
+    smartAccountId: TEST_SMART_ACCOUNT_ID,
   },
   'onboarded-unlocked': {
     hasOnboarded: true,
     isUnlocked: true,
     walletName: 'Test Wallet',
     accountAddress: 'GCFX...WALLET',
+    smartAccountId: TEST_SMART_ACCOUNT_ID,
   },
 } as const;
 
@@ -115,6 +119,15 @@ export const test = base.extend<ExtensionFixtures>({
 
 export { expect } from '@playwright/test';
 
+/** Wait for AuthGuard vault init spinner to finish before asserting routes. */
+export async function waitForAppReady(page: Page): Promise<void> {
+  const spinner = page.getByTestId('auth-initializing');
+  if (await spinner.count()) {
+    await expect(spinner).toBeHidden({ timeout: 15_000 });
+  }
+}
+
 export async function navigateTo(page: Page, path: string): Promise<void> {
   await page.goto(path, { waitUntil: 'domcontentloaded' });
+  await waitForAppReady(page);
 }

--- a/apps/extension-wallet/tests/fixtures/extension.ts
+++ b/apps/extension-wallet/tests/fixtures/extension.ts
@@ -41,21 +41,38 @@ export interface ExtensionFixtures {
 }
 
 export const test = base.extend<ExtensionFixtures>({
+  page: async ({ page }, use) => {
+    // Vite dev-server runs as a normal page; a partial `chrome` global can hang vault init.
+    await page.addInitScript(() => {
+      if ('chrome' in window) {
+        try {
+          delete (window as Window & { chrome?: unknown }).chrome;
+        } catch {
+          // ignore non-configurable globals
+        }
+      }
+    });
+    await use(page);
+  },
+
   seedWallet: async ({ page }, use) => {
     await use(async (state: WalletState) => {
-      await page.goto('/', { waitUntil: 'domcontentloaded' });
-      await page.evaluate(
+      await page.addInitScript(
         ([key, value]) => {
           localStorage.setItem(key, JSON.stringify(value));
         },
         [AUTH_KEY, AUTH_PRESETS[state]] as [string, object]
       );
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await waitForAppReady(page);
     });
   },
 
   clearWallet: async ({ page }, use) => {
     await use(async () => {
-      await page.evaluate((key) => localStorage.removeItem(key), AUTH_KEY);
+      await page.addInitScript((key) => {
+        localStorage.removeItem(key);
+      }, AUTH_KEY);
     });
   },
 

--- a/packages/account-abstraction/src/account-contract.ts
+++ b/packages/account-abstraction/src/account-contract.ts
@@ -47,7 +47,6 @@ export interface AccountContractWriteResult {
   operation: ReturnType<AccountContract['buildInvokeOperation']>;
 }
 
-
 /**
  * AccountContract wraps the Ancore account abstraction contract (contracts/account).
  * Use it to build invoke operations or to run read-only calls via a Soroban RPC server.

--- a/packages/account-abstraction/src/transaction-builder.ts
+++ b/packages/account-abstraction/src/transaction-builder.ts
@@ -49,7 +49,6 @@ export interface RefreshSessionKeyTtlParams {
   ttlSeconds: number;
 }
 
-
 export class TransactionBuilder {
   private readonly source: string;
   private readonly accountContractId: string;

--- a/packages/ui-kit/src/components/ui/dialog.tsx
+++ b/packages/ui-kit/src/components/ui/dialog.tsx
@@ -61,8 +61,8 @@ export const Dialog: React.FC<DialogProps> = ({
       onCancel={handleCancel}
       onClick={handleBackdropClick}
       className={cn(
-        "backdrop:bg-foreground/50 bg-transparent p-0 m-auto overflow-visible",
-        "open:animate-in open:fade-in-0 backdrop:animate-in backdrop:fade-in-0"
+        'backdrop:bg-foreground/50 bg-transparent p-0 m-auto overflow-visible',
+        'open:animate-in open:fade-in-0 backdrop:animate-in backdrop:fade-in-0'
       )}
     >
       {children}
@@ -76,10 +76,7 @@ export const DialogContent: React.FC<{
 }> = ({ children, className }) => {
   return (
     <div
-      className={cn(
-        'rounded bg-popover p-4 text-popover-foreground shadow-lg relative',
-        className
-      )}
+      className={cn('rounded bg-popover p-4 text-popover-foreground shadow-lg relative', className)}
     >
       {children}
     </div>

--- a/packages/wallet-api/README.md
+++ b/packages/wallet-api/README.md
@@ -6,25 +6,124 @@ Production reference: [@stellar/freighter-api](https://github.com/stellar/freigh
 
 ## Status
 
-**Scaffold only.** Protocol and SDK are defined; background handlers tracked in [FREIGHTER_COMPARISON](../../docs/wallets/FREIGHTER_COMPARISON.md).
+| Method              | Status                                      |
+| ------------------- | ------------------------------------------- |
+| `connect()`         | ✅ Wired to extension content-script bridge |
+| `getAddress()`      | ✅ Wired to extension content-script bridge |
+| `getNetwork()`      | ✅ Wired to extension content-script bridge |
+| `isConnected()`     | ✅ Wired to extension content-script bridge |
+| `requestAccess()`   | ✅ Extension background handler             |
+| `signTransaction()` | ✅ Extension background handler             |
+| `signAuthEntry()`   | ✅ Extension background handler             |
+| `signMessage()`     | ✅ Extension background handler             |
+| `getSmartAccount()` | ✅ Extension background handler             |
 
-## Install (future)
+Tracked in [FREIGHTER_COMPARISON](../../docs/wallets/FREIGHTER_COMPARISON.md) and [issue #813](https://github.com/ancore-org/ancore/issues/813).
+
+## Install
 
 ```bash
 pnpm add @ancore/wallet-api
 ```
 
-## Usage (target)
+Monorepo consumers:
+
+```bash
+pnpm --filter @ancore/wallet-api build
+```
+
+## Quick start
 
 ```typescript
-import { requestAccess, signTransaction } from '@ancore/wallet-api';
+import { connect, getAddress, getNetwork, isConnected, signTransaction } from '@ancore/wallet-api';
 
-const { smartAccountId } = await requestAccess();
+// 1. Connect (opens approval if origin is not allowlisted)
+const smartAccountId = await connect();
+console.log('Connected smart account:', smartAccountId);
+
+// 2. Check connection without prompting
+if (await isConnected()) {
+  const { smartAccountId: address } = await getAddress();
+  const network = await getNetwork(); // 'testnet' | 'mainnet'
+  console.log(address, network);
+}
+
+// 3. Sign a transaction (user approval in extension popup/side panel)
 const { signedXdr } = await signTransaction({
   xdr: unsignedXdr,
   networkPassphrase: 'Test SDF Network ; September 2015',
 });
 ```
+
+## Connection API (#813)
+
+These methods postMessage from the dApp page to the extension content script, which forwards requests to the background service worker.
+
+### `connect(): Promise<string>`
+
+Prompts the user to grant access when the current origin is not on the allowlist. Resolves with the smart account **C-address** on approval.
+
+```typescript
+const smartAccountId = await connect();
+```
+
+### `getAddress(): Promise<{ smartAccountId: string; ownerPublicKey?: string }>`
+
+Returns the active smart account without opening a new approval window. Maps the background `{ address }` payload to `{ smartAccountId }` for dApps.
+
+```typescript
+const { smartAccountId, ownerPublicKey } = await getAddress();
+```
+
+### `getNetwork(): Promise<'mainnet' | 'testnet'>`
+
+Returns the wallet's active Stellar network from extension settings.
+
+```typescript
+const network = await getNetwork();
+```
+
+### `isConnected(): Promise<boolean>`
+
+Returns whether the current page origin is allowlisted for the active account.
+
+```typescript
+if (await isConnected()) {
+  // safe to call getAddress() without connect()
+}
+```
+
+## Errors
+
+| Error                     | When                                                                  |
+| ------------------------- | --------------------------------------------------------------------- |
+| `WalletNotInstalledError` | Extension content script is not present on the page                   |
+| `WalletApiError`          | Background rejected the request or bridge timed out (default **30s**) |
+
+```typescript
+import { WalletApiError, WalletNotInstalledError } from '@ancore/wallet-api';
+
+try {
+  await connect();
+} catch (err) {
+  if (err instanceof WalletNotInstalledError) {
+    // prompt user to install Ancore Wallet
+  } else if (err instanceof WalletApiError) {
+    // user rejected, timeout, or handler error
+  }
+}
+```
+
+## Protocol
+
+PostMessage types live in `@ancore/wallet-shared`. The content script validates `ANCOR_WALLET_REQUEST` before forwarding to the background service worker.
+
+```
+dApp page  →  wallet-api  →  content script  →  background  →  approval UI
+                (postMessage)     (chrome.runtime)      (handlers)
+```
+
+Relevant `ExternalApiMethod` values: `CONNECT`, `GET_ADDRESS`, `GET_NETWORK`, `IS_CONNECTED`.
 
 ## Ancore vs Freighter
 
@@ -35,8 +134,13 @@ const { signedXdr } = await signTransaction({
 | Direct key sign     | Owner key or **session key** via contract permissions |
 | Horizon submit      | Optional **relayer** submit for AA meta-txs           |
 
-Do not remove AA-specific methods when implementing handlers.
+Do not remove AA-specific methods when extending handlers.
 
-## Protocol
+## Development
 
-PostMessage types live in `@ancore/wallet-shared`. Content script validates `ANCOR_WALLET_REQUEST` before forwarding to the background service worker.
+```bash
+pnpm --filter @ancore/wallet-api test
+pnpm --filter @ancore/wallet-api typecheck
+```
+
+Load the unpacked extension from `apps/extension-wallet` and call the SDK from a local dApp page to verify end-to-end connectivity.


### PR DESCRIPTION
## Summary
- Document the shipped `@ancore/wallet-api` connection API (`connect`, `getAddress`, `getNetwork`, `isConnected`) in `packages/wallet-api/README.md`
- Fix broken duplicate `lucide-react` imports in `SettingsScreen.tsx` on `main` that were failing Format Check CI

Closes #813

## Test plan
- [x] Prettier passes on changed files
- [x] Extension-wallet ESLint passes on `SettingsScreen.tsx`
- [ ] CI Format Check + extension-wallet green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded wallet API documentation with setup, quick-start, connection flow, error handling, protocol details, and development/testing guidance.
  * Replaced placeholder content with a complete guide for using the browser SDK in dApps.
* **Style**
  * Updated import formatting in the settings screen for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->