### PR TITLE
feat: per-account relay rate limiting (#874) and WalletConnect session approval sheet (#842)

### DIFF
--- a/apps/mobile-wallet/src/components/SessionApprovalSheet.tsx
+++ b/apps/mobile-wallet/src/components/SessionApprovalSheet.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 
+type NamespaceEntry = {
+  chains?: string[];
+  methods?: string[];
+  events?: string[];
+};
+
 export interface SessionProposal {
   id: number;
   params: {
@@ -11,14 +17,8 @@ export interface SessionProposal {
         icons: string[];
       };
     };
-    requiredNamespaces: Record<
-      string,
-      {
-        chains?: string[];
-        methods?: string[];
-        events?: string[];
-      }
-    >;
+    requiredNamespaces: Record<string, NamespaceEntry>;
+    optionalNamespaces?: Record<string, NamespaceEntry>;
   };
 }
 
@@ -33,11 +33,14 @@ export const SessionApprovalSheet: React.FC<SessionApprovalSheetProps> = ({
   onApprove,
   onReject,
 }) => {
-  const { proposer, requiredNamespaces } = proposal.params;
+  const { proposer, requiredNamespaces, optionalNamespaces } = proposal.params;
   const { metadata } = proposer;
 
-  // Extract requested methods from namespaces
-  const requestedMethods = Object.values(requiredNamespaces).flatMap((ns) => ns.methods || []);
+  // Extract requested methods from required and optional namespaces
+  const requestedMethods = [
+    ...Object.values(requiredNamespaces),
+    ...Object.values(optionalNamespaces ?? {}),
+  ].flatMap((ns) => ns.methods ?? []);
 
   return (
     <div className="session-approval-sheet">

--- a/apps/mobile-wallet/src/components/__tests__/SessionApprovalSheet.test.tsx
+++ b/apps/mobile-wallet/src/components/__tests__/SessionApprovalSheet.test.tsx
@@ -1,0 +1,366 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { SessionApprovalSheet, SessionProposal } from '../SessionApprovalSheet';
+import { WalletKitProvider } from '../../providers/WalletKitProvider';
+import { SessionTypes } from '@walletconnect/types';
+
+// ─── Shared mock proposal ────────────────────────────────────────────────────
+
+const mockProposal: SessionProposal = {
+  id: 42,
+  params: {
+    proposer: {
+      metadata: {
+        name: 'Test dApp',
+        description: 'A test decentralized application',
+        url: 'https://testdapp.example.com',
+        icons: ['https://testdapp.example.com/icon.png'],
+      },
+    },
+    requiredNamespaces: {
+      stellar: {
+        chains: ['stellar:pubnet'],
+        methods: ['stellar_signXDR', 'stellar_signAndSubmitXDR'],
+        events: [],
+      },
+    },
+  },
+};
+
+// ─── Mock WalletKit factory (mirrors WalletKitProvider.test.tsx style) ────────
+
+const createMockWalletKit = () => {
+  let sessions: Record<string, SessionTypes.Struct> = {};
+  const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+  return {
+    init: jest.fn().mockResolvedValue(undefined),
+    pair: jest.fn().mockResolvedValue(undefined),
+    approveSession: jest
+      .fn()
+      .mockImplementation(async (params: { id: number; namespaces: Record<string, unknown> }) => {
+        sessions[String(params.id)] = {
+          topic: `topic-${params.id}`,
+          peer: { metadata: { name: 'Test dApp' } },
+          namespaces: params.namespaces,
+        } as SessionTypes.Struct;
+      }),
+    rejectSession: jest.fn().mockResolvedValue(undefined),
+    disconnectSession: jest.fn().mockImplementation(async (params: { topic: string }) => {
+      delete sessions[params.topic];
+    }),
+    getActiveSessions: jest.fn(() => sessions),
+    on: jest.fn((event: string, callback: (...args: unknown[]) => void) => {
+      if (!listeners[event]) listeners[event] = [];
+      listeners[event].push(callback);
+    }),
+    off: jest.fn((event: string, callback: (...args: unknown[]) => void) => {
+      if (listeners[event]) {
+        listeners[event] = listeners[event].filter((cb) => cb !== callback);
+      }
+    }),
+    // Helper: trigger an event with an optional argument (e.g., a proposal)
+    triggerEvent: (event: string, data?: unknown) => {
+      listeners[event]?.forEach((cb) => cb(data));
+    },
+    _reset: () => {
+      sessions = {};
+    },
+  };
+};
+
+// ─── Direct component tests ───────────────────────────────────────────────────
+
+describe('SessionApprovalSheet component', () => {
+  describe('proposal rendering', () => {
+    it('renders the dApp name', () => {
+      render(
+        <SessionApprovalSheet proposal={mockProposal} onApprove={jest.fn()} onReject={jest.fn()} />
+      );
+      expect(screen.getByText('Test dApp')).toBeInTheDocument();
+    });
+
+    it('renders the dApp URL', () => {
+      render(
+        <SessionApprovalSheet proposal={mockProposal} onApprove={jest.fn()} onReject={jest.fn()} />
+      );
+      expect(screen.getByText('https://testdapp.example.com')).toBeInTheDocument();
+    });
+
+    it('renders the dApp description', () => {
+      render(
+        <SessionApprovalSheet proposal={mockProposal} onApprove={jest.fn()} onReject={jest.fn()} />
+      );
+      expect(screen.getByText('A test decentralized application')).toBeInTheDocument();
+    });
+
+    it('renders the dApp icon', () => {
+      render(
+        <SessionApprovalSheet proposal={mockProposal} onApprove={jest.fn()} onReject={jest.fn()} />
+      );
+      const img = screen.getByRole('img');
+      expect(img).toHaveAttribute('src', 'https://testdapp.example.com/icon.png');
+      expect(img).toHaveAttribute('alt', 'Test dApp icon');
+    });
+
+    it('renders required namespace methods', () => {
+      render(
+        <SessionApprovalSheet proposal={mockProposal} onApprove={jest.fn()} onReject={jest.fn()} />
+      );
+      expect(screen.getByText('stellar_signXDR')).toBeInTheDocument();
+      expect(screen.getByText('stellar_signAndSubmitXDR')).toBeInTheDocument();
+    });
+
+    it('renders optional namespace methods alongside required ones', () => {
+      const proposalWithOptional: SessionProposal = {
+        ...mockProposal,
+        params: {
+          ...mockProposal.params,
+          optionalNamespaces: {
+            stellar: {
+              methods: ['stellar_signMessage'],
+              events: [],
+            },
+          },
+        },
+      };
+      render(
+        <SessionApprovalSheet
+          proposal={proposalWithOptional}
+          onApprove={jest.fn()}
+          onReject={jest.fn()}
+        />
+      );
+      expect(screen.getByText('stellar_signXDR')).toBeInTheDocument();
+      expect(screen.getByText('stellar_signMessage')).toBeInTheDocument();
+    });
+
+    it('does not render icon when icons array is empty', () => {
+      const proposalNoIcon: SessionProposal = {
+        ...mockProposal,
+        params: {
+          ...mockProposal.params,
+          proposer: {
+            metadata: {
+              ...mockProposal.params.proposer.metadata,
+              icons: [],
+            },
+          },
+        },
+      };
+      render(
+        <SessionApprovalSheet
+          proposal={proposalNoIcon}
+          onApprove={jest.fn()}
+          onReject={jest.fn()}
+        />
+      );
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('action buttons', () => {
+    it('renders Connect and Reject buttons', () => {
+      render(
+        <SessionApprovalSheet proposal={mockProposal} onApprove={jest.fn()} onReject={jest.fn()} />
+      );
+      expect(screen.getByRole('button', { name: /Connect/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Reject/i })).toBeInTheDocument();
+    });
+
+    it('calls onApprove when Connect is clicked', () => {
+      const onApprove = jest.fn();
+      render(
+        <SessionApprovalSheet proposal={mockProposal} onApprove={onApprove} onReject={jest.fn()} />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /Connect/i }));
+      expect(onApprove).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onReject when Reject is clicked', () => {
+      const onReject = jest.fn();
+      render(
+        <SessionApprovalSheet proposal={mockProposal} onApprove={jest.fn()} onReject={onReject} />
+      );
+      fireEvent.click(screen.getByRole('button', { name: /Reject/i }));
+      expect(onReject).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+// ─── Integration tests via WalletKitProvider ─────────────────────────────────
+
+describe('SessionApprovalSheet via WalletKitProvider', () => {
+  it('does not show the sheet before a session_proposal event', () => {
+    const mockWalletKit = createMockWalletKit();
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit as any}>
+        <div data-testid="app-content">App</div>
+      </WalletKitProvider>
+    );
+
+    expect(screen.getByTestId('app-content')).toBeInTheDocument();
+    expect(screen.queryByText('Test dApp')).not.toBeInTheDocument();
+  });
+
+  it('shows the sheet with proposal data when session_proposal fires', async () => {
+    const mockWalletKit = createMockWalletKit();
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit as any}>
+        <div>App</div>
+      </WalletKitProvider>
+    );
+
+    act(() => {
+      mockWalletKit.triggerEvent('session_proposal', mockProposal);
+    });
+
+    expect(screen.getByText('Test dApp')).toBeInTheDocument();
+    expect(screen.getByText('https://testdapp.example.com')).toBeInTheDocument();
+    expect(screen.getByText('stellar_signXDR')).toBeInTheDocument();
+    expect(screen.getByText('stellar_signAndSubmitXDR')).toBeInTheDocument();
+  });
+
+  it('calls walletKit.approveSession with the proposal id and built namespaces on approve', async () => {
+    const mockWalletKit = createMockWalletKit();
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit as any}>
+        <div>App</div>
+      </WalletKitProvider>
+    );
+
+    act(() => {
+      mockWalletKit.triggerEvent('session_proposal', mockProposal);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Connect/i }));
+
+    await waitFor(() => {
+      expect(mockWalletKit.approveSession).toHaveBeenCalledWith({
+        id: 42,
+        namespaces: expect.objectContaining({
+          stellar: expect.objectContaining({
+            methods: ['stellar_signXDR', 'stellar_signAndSubmitXDR'],
+            chains: ['stellar:pubnet'],
+          }),
+        }),
+      });
+    });
+  });
+
+  it('calls walletKit.rejectSession with id and reason code 4001 on reject', async () => {
+    const mockWalletKit = createMockWalletKit();
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit as any}>
+        <div>App</div>
+      </WalletKitProvider>
+    );
+
+    act(() => {
+      mockWalletKit.triggerEvent('session_proposal', mockProposal);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Reject/i }));
+
+    await waitFor(() => {
+      expect(mockWalletKit.rejectSession).toHaveBeenCalledWith({
+        id: 42,
+        reason: {
+          code: 4001,
+          message: expect.any(String),
+        },
+      });
+    });
+  });
+
+  it('dismisses the sheet after approve', async () => {
+    const mockWalletKit = createMockWalletKit();
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit as any}>
+        <div>App</div>
+      </WalletKitProvider>
+    );
+
+    act(() => {
+      mockWalletKit.triggerEvent('session_proposal', mockProposal);
+    });
+
+    expect(screen.getByText('Test dApp')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Connect/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Test dApp')).not.toBeInTheDocument();
+    });
+  });
+
+  it('dismisses the sheet after reject', async () => {
+    const mockWalletKit = createMockWalletKit();
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit as any}>
+        <div>App</div>
+      </WalletKitProvider>
+    );
+
+    act(() => {
+      mockWalletKit.triggerEvent('session_proposal', mockProposal);
+    });
+
+    expect(screen.getByText('Test dApp')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Reject/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Test dApp')).not.toBeInTheDocument();
+    });
+  });
+
+  it('auto-dismisses the sheet after 60 seconds', async () => {
+    jest.useFakeTimers();
+    const mockWalletKit = createMockWalletKit();
+
+    render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit as any}>
+        <div>App</div>
+      </WalletKitProvider>
+    );
+
+    act(() => {
+      mockWalletKit.triggerEvent('session_proposal', mockProposal);
+    });
+
+    expect(screen.getByText('Test dApp')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Test dApp')).not.toBeInTheDocument();
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('unsubscribes from session_proposal when the provider unmounts', () => {
+    const mockWalletKit = createMockWalletKit();
+
+    const { unmount } = render(
+      <WalletKitProvider projectId="test-project-id" walletKitInstance={mockWalletKit as any}>
+        <div>App</div>
+      </WalletKitProvider>
+    );
+
+    expect(mockWalletKit.on).toHaveBeenCalledWith('session_proposal', expect.any(Function));
+
+    unmount();
+
+    expect(mockWalletKit.off).toHaveBeenCalledWith('session_proposal', expect.any(Function));
+  });
+});

--- a/apps/mobile-wallet/src/providers/WalletKitProvider.tsx
+++ b/apps/mobile-wallet/src/providers/WalletKitProvider.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { SessionTypes } from '@walletconnect/types';
+import { SessionApprovalSheet, SessionProposal } from '../components/SessionApprovalSheet';
 
 // Abstract WalletKit interface - to be implemented with actual @reown/walletkit API
 interface IWalletKit {
@@ -15,8 +16,8 @@ interface IWalletKit {
     reason: { code: number; message: string };
   }): Promise<void>;
   getActiveSessions(): SessionTypes.Struct[];
-  on(event: string, callback: () => void): void;
-  off(event: string, callback: () => void): void;
+  on(event: string, callback: (...args: unknown[]) => void): void;
+  off(event: string, callback: (...args: unknown[]) => void): void;
 }
 
 interface WalletConnectContextType {
@@ -30,6 +31,8 @@ interface WalletConnectContextType {
   rejectSession: (proposal: { id: number }) => Promise<void>;
   disconnectSession: (topic: string) => Promise<void>;
   isInitialized: boolean;
+  pendingProposal: SessionProposal | null;
+  clearPendingProposal: () => void;
 }
 
 const WalletConnectContext = createContext<WalletConnectContextType | null>(null);
@@ -48,6 +51,7 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
   const [walletKit] = useState<IWalletKit | null>(walletKitInstance || null);
   const [sessions, setSessions] = useState<SessionTypes.Struct[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
+  const [pendingProposal, setPendingProposal] = useState<SessionProposal | null>(null);
 
   useEffect(() => {
     // Skip initialization if walletKitInstance is provided (for testing)
@@ -171,6 +175,52 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
     }
   };
 
+  const clearPendingProposal = () => setPendingProposal(null);
+
+  // Subscribe to session_proposal events from WalletKit
+  useEffect(() => {
+    if (!walletKit || !isInitialized) return;
+
+    const handleSessionProposal = (...args: unknown[]) => {
+      setPendingProposal(args[0] as SessionProposal);
+    };
+
+    walletKit.on('session_proposal', handleSessionProposal);
+
+    return () => {
+      walletKit.off('session_proposal', handleSessionProposal);
+    };
+  }, [walletKit, isInitialized]);
+
+  // Auto-dismiss the sheet after 60 seconds if the user hasn't acted
+  useEffect(() => {
+    if (!pendingProposal) return;
+
+    const timer = setTimeout(() => {
+      setPendingProposal(null);
+    }, 60_000);
+
+    return () => clearTimeout(timer);
+  }, [pendingProposal]);
+
+  const handleSheetApprove = async () => {
+    if (!pendingProposal) return;
+    try {
+      await approveSession(pendingProposal);
+    } finally {
+      setPendingProposal(null);
+    }
+  };
+
+  const handleSheetReject = async () => {
+    if (!pendingProposal) return;
+    try {
+      await rejectSession({ id: pendingProposal.id });
+    } finally {
+      setPendingProposal(null);
+    }
+  };
+
   const value: WalletConnectContextType = {
     walletKit,
     sessions,
@@ -179,9 +229,22 @@ export const WalletKitProvider: React.FC<WalletKitProviderProps> = ({
     rejectSession,
     disconnectSession,
     isInitialized,
+    pendingProposal,
+    clearPendingProposal,
   };
 
-  return <WalletConnectContext.Provider value={value}>{children}</WalletConnectContext.Provider>;
+  return (
+    <WalletConnectContext.Provider value={value}>
+      {children}
+      {pendingProposal && (
+        <SessionApprovalSheet
+          proposal={pendingProposal}
+          onApprove={handleSheetApprove}
+          onReject={handleSheetReject}
+        />
+      )}
+    </WalletConnectContext.Provider>
+  );
 };
 
 export const useWalletConnect = (): WalletConnectContextType => {

--- a/services/relayer/src/middleware/__tests__/accountRateLimiter.test.ts
+++ b/services/relayer/src/middleware/__tests__/accountRateLimiter.test.ts
@@ -1,0 +1,53 @@
+import express from 'express';
+import request from 'supertest';
+import { createAccountRateLimiterMiddleware } from '../accountRateLimiter';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildApp(rpm = 30) {
+  const app = express();
+  app.use(express.json());
+  app.post('/test', createAccountRateLimiterMiddleware({ rpm }), (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+  return app;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('createAccountRateLimiterMiddleware', () => {
+  it('allows exactly rpm requests and blocks the (rpm+1)th from the same account', async () => {
+    const RPM = 30;
+    const app = buildApp(RPM);
+    const body = { sessionKey: 'a'.repeat(64) };
+
+    // First 30 requests should all succeed
+    for (let i = 0; i < RPM; i++) {
+      const res = await request(app).post('/test').send(body);
+      expect(res.status).toBe(200);
+    }
+
+    // 31st request must be rate-limited
+    const limited = await request(app).post('/test').send(body);
+    expect(limited.status).toBe(429);
+    expect(limited.body).toEqual({ error: 'RATE_LIMITED', retryAfter: 60 });
+  });
+
+  it("does not apply one account's limit to a different account (per-account isolation)", async () => {
+    const RPM = 30;
+    const app = buildApp(RPM);
+    const bodyA = { sessionKey: 'a'.repeat(64) };
+    const bodyB = { sessionKey: 'b'.repeat(64) };
+
+    // Exhaust account A's quota
+    for (let i = 0; i < RPM; i++) {
+      await request(app).post('/test').send(bodyA);
+    }
+    const limitedA = await request(app).post('/test').send(bodyA);
+    expect(limitedA.status).toBe(429);
+
+    // Account B should still be under its own quota
+    const resB = await request(app).post('/test').send(bodyB);
+    expect(resB.status).toBe(200);
+  });
+});

--- a/services/relayer/src/middleware/accountRateLimiter.ts
+++ b/services/relayer/src/middleware/accountRateLimiter.ts
@@ -1,0 +1,83 @@
+import { Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
+
+/**
+ * Resolves the per-account rate-limit (requests per minute) from options or env.
+ *
+ * Priority: options.rpm → RELAY_RATE_LIMIT_RPM env var → 30 (default).
+ * Guards against NaN and non-positive values by falling back to 30.
+ */
+function resolveRpm(rpm?: number): number {
+  if (rpm !== undefined && rpm > 0) return rpm;
+  const fromEnv = Number(process.env.RELAY_RATE_LIMIT_RPM);
+  if (!isNaN(fromEnv) && fromEnv > 0) return fromEnv;
+  return 30;
+}
+
+/**
+ * Derives a stable account key from the relay request body.
+ *
+ * Resolution order (first truthy value wins):
+ *   1. req.body.sender              – explicit sender address (future schema extension)
+ *   2. req.body.parameters.sender   – sender nested in parameters map
+ *   3. req.body.parameters.account  – account nested in parameters map
+ *   4. req.body.parameters.contractAddress – contract address as a proxy identity
+ *   5. req.body.sessionKey          – the session key itself (always present per current schema)
+ *   6. 'unknown'                    – last-resort stable fallback
+ *
+ * NOTE: The current relay request schema has NO top-level `sender` field.
+ * `sessionKey` (a 64-hex string) is the primary session identity and is
+ * almost always present after body parsing, making it the practical default.
+ *
+ * We deliberately do NOT fall back to IP — the existing `relayLimiter` already
+ * covers IP-based limiting, and returning an IP from a custom keyGenerator
+ * triggers express-rate-limit v7's IPv6-key validation error.
+ *
+ * TODO (scaling): Replace the default in-memory store with a Redis store
+ * (e.g. `rate-limit-redis`) so limits are shared across multiple relayer
+ * instances. The keyGenerator and handler below are store-agnostic.
+ */
+function deriveAccountKey(req: Request): string {
+  const body = req.body as Record<string, unknown> | undefined;
+  const params = (body?.['parameters'] ?? {}) as Record<string, unknown>;
+
+  return (
+    (body?.['sender'] as string | undefined) ??
+    (params['sender'] as string | undefined) ??
+    (params['account'] as string | undefined) ??
+    (params['contractAddress'] as string | undefined) ??
+    (body?.['sessionKey'] as string | undefined) ??
+    'unknown'
+  );
+}
+
+export interface AccountRateLimiterOptions {
+  /** Requests per minute allowed per account. Defaults to 30 (or RELAY_RATE_LIMIT_RPM env var). */
+  rpm?: number;
+}
+
+/**
+ * Creates an Express middleware that enforces per-account rate limiting on
+ * relay requests. Independent of the existing IP-based limiter.
+ *
+ * Default: 30 requests / minute / account. Configurable via `RELAY_RATE_LIMIT_RPM`.
+ * Exceeding the limit yields HTTP 429 with `{ error: 'RATE_LIMITED', retryAfter: 60 }`.
+ *
+ * Storage: in-memory (express-rate-limit default). For multi-instance deployments,
+ * swap in a Redis store via `rate-limit-redis`.
+ */
+export function createAccountRateLimiterMiddleware(options?: AccountRateLimiterOptions) {
+  return rateLimit({
+    windowMs: 60_000,
+    limit: resolveRpm(options?.rpm),
+    standardHeaders: true,
+    legacyHeaders: false,
+    // No validate overrides needed: our keyGenerator always returns a non-IP
+    // string (hex session key or a named account address), so express-rate-limit
+    // v7's IP validation never fires.
+    keyGenerator: deriveAccountKey,
+    handler(_req: Request, res: Response) {
+      res.status(429).json({ error: 'RATE_LIMITED', retryAfter: 60 });
+    },
+  });
+}

--- a/services/relayer/src/server.ts
+++ b/services/relayer/src/server.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { RelayService } from './services/relayService';
 import { createStellarSubmitterFromEnv } from './services/stellarSubmitter';
 import { createAuthMiddleware } from './middleware/auth';
+import { createAccountRateLimiterMiddleware } from './middleware/accountRateLimiter';
 import { createIdempotencyMiddleware } from './middleware/idempotency';
 import { createPayloadGuardMiddleware } from './middleware/payloadGuard';
 import { createRequestLoggerMiddleware } from './middleware/requestLogger';
@@ -138,6 +139,9 @@ export function createApp(
     },
   });
 
+  // Per-account rate limiting for relay execute: 30 req/min per account (independent of IP limiter above)
+  const accountLimiter = createAccountRateLimiterMiddleware();
+
   // Rate limiting for status
   const statusLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
@@ -182,7 +186,15 @@ export function createApp(
 
   const validateScheduledTransfer = validateBody(createScheduledTransferSchema);
 
-  app.post('/relay/execute', auth, relayLimiter, validate, idempotency, executeHandler);
+  app.post(
+    '/relay/execute',
+    auth,
+    relayLimiter,
+    accountLimiter,
+    validate,
+    idempotency,
+    executeHandler
+  );
   app.post('/relay/validate', auth, relayLimiter, validate, validateHandler);
   app.get('/relay/status', statusLimiter, (_req, res) => res.json(relayService.health()));
   app.get('/health', healthHandler);


### PR DESCRIPTION
## Summary

Two self-contained additions:

### RELAYER — per-account rate limiting (#874)
- New `accountRateLimiter` middleware (`services/relayer/src/middleware/accountRateLimiter.ts`) applied to `POST /relay/execute`, independent of the existing IP-based `relayLimiter`.
- Default **30 requests/min/account**, configurable via `RELAY_RATE_LIMIT_RPM`.
- On exceed: `429 { "error": "RATE_LIMITED", "retryAfter": 60 }`.
- In-memory store for the MVP; Redis (`rate-limit-redis`) documented as the scaling path.
- **Key generator note:** the issue assumed `req.body.sender`, but the current relay request schema has no top-level `sender`. The limiter resolves the account identity in priority order `sender → parameters.sender → parameters.account → parameters.contractAddress → sessionKey`, so it keys on `sessionKey` today (always present) and automatically uses an explicit account/C-address if the schema later carries one. It deliberately does not fall back to IP (that is the existing limiter's job).

### MOBILE — WalletConnect session approval sheet (#842)
- Wired the WalletKit `session_proposal` event in `WalletKitProvider` to open `SessionApprovalSheet` with the live proposal.
- Sheet shows dApp name, icon, description, URL, and requested methods (required + optional namespaces).
- Approve/Reject route through the provider's existing `approveSession`/`rejectSession` (reject uses `{ code: 4001 }`).
- Auto-dismiss on action or after a 60s timeout.

## Test plan
- [x] Relayer: `npx jest src/middleware/__tests__/accountRateLimiter.test.ts` — 2 passing (quota exhaustion at 31st request + per-account isolation).
- [x] Mobile: new `SessionApprovalSheet.test.tsx` — 18 passing (rendering, approve/reject calls, dismiss-on-action, 60s auto-dismiss); full mobile suite 248 pass / 1 pre-existing skip.
- [x] Type-check clean for all touched files (remaining `tsc` errors are pre-existing, in unbuilt workspace packages I did not touch).

## Note
`main` currently fails `pnpm build` due to a pre-existing, unrelated syntax error (duplicated `<SettingItem` JSX tag in `apps/extension-wallet/src/screens/Settings/SettingsScreen.tsx`, from #908) — out of scope for this PR. My changed packages (`@ancore/relayer`, `@ancore/mobile-wallet`) build and test cleanly.

Closes #874
Closes #842
Closes #875
Closes #861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session approval support for optional namespace details in the mobile wallet, with approval dialogs now showing all requested methods.
  * Introduced per-account request throttling on relay execution to better protect service stability.

* **Bug Fixes**
  * Session approval prompts now auto-close after approval, rejection, or after a timeout.
  * Relay requests now return a clear rate-limit response when limits are exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->