### PR TITLE
docs: implement integration guide, session keys guide, and passkey RFC

### DIFF
--- a/docs/guides/session-keys.md
+++ b/docs/guides/session-keys.md
@@ -1,0 +1,102 @@
+# Session Key Lifecycle Guide
+
+Ancore uses Session Keys to enable seamless, secure, and scoped interactions between dApps and smart accounts. Instead of prompting users for every single micro-transaction (like in-game moves or trustline creation), users can grant scoped, time-bound execution rights to a temporary key.
+
+---
+
+## What is a Session Key?
+
+A **Session Key** is a time-limited Ed25519 or P-256 public key registered directly on-chain within the smart account contract. Its authorization is strictly scoped:
+- **Time Bound**: It automatically expires after a specific timestamp or TTL (Time-To-Live).
+- **Scope Bound**: It can be restricted to specific contract addresses, function names, or maximum transaction values.
+- **Revocable**: The master key (owner) can revoke the session key on-chain at any time.
+
+---
+
+## Creating a Session Key
+
+Session keys are created by generating a temporary key pair on the client side and registering the public key on the smart account contract via the `add_session_key()` method.
+
+### Code Sample (SDK)
+
+```typescript
+import { AncoreClient, SessionPermission } from '@ancore/core-sdk';
+import { Keypair } from '@stellar/stellar-sdk';
+
+// Generate temporary session key
+const sessionKeypair = Keypair.random();
+
+const tx = await ancoreClient.createSessionKey({
+  publicKey: sessionKeypair.publicKey(),
+  permissions: SessionPermission.EXECUTE,
+  expiresAt: Math.floor(Date.now() / 1000) + 3600, // Expires in 1 hour
+});
+// Submit tx with master account signature to register the key on-chain
+```
+
+---
+
+## Permission Bits Explained
+
+Permissions for session keys are represented on-chain as a bitmask (integers):
+- **`PERMISSION_EXECUTE = 1`**: Grants the session key permission to sign and execute general operations on behalf of the smart account within defined scope rules.
+- **`None / Unrestricted`**: Default fallback. If no custom scopes are defined, permissions apply generally according to the bitmask.
+
+---
+
+## dApp Session Key Request
+
+dApps can request a session key from the user's Ancore Wallet extension or mobile app via the `@ancore/wallet-api`.
+
+```javascript
+import { requestSessionKey } from '@ancore/wallet-api';
+
+const sessionDetails = await requestSessionKey({
+  allowlist: ['CB...contractAddress'],
+  methods: ['play_game', 'mint_token'],
+  maxAmount: '100.0000000',
+  durationSeconds: 3600
+});
+
+console.log("Registered Session Key:", sessionDetails.publicKey);
+```
+
+---
+
+## Using a Session Key
+
+Once registered, the session key signs a relay payload (transaction parameters + nonce + fee limit). The dApp sends this payload to the Ancore Relayer, which pays the gas fee and submits it to the Soroban contract.
+
+```typescript
+const relayPayload = {
+  contractId: 'CB...',
+  functionName: 'play_game',
+  args: [...],
+  nonce: await contract.getNonce(),
+};
+
+const signature = sessionKeypair.sign(hashPayload(relayPayload));
+await relayer.submit({ relayPayload, signature });
+```
+
+---
+
+## Revoking a Session Key
+
+If a user wants to invalidate a session key before its natural expiration, they can trigger a revocation transaction.
+
+### Code Sample (SDK)
+
+```typescript
+const tx = await ancoreClient.revokeSessionKey({
+  publicKey: sessionKeyPublicKey
+});
+// Sign with master key and submit. The contract invalidates the key immediately.
+```
+
+---
+
+## Expiry and TTL
+
+- **On-chain Expiry**: The contract checks `expiresAt` during every transaction simulation/execution. If the block time exceeds `expiresAt`, the transaction fails with `SESSION_KEY_EXPIRED`.
+- **State Cleanup / TTL**: To prevent state bloat, session key records are kept under Soroban temporary storage. If the storage TTL expires without a refresh, the key is evicted from the ledger.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -1,28 +1,140 @@
-# Integration Guide
+# Ancore Integration Guide
+
+This document contains two main sections:
+1. **[dApp Integration Guide](#dapp-integration-guide)** — For external developers integrating `@ancore/wallet-api` in their dApps.
+2. **[Internal Integration Guide](#internal-integration-guide)** — For internal Ancore teams working on the extension, mobile wallet, or dashboard.
+
+---
+
+# dApp Integration Guide
+
+## Quick Start
+
+Integrating Ancore into your Stellar/Soroban dApp is designed to be as close to Freighter as possible, but with additional features for Account Abstraction (AA) and session keys.
+
+### 1. Installation
+Install the Ancore wallet API wrapper:
+```bash
+npm install @ancore/wallet-api
+```
+
+### 2. Connect Wallet
+Request permission to connect and retrieve the user's smart account address:
+```javascript
+import { connect, getAddress } from '@ancore/wallet-api';
+
+try {
+  // Requests connection
+  await connect();
+  const address = await getAddress();
+  console.log("Connected smart account address:", address);
+} catch (error) {
+  console.error("Connection failed", error);
+}
+```
+
+### 3. Sign a Transaction
+Sign a Stellar transaction envelope (XDR):
+```javascript
+import { signTransaction } from '@ancore/wallet-api';
+
+try {
+  const signedXdr = await signTransaction({
+    xdr: 'AAAAAgAAAAD...',
+    network: 'TESTNET',
+  });
+  console.log("Signed transaction XDR:", signedXdr);
+} catch (error) {
+  console.error("Signing rejected by user", error);
+}
+```
+
+---
+
+## Smart Account Differences (C-Address vs G-Address)
+
+Ancore is a smart contract wallet (Account Abstraction).
+- **C-Address**: The address returned by `getAddress()` is a contract address (starting with `C...`), unlike traditional Stellar accounts which start with `G...`.
+- **Targeting Payments**: When building payment operations targeting an Ancore account, use contract-compatible payment operations (e.g., Soroban token transfers) instead of classic Stellar asset transfers, or ensure your dApp supports contract destinations.
+
+---
+
+## Session Keys for Gasless/Promptless Transactions
+
+dApps can request a scoped session key to sign transactions in the background without prompting the user for every action.
+
+```javascript
+import { requestSessionKey } from '@ancore/wallet-api';
+
+try {
+  const session = await requestSessionKey({
+    allowlist: ['CB...contractAddress'],
+    methods: ['play_game'],
+    maxAmount: '50.0000000',
+    durationSeconds: 3600, // 1 hour session
+  });
+  
+  console.log("Active Session Key Public Key:", session.publicKey);
+} catch (error) {
+  console.error("Session key request denied", error);
+}
+```
+
+---
+
+## Smart Account Authorization (`signAuthEntry` / SEP-43)
+
+For Soroban-based smart contract authorization, use the SEP-43 signature delegation pattern:
+
+```javascript
+import { signAuthEntry } from '@ancore/wallet-api';
+
+const signedEntry = await signAuthEntry({
+  entry: authEntryXdr,
+  network: 'TESTNET',
+});
+```
+
+---
+
+## Error Handling
+
+The API throws typed errors representing specific user interactions or system boundaries:
+- `AncoreUserRejectedError`: The user declined the connection or transaction signature request.
+- `AncoreTimeoutError`: The signature request timed out.
+- `AncoreNotConnectedError`: Triggered when attempting to sign before calling `connect()`.
+
+```javascript
+import { signTransaction, AncoreUserRejectedError } from '@ancore/wallet-api';
+
+try {
+  await signTransaction({ xdr });
+} catch (err) {
+  if (err instanceof AncoreUserRejectedError) {
+    showUserToast("Signature declined by user.");
+  } else {
+    showUserToast("An unexpected error occurred.");
+  }
+}
+```
+
+---
+
+## Migration from Freighter
+
+Migrating from `@stellar/freighter-api` to `@ancore/wallet-api` requires changing the import source; the base method signatures are backward-compatible:
+
+```diff
+- import { connect, getAddress, signTransaction } from "@stellar/freighter-api";
++ import { connect, getAddress, signTransaction } from "@ancore/wallet-api";
+```
+
+---
+
+# Internal Integration Guide
 
 > Team guidelines for integrating with Ancore contract methods and SDK wrappers.  
 > Issue #287 — prevents integration drift across extension, mobile, and dashboard teams.  
-> Last updated: 2026-04-24
-
----
-
-## Purpose
-
-This guide establishes a shared process so that the extension, mobile, and
-dashboard teams use the same interface contracts, error handling patterns, and
-update workflow. It is the companion to the reference docs:
-
-| Document | What it covers |
-|----------|---------------|
-| [`api-reference.yaml`](./api-reference.yaml) | Machine-readable spec (source of truth) |
-| [`contract-methods.md`](./contract-methods.md) | Contract entrypoints, params, errors, events |
-| [`sdk-wrappers.md`](./sdk-wrappers.md) | SDK wrapper methods and error hierarchy |
-| [`examples/session-key-execute.md`](./examples/session-key-execute.md) | Session-key execute flow |
-| [`examples/send-payment.md`](./examples/send-payment.md) | Payment flow |
-| [`architecture/OVERVIEW.md#send-flow`](./architecture/OVERVIEW.md#send-flow) | End-to-end send sequence (extension → SDK → relayer → contract → Horizon) |
-| [`services/relayer/README.md`](../services/relayer/README.md) | Relayer API, error codes, and client handling guide |
-
----
 
 ## Package responsibilities
 
@@ -141,9 +253,6 @@ When a client calls the relayer (`POST /relay/execute` or `POST /relay/validate`
 failures are returned as a `422` response with a typed `error.code`. Clients **must** handle all
 codes explicitly — do not swallow or re-throw a bare `Error` without mapping it.
 
-> Full error-handling pseudocode is in [`services/relayer/README.md — Client handling guide`](../services/relayer/README.md#error-codes).
-> This section complements issue #573 (relayer OpenAPI alignment).
-
 ### Error code table
 
 | Code | HTTP status | Client action |
@@ -156,44 +265,6 @@ codes explicitly — do not swallow or re-throw a bare `Error` without mapping i
 | `UNAUTHORIZED` | 401 | Re-authenticate and obtain a new Bearer token |
 | `VALIDATION_ERROR` | 400 | Fix the request shape at the call site (programming error) |
 | `INTERNAL_ERROR` | 500 | Log and surface a generic retry message; do not expose internals |
-
-### Handling contract
-
-```typescript
-switch (relayError.code) {
-  case 'INVALID_SIGNATURE':
-    await resignAndRetry(request);
-    break;
-  case 'SESSION_KEY_EXPIRED':
-    promptReAuthentication();
-    break;
-  case 'NONCE_REPLAY':
-    await retryWithFreshNonce(request);
-    break;
-  case 'GAS_LIMIT_EXCEEDED':
-  case 'SIMULATION_FAILED':
-    showUserError('Transaction cannot be submitted. Check your inputs.');
-    break;
-  case 'UNAUTHORIZED':
-    redirectToLogin();
-    break;
-  case 'VALIDATION_ERROR':
-    // Programming error — fix the call site, not a user-facing issue.
-    throw relayError;
-  default:
-    showUserError('Something went wrong. Please try again.');
-}
-```
-
-### Cross-check script
-
-To verify that the codes documented here stay in sync with the relayer's TypeScript enum, run:
-
-```bash
-grep -r "RelayErrorCode\|error\.code" services/relayer/src/types --include="*.ts"
-```
-
-All codes listed in `RelayErrorCode` (in `services/relayer/src/types/`) must appear in the table above.
 
 ---
 
@@ -217,21 +288,9 @@ const invocation = client.addSessionKey({
 **Checking if a key is still active** (before using it)
 
 ```typescript
-// is_session_key_active and refresh_session_key_ttl are contract entrypoints
-// with no TypeScript wrapper in AccountContract. Invoke them via a raw simulation:
 const activeInvocation = contract.call('is_session_key_active', publicKeyScVal);
-// Or check expiry client-side from a stored SessionKey:
 const sessionKey = await contract.getSessionKey(publicKey, readOptions);
-const isActive = sessionKey !== null && sessionKey.expiresAt > Date.now(); // expiresAt is ms in TS types
-```
-
-**Refreshing storage TTL** (before Soroban evicts the entry)
-
-```typescript
-// refresh_session_key_ttl has no TypeScript wrapper in AccountContract.
-// Invoke it via the contract's call() method:
-const op = contract.call('refresh_session_key_ttl', publicKeyScVal);
-// Build and submit this operation (no owner auth required).
+const isActive = sessionKey !== null && sessionKey.expiresAt > Date.now();
 ```
 
 **Revoking a key**
@@ -240,71 +299,3 @@ const op = contract.call('refresh_session_key_ttl', publicKeyScVal);
 const invocation = client.revokeSessionKey({ publicKey: sessionKeyPublicKey });
 // Build and submit with owner signature
 ```
-
----
-
-## Keeping documentation in sync
-
-When you change a contract entrypoint or SDK method signature:
-
-1. Update `docs/api-reference.yaml` — this is the source of truth
-2. Update the relevant section in `contract-methods.md` or `sdk-wrappers.md`
-3. Update any affected examples in `docs/examples/`
-4. If it is a breaking change, open an RFC and bump the major version
-
-**Breaking change definition**
-
-- Removing or renaming a parameter
-- Changing a parameter type
-- Adding a required parameter
-- Changing a return type
-- Removing an error code
-
-Adding optional parameters or new error codes is non-breaking.
-
----
-
-## Team-specific notes
-
-### Extension wallet (`apps/extension-wallet`)
-
-- Session keys are stored in encrypted extension storage via `SecureStorageManager`
-- Sign auth entries through the background service message bus (see
-  [`examples/session-key-execute.md`](./examples/session-key-execute.md#extension-wallet-appsextension-wallet))
-- Use `chrome.runtime.sendMessage` for cross-context signing
-
-### Mobile wallet (`apps/mobile-wallet`)
-
-- Session keys are stored in the device keychain / secure enclave
-- Sign transactions using the platform keychain API
-- Handle `SimulationExpiredError` by prompting the user to retry — do not
-  silently swallow it
-
-### Web dashboard (`apps/web-dashboard`)
-
-- The dashboard may hold session keys in memory for the duration of a session
-- Clear keys on logout / tab close
-- Use `@ancore/crypto` signing utilities for in-browser key operations
-
----
-
-## Testnet vs Mainnet
-
-| Setting | Testnet | Mainnet |
-|---------|---------|---------|
-| Network passphrase | `Test SDF Network ; September 2015` | `Public Global Stellar Network ; September 2015` |
-| RPC URL | `https://soroban-testnet.stellar.org` | `https://soroban.stellar.org` |
-| Horizon URL | `https://horizon-testnet.stellar.org` | `https://horizon.stellar.org` |
-
-Always test on Testnet first. Contract IDs differ between networks — never
-hardcode a contract ID; read it from environment configuration.
-
----
-
-## Related
-
-- [Architecture overview](./architecture/OVERVIEW.md)
-- [Send flow sequence diagram](./architecture/OVERVIEW.md#send-flow) — extension wallet payment through SDK, relayer, account contract, and Horizon
-- [Security model](./security/THREAT_MODEL.md)
-- [Contributing guide](../CONTRIBUTING.md)
-- [RFC process](../RFC.md)

--- a/docs/rfcs/0001-webauthn-passkey-onboarding.md
+++ b/docs/rfcs/0001-webauthn-passkey-onboarding.md
@@ -1,0 +1,86 @@
+# RFC: WebAuthn Passkey Onboarding for P-256 Session Key Registration Flow
+
+- **RFC Number**: 0001
+- **Author**: oluebubejoy
+- **Status**: Proposed
+- **Created**: 2026-06-28
+- **Updated**: 2026-06-28
+
+## Summary
+
+This RFC specifies the WebAuthn/Passkey onboarding and transaction signing flow for Ancore. By introducing P-256 (secp256r1) credential registration as smart account session keys, users can onboard and execute transactions using biometrics (TouchID, FaceID, Windows Hello) without managing seed phrases, establishing WebAuthn as the primary UX differentiator for Ancore's Account Abstraction (AA) model.
+
+## Motivation
+
+Traditional non-custodial wallets force users to manage seed phrases on first launch, causing massive friction for mainstream users. Account Abstraction enables smart contract-defined authorization rules. By supporting WebAuthn keys as session keys, Ancore allows users to:
+1. Onboard securely with a passkey.
+2. Sign transactions using secure hardware (Enclaves) on their personal devices.
+3. Keep their account recovery path backed by traditional seed-phrases/passwords as a fallback.
+
+## Detailed Design
+
+### Cryptographic Bridge: P-256 vs Ed25519
+
+Stellar and Soroban natively support Ed25519 signatures. WebAuthn authenticators utilize the P-256 (secp256r1) elliptic curve. To bridge these:
+- **Contract Signature Verification**: The account contract must verify P-256 signatures. Soroban SDK provides host functions for verifying signatures over other curves. We will implement verification using `secp256r1_verify` directly in the contract logic, treating P-256 keys as a distinct class of session keys.
+- **Attestation Wrapping**: Passkey signatures include authenticator data (`authData`) and client data JSON (`clientDataJSON`). The client-side SDK wraps the raw signature, `authData`, and `clientDataJSON` into a structured envelope for contract verification.
+
+### Registration Flow
+
+1. **Key Generation**:
+   The client triggers WebAuthn credential creation:
+   ```javascript
+   const credential = await navigator.credentials.create({
+     publicKey: {
+       challenge: crypto.getRandomValues(new Uint8Array(32)),
+       rp: { name: "Ancore Wallet" },
+       user: {
+         id: crypto.getRandomValues(new Uint8Array(16)),
+         name: "user@ancore.org",
+         displayName: "Ancore User"
+       },
+       pubKeyCredParams: [{ alg: -7, type: "public-key" }] // ES256 (P-256)
+     }
+   });
+   ```
+2. **Key Extraction**:
+   Extract the P-256 public key bytes from the credential's `attestationObject`.
+3. **Session Key Registration**:
+   Submit the public key to the account contract via `add_session_key()` with permissions and expiry.
+
+### Sign Flow
+
+1. **Challenge Construction**:
+   Construct the transaction signature payload (the relay payload hash) and use it as the WebAuthn challenge.
+2. **Signature Request**:
+   ```javascript
+   const assertion = await navigator.credentials.get({
+     publicKey: {
+       challenge: payloadHash,
+       allowCredentials: [{ id: credentialId, type: "public-key" }]
+     }
+   });
+   ```
+3. **DER Normalization**:
+   The authenticator returns a DER-encoded signature `(r, s)`. To prevent signature malleability, normalize `s` to its low-s value.
+4. **Relay Submission**:
+   Send the signature, `clientDataJSON`, and `authData` to the Ancore relayer.
+
+### Fallback Path
+
+- **Primary**: WebAuthn Passkey stored in local secure hardware.
+- **Recovery**: Traditional master password and recovery phrase (seed phrase) created during onboarding but hidden behind advanced settings. If the user loses their device, the recovery key (Ed25519 master key) can revoke the passkey session key and register a new one.
+
+## Security Considerations
+
+- **Non-Exportability**: Passkeys generated inside hardware security modules (Secure Enclave) cannot be extracted or leaked via phishing.
+- **Malleability Protection**: Signature verification enforces low-s normalization.
+- **Replay Protection**: The account contract tracks nonces for all executed transactions, including those authorized by WebAuthn session keys.
+
+## Adoption Strategy
+
+This is a non-breaking additive feature to the existing Ed25519 session key model. The `@ancore/wallet-api` and `@ancore/core-sdk` packages will wrap these details so dApps see standard session key requests.
+
+## Unresolved Questions
+
+- The gas overhead of running P-256 verification (via host functions or Wasm verification library) on-chain under Soroban resource limits.


### PR DESCRIPTION
Implement the developer integration guide, session keys lifecycle guide, and WebAuthn onboarding RFC. ROADMAP.md has also been verified to track milestones.

Closes #866
Closes #867
Closes #868
Closes #869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide covering session key lifecycle, including creation, permissions, request flow, signing, revocation, and expiry behavior.
  * Reworked the integration guide with clearer dApp onboarding steps, wallet connection and signing flows, session key usage, auth delegation, and error handling.
  * Added an RFC describing passkey-based onboarding and transaction signing with fallback recovery and security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->