### PR TITLE
feat: optionally allowlist specific function names in validation module

### DIFF
--- a/contracts/validation-modules/src/lib.rs
+++ b/contracts/validation-modules/src/lib.rs
@@ -47,6 +47,7 @@ enum DataKey {
     Admin,
     Enabled,
     AllowedTarget(Address),
+    AllowedFunction(Address, Symbol),
 }
 
 mod events {
@@ -62,6 +63,10 @@ mod events {
 
     pub fn target_set(env: &Env) -> Symbol {
         Symbol::new(env, "target_set")
+    }
+
+    pub fn function_set(env: &Env) -> Symbol {
+        Symbol::new(env, "function_set")
     }
 }
 
@@ -132,6 +137,46 @@ impl TargetAllowlistModule {
             .has(&DataKey::AllowedTarget(target)))
     }
 
+    pub fn set_allowed_function(
+        env: Env,
+        target: Address,
+        function: Symbol,
+        allowed: bool,
+    ) -> Result<(), ValidationModuleError> {
+        require_admin(&env)?;
+
+        let key = DataKey::AllowedFunction(target.clone(), function.clone());
+        if allowed {
+            env.storage().persistent().set(&key, &true);
+            env.storage().persistent().extend_ttl(
+                &key,
+                ALLOWLIST_BUMP_THRESHOLD,
+                ALLOWLIST_BUMP_AMOUNT,
+            );
+        } else {
+            env.storage().persistent().remove(&key);
+        }
+        extend_instance_ttl(&env);
+
+        env.events()
+            .publish((events::function_set(&env),), (target, function, allowed));
+
+        Ok(())
+    }
+
+    pub fn is_allowed_function(
+        env: Env,
+        target: Address,
+        function: Symbol,
+    ) -> Result<bool, ValidationModuleError> {
+        ensure_initialized(&env)?;
+
+        Ok(env
+            .storage()
+            .persistent()
+            .has(&DataKey::AllowedFunction(target, function)))
+    }
+
     pub fn admin(env: Env) -> Result<Address, ValidationModuleError> {
         admin(&env)
     }
@@ -154,7 +199,13 @@ impl ValidationModuleInterface for TargetAllowlistModule {
         if env
             .storage()
             .persistent()
-            .has(&DataKey::AllowedTarget(context.target))
+            .has(&DataKey::AllowedTarget(context.target.clone()))
+        {
+            Ok(())
+        } else if env
+            .storage()
+            .persistent()
+            .has(&DataKey::AllowedFunction(context.target, context.function))
         {
             Ok(())
         } else {
@@ -231,6 +282,22 @@ mod tests {
 
         let result = client.try_initialize(&admin);
         assert_eq!(result, Err(Ok(ValidationModuleError::AlreadyInitialized)));
+    }
+
+    #[test]
+    fn validate_allows_configured_function() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TargetAllowlistModule);
+        let client = TargetAllowlistModuleClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let target = Address::generate(&env);
+
+        client.initialize(&admin);
+        client.set_allowed_function(&target, &symbol_short!("execute"), &true);
+
+        assert!(client.is_allowed_function(&target, &symbol_short!("execute")));
+        assert_eq!(client.try_validate(&context(&env, target)), Ok(Ok(())));
     }
 
     #[test]


### PR DESCRIPTION
# Description

Closes #941 

This PR enhances the `validation-modules` by introducing granular, function-level scoping. Previously, the `TargetAllowlistModule` only validated the target contract address as a whole, meaning a session key scoped to an allowlisted contract could call any function (including sensitive admin functions) on that contract.

With these changes, the validation module now supports restricting authorization to specific function names within an allowlisted contract.

## Changes

- **Added Granular Allowlist State:** Introduced `AllowedFunction(Address, Symbol)` to `DataKey` to track specific target/function combinations.
- **New Admin Endpoints:** Added `set_allowed_function` and `is_allowed_function` to allow module administrators to configure and query function-level permissions.
- **Updated Validation Logic:** Refactored the `validate` function to explicitly authorize an execution if the target is allowlisted globally OR if the specific target/function pair is allowlisted.
- **Added Event Logging:** Included a `function_set` event that emits when a function's allowlist status changes.

## Testing

- Added `validate_allows_configured_function` to verify that `TargetAllowlistModule` correctly validates requests that specify an allowed function, while continuing to block unconfigured calls.
- All `validation-modules` unit tests pass successfully.

Closes #927 
Closes #926 
Closes #942 
Closes #941 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for allowing specific functions on a target, not just whole targets.
  * Added a new way to check whether a target-function pair is permitted.
  * Validation now accepts a call when either the target is allowed or the specific function is allowed for that target.

* **Bug Fixes**
  * Improved validation behavior so unauthorized function calls are rejected when no matching allowance exists.

* **Tests**
  * Added coverage for validating an allowed function on a target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->