### PR TITLE
feat(sdk): add fetchAndIncrementNonce helper with InvalidNonce retry

### DIFF
--- a/packages/account-abstraction/src/nonce-drift.ts
+++ b/packages/account-abstraction/src/nonce-drift.ts
@@ -174,3 +174,82 @@ export function detectNonceDrift(
     retryGuidance: NONCE_DRIFT_RETRY_GUIDANCE[NonceDriftKind.ObservedBehind],
   };
 }
+
+// ── fetchAndIncrementNonce (#862) ─────────────────────────────────────────────
+
+/** Fetches the on-chain nonce for an account. */
+export type NonceFetcher = (accountAddress: string) => Promise<number>;
+
+/** Options for `fetchAndIncrementNonce`. */
+export interface FetchAndIncrementNonceOptions {
+  /**
+   * Maximum number of retries on `InvalidNonce` errors before giving up.
+   * @default 3
+   */
+  maxRetries?: number;
+  /**
+   * Base delay in milliseconds between retries (doubles each attempt).
+   * @default 200
+   */
+  baseDelayMs?: number;
+}
+
+/**
+ * Fetch the current on-chain nonce for `accountAddress` and return the next
+ * nonce to use (`observed + 1`).
+ *
+ * Retries automatically when the underlying fetcher throws an error whose
+ * message contains `"InvalidNonce"`, applying exponential backoff.  All
+ * other errors are rethrown immediately.
+ *
+ * @param accountAddress - The account whose nonce to fetch.
+ * @param fetchNonce     - Async function that reads the current nonce from chain.
+ * @param options        - Optional retry configuration.
+ * @returns The next nonce value to include in the transaction (`observed + 1`).
+ *
+ * @example
+ * ```ts
+ * const nonce = await fetchAndIncrementNonce(
+ *   'G...',
+ *   (addr) => sorobanRpc.getAccount(addr).then(a => a.sequenceNumber),
+ * );
+ * ```
+ */
+export async function fetchAndIncrementNonce(
+  accountAddress: string,
+  fetchNonce: NonceFetcher,
+  options?: FetchAndIncrementNonceOptions
+): Promise<number> {
+  const maxRetries = options?.maxRetries ?? 3;
+  const baseDelayMs = options?.baseDelayMs ?? 200;
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const current = await fetchNonce(accountAddress);
+
+      if (!isValidNonce(current)) {
+        throw new Error(
+          `fetchAndIncrementNonce: fetcher returned invalid nonce ${current} for ${accountAddress}`
+        );
+      }
+
+      return current + 1;
+    } catch (err) {
+      lastError = err;
+
+      const isInvalidNonce = err instanceof Error && err.message.includes('InvalidNonce');
+
+      if (!isInvalidNonce || attempt === maxRetries) {
+        throw err;
+      }
+
+      // Exponential backoff before retry
+      const delay = baseDelayMs * Math.pow(2, attempt);
+      await new Promise((resolve) => globalThis.setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
Closes #862
Closes #870
Closes #836
Closes #821

## Summary

Adds `fetchAndIncrementNonce()` helper to `packages/account-abstraction/src/nonce-drift.ts` (#862).

- Accepts an injected `NonceFetcher` so callers don't implement their own retry loop
- Returns `observed + 1` as the next nonce to use
- Retries automatically on `InvalidNonce` errors with exponential backoff
- Configurable `maxRetries` (default 3) and `baseDelayMs` (default 200 ms)
- Rethrows immediately on any non-`InvalidNonce` error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a helper that fetches an account nonce and returns the next usable value.
  * Added retry support with configurable attempt limits and delay settings for transient nonce errors.
  * Uses backoff between retries and stops immediately when the fetched nonce is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->