### PR TITLE
ci(wallet-api): add npm publish workflow and semver policy

### DIFF
--- a/.github/workflows/publish-wallet-api.yml
+++ b/.github/workflows/publish-wallet-api.yml
@@ -1,0 +1,134 @@
+name: Publish @ancore/wallet-api
+
+on:
+  push:
+    tags:
+      - 'wallet-api/v*'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Publish in dry-run mode (no actual npm publish)'
+        required: false
+        default: 'true'
+        type: choice
+        options: ['true', 'false']
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-wallet-api-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ── Dry-run check — runs on every PR that touches packages/wallet-api/ ────
+  dry-run-check:
+    name: Dry-Run Publish Check
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @ancore/wallet-api
+        run: pnpm --filter @ancore/wallet-api build
+
+      - name: Dry-run publish check
+        run: pnpm --filter @ancore/wallet-api publish --dry-run --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify TypeScript types are present
+        run: |
+          if [ ! -f packages/wallet-api/dist/index.d.ts ]; then
+            echo "ERROR: dist/index.d.ts not found — types will not ship with the package"
+            exit 1
+          fi
+          echo "✓ TypeScript declaration file present at dist/index.d.ts"
+
+  # ── Real publish — triggered by wallet-api/v* tag or release event ────────
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/wallet-api/v')) ||
+      (github.event_name == 'release' && github.event.action == 'published') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @ancore/wallet-api
+        run: pnpm --filter @ancore/wallet-api build
+
+      - name: Run tests
+        run: pnpm --filter @ancore/wallet-api test
+
+      - name: Verify TypeScript types are present
+        run: |
+          if [ ! -f packages/wallet-api/dist/index.d.ts ]; then
+            echo "ERROR: dist/index.d.ts not found — types will not ship with the package"
+            exit 1
+          fi
+
+      - name: Extract version from package.json
+        id: pkg
+        run: |
+          VERSION=$(node -p "require('./packages/wallet-api/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing @ancore/wallet-api@$VERSION"
+
+      - name: Check version not already published
+        run: |
+          VERSION=${{ steps.pkg.outputs.version }}
+          if npm view "@ancore/wallet-api@$VERSION" version 2>/dev/null; then
+            echo "ERROR: @ancore/wallet-api@$VERSION is already published to npm. Bump the version before releasing."
+            exit 1
+          fi
+          echo "✓ Version $VERSION is not yet published — proceeding"
+
+      - name: Publish to npm
+        run: pnpm --filter @ancore/wallet-api publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish summary
+        run: |
+          echo "## Published @ancore/wallet-api@${{ steps.pkg.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Version | \`${{ steps.pkg.outputs.version }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Registry | https://www.npmjs.com/package/@ancore/wallet-api |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Trigger | \`${{ github.event_name }}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/packages/wallet-api/README.md
+++ b/packages/wallet-api/README.md
@@ -140,19 +140,21 @@ Do not remove AA-specific methods when extending handlers.
 
 `@ancore/wallet-api` follows [Semantic Versioning](https://semver.org).
 
-| Range | Meaning | Current state |
-|-------|---------|---------------|
-| `0.x` | Public API is in progress — minor releases may contain breaking changes | **Publishing now** |
-| `1.0.0` | All methods fully wired to extension handlers; API is stable | Gated on [#766](https://github.com/ancore-org/ancore/issues/766) |
-| `^1.x` | Breaking API change → major bump; additive change → minor bump | After 1.0.0 |
+| Range   | Meaning                                                                 | Current state                                                    |
+| ------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `0.x`   | Public API is in progress — minor releases may contain breaking changes | **Publishing now**                                               |
+| `1.0.0` | All methods fully wired to extension handlers; API is stable            | Gated on [#766](https://github.com/ancore-org/ancore/issues/766) |
+| `^1.x`  | Breaking API change → major bump; additive change → minor bump          | After 1.0.0                                                      |
 
 **What "breaking" means for this package:**
+
 - Removing or renaming an exported function or type
 - Changing the resolved type of a Promise return value
 - Adding a required parameter to an existing function
 - Changing error class names (dApps `instanceof`-check these)
 
 **What is not breaking:**
+
 - Adding a new exported function
 - Adding optional parameters (new overload)
 - Extending a return type with new optional fields

--- a/packages/wallet-api/README.md
+++ b/packages/wallet-api/README.md
@@ -136,6 +136,39 @@ Relevant `ExternalApiMethod` values: `CONNECT`, `GET_ADDRESS`, `GET_NETWORK`, `I
 
 Do not remove AA-specific methods when extending handlers.
 
+## Versioning and Semver Policy
+
+`@ancore/wallet-api` follows [Semantic Versioning](https://semver.org).
+
+| Range | Meaning | Current state |
+|-------|---------|---------------|
+| `0.x` | Public API is in progress — minor releases may contain breaking changes | **Publishing now** |
+| `1.0.0` | All methods fully wired to extension handlers; API is stable | Gated on [#766](https://github.com/ancore-org/ancore/issues/766) |
+| `^1.x` | Breaking API change → major bump; additive change → minor bump | After 1.0.0 |
+
+**What "breaking" means for this package:**
+- Removing or renaming an exported function or type
+- Changing the resolved type of a Promise return value
+- Adding a required parameter to an existing function
+- Changing error class names (dApps `instanceof`-check these)
+
+**What is not breaking:**
+- Adding a new exported function
+- Adding optional parameters (new overload)
+- Extending a return type with new optional fields
+
+During `0.x` the package is safe to depend on for integration and testing purposes.
+Pin to an exact version (`"@ancore/wallet-api": "0.1.0"`) until `1.0.0` is released.
+
+### Release process
+
+1. Bump `version` in `packages/wallet-api/package.json`.
+2. Push a git tag: `wallet-api/v<version>` (e.g. `wallet-api/v0.2.0`).
+3. The [publish-wallet-api](.github/workflows/publish-wallet-api.yml) CI workflow
+   builds, tests, and publishes to npm automatically.
+
+The workflow fails if the version is already published — bump the version before tagging.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
Closes #779
Closes #788
Closes #833
Closes #840

## What this adds

### `.github/workflows/publish-wallet-api.yml`

A dedicated CI workflow for `@ancore/wallet-api` with two jobs:

- **`dry-run-check`** — runs on every PR; builds the package and runs
  `pnpm publish --dry-run` to confirm the artifact is publish-ready and
  that `dist/index.d.ts` (TypeScript types) is present.
- **`publish`** — triggered by a `wallet-api/v*` tag, a `release` event,
  or manual dispatch with `dry_run: false`; builds, tests, checks that the
  version isn't already published, then publishes to npm with `NODE_AUTH_TOKEN`.

### `packages/wallet-api/README.md` — Versioning and Semver Policy section

Documents the `0.x` → `1.0.0` progression, what constitutes a breaking
change, and the tagging/release process so contributors know how to ship a
new version.

## Notes

- `package.json` already has the correct `exports` (ESM + CJS + types) and
  `version: "0.1.0"`, so no package config changes were needed.
- The workflow uses `--no-git-checks` so it works from the tag SHA without
  requiring a clean working tree.
- The version-already-published guard (`npm view`) prevents accidental
  re-releases of the same version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated CI workflow to publish the wallet API package to npm based on version tags, published releases, or manual runs.
  * Included a dry-run option to verify build and publish readiness before publishing.
  * Added safeguards to ensure the release version isn’t already present on npm, and included a brief publish summary.

* **Documentation**
  * Updated the wallet API README with a clear SemVer and “breaking vs. not breaking” policy.
  * Documented the release steps (version bump, tagging, and publishing via the automated workflow).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->