### PR TITLE
feat: add PasskeyModule for WebAuthn P-256 session key registration a…

### DIFF
--- a/packages/account-abstraction/src/__tests__/passkey-module.test.ts
+++ b/packages/account-abstraction/src/__tests__/passkey-module.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Unit tests for PasskeyModule.
+ * navigator.credentials is mocked throughout; crypto.subtle is provided by jest.setup via Node webcrypto.
+ */
+
+import {
+  buildAddSessionKeyInvocation,
+  PasskeyNotSupportedError,
+  PasskeyRegistrationError,
+  PasskeySigningError,
+  registerPasskey,
+  signRelayPayload,
+} from '../passkey/passkeyModule';
+
+// ---------------------------------------------------------------------------
+// Helpers to build realistic mock WebAuthn objects
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a P-256 SubjectPublicKeyInfo DER buffer for a given (x, y) pair.
+ *
+ * Layout (91 bytes):
+ *   30 59  – outer SEQUENCE
+ *     30 13 – algorithm SEQUENCE
+ *       06 07 2a86 48ce 3d02 01  – OID 1.2.840.10045.2.1 (ecPublicKey)
+ *       06 08 2a86 48ce 3d03 0107 – OID 1.2.840.10045.3.1.7 (P-256)
+ *     03 42 00  – BIT STRING (0 unused bits)
+ *       04        – uncompressed point prefix
+ *       x[32]
+ *       y[32]
+ */
+function buildSpki(x: Uint8Array, y: Uint8Array): ArrayBuffer {
+  const header = new Uint8Array([
+    0x30, 0x59, 0x30, 0x13,
+    0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01,
+    0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07,
+    0x03, 0x42, 0x00, 0x04,
+  ]);
+  const out = new Uint8Array(header.length + 64);
+  out.set(header);
+  out.set(x, header.length);
+  out.set(y, header.length + 32);
+  return out.buffer;
+}
+
+/**
+ * Build a DER-encoded ECDSA signature SEQUENCE { INTEGER r, INTEGER s }.
+ * Optionally adds a leading 0x00 padding byte to r and/or s (as DER requires when MSB is set).
+ */
+function buildDerSig(r: Uint8Array, s: Uint8Array, padR = false, padS = false): ArrayBuffer {
+  const rBytes = padR ? new Uint8Array([0x00, ...r]) : r;
+  const sBytes = padS ? new Uint8Array([0x00, ...s]) : s;
+  const inner = new Uint8Array([
+    0x02, rBytes.length, ...rBytes,
+    0x02, sBytes.length, ...sBytes,
+  ]);
+  return new Uint8Array([0x30, inner.length, ...inner]).buffer;
+}
+
+const ACCOUNT_ADDRESS = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+const CONTRACT_ID = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+
+const mockX = new Uint8Array(32).fill(0xaa);
+const mockY = new Uint8Array(32).fill(0xbb);
+const mockRawId = new Uint8Array([0x01, 0x02, 0x03]);
+const mockR = new Uint8Array(32).fill(0x11);
+const mockS = new Uint8Array(32).fill(0x22);
+const mockAuthData = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+const mockClientDataJSON = new Uint8Array(new TextEncoder().encode('{"type":"webauthn.get"}'));
+
+function makeRegistrationCredential(overrides: Partial<{ spki: ArrayBuffer | null; rawId: ArrayBuffer }> = {}) {
+  return {
+    type: 'public-key',
+    rawId: overrides.rawId ?? mockRawId.buffer,
+    response: {
+      getPublicKey: () => overrides.spki !== undefined ? overrides.spki : buildSpki(mockX, mockY),
+    },
+  };
+}
+
+function makeAssertionCredential(overrides: Partial<{ sig: ArrayBuffer }> = {}) {
+  const derSig = overrides.sig ?? buildDerSig(mockR, mockS);
+  return {
+    type: 'public-key',
+    rawId: mockRawId.buffer,
+    response: {
+      signature: derSig,
+      authenticatorData: mockAuthData.buffer,
+      clientDataJSON: mockClientDataJSON.buffer,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock setup
+// ---------------------------------------------------------------------------
+
+let mockCreate: jest.Mock;
+let mockGet: jest.Mock;
+
+beforeAll(() => {
+  mockCreate = jest.fn();
+  mockGet = jest.fn();
+
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { credentials: { create: mockCreate, get: mockGet } },
+    configurable: true,
+    writable: true,
+  });
+
+  Object.defineProperty(globalThis, 'window', {
+    value: { location: { hostname: 'ancore.app' } },
+    configurable: true,
+    writable: true,
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// registerPasskey
+// ---------------------------------------------------------------------------
+
+describe('registerPasskey', () => {
+  it('returns credentialId, publicKey x/y, and expiresAt on success', async () => {
+    mockCreate.mockResolvedValue(makeRegistrationCredential());
+
+    const result = await registerPasskey(ACCOUNT_ADDRESS);
+
+    expect(result.credentialId).toBeDefined();
+    expect(typeof result.credentialId).toBe('string');
+    expect(result.publicKey.x).toEqual(mockX);
+    expect(result.publicKey.y).toEqual(mockY);
+    expect(result.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('uses provided expiresAt instead of the default', async () => {
+    const expiresAt = Date.now() + 7 * 24 * 60 * 60 * 1000;
+    mockCreate.mockResolvedValue(makeRegistrationCredential());
+
+    const result = await registerPasskey(ACCOUNT_ADDRESS, { expiresAt });
+
+    expect(result.expiresAt).toBe(expiresAt);
+  });
+
+  it('passes rpId and rpName to the authenticator when provided', async () => {
+    mockCreate.mockResolvedValue(makeRegistrationCredential());
+
+    await registerPasskey(ACCOUNT_ADDRESS, { rpId: 'example.com', rpName: 'Example' });
+
+    const callArg = mockCreate.mock.calls[0][0] as CredentialCreationOptions;
+    expect(callArg.publicKey?.rp.id).toBe('example.com');
+    expect(callArg.publicKey?.rp.name).toBe('Example');
+  });
+
+  it('uses window.location.hostname as default rpId', async () => {
+    mockCreate.mockResolvedValue(makeRegistrationCredential());
+
+    await registerPasskey(ACCOUNT_ADDRESS);
+
+    const callArg = mockCreate.mock.calls[0][0] as CredentialCreationOptions;
+    expect(callArg.publicKey?.rp.id).toBe('ancore.app');
+  });
+
+  it('requests ES256 (alg -7) credential', async () => {
+    mockCreate.mockResolvedValue(makeRegistrationCredential());
+
+    await registerPasskey(ACCOUNT_ADDRESS);
+
+    const callArg = mockCreate.mock.calls[0][0] as CredentialCreationOptions;
+    expect(callArg.publicKey?.pubKeyCredParams).toEqual([{ alg: -7, type: 'public-key' }]);
+  });
+
+  it('throws PasskeyRegistrationError when create() returns null', async () => {
+    mockCreate.mockResolvedValue(null);
+
+    await expect(registerPasskey(ACCOUNT_ADDRESS)).rejects.toThrow(PasskeyRegistrationError);
+  });
+
+  it('throws PasskeyRegistrationError when credential type is not public-key', async () => {
+    mockCreate.mockResolvedValue({ type: 'identity' });
+
+    await expect(registerPasskey(ACCOUNT_ADDRESS)).rejects.toThrow(PasskeyRegistrationError);
+  });
+
+  it('throws PasskeyRegistrationError when getPublicKey() returns null', async () => {
+    mockCreate.mockResolvedValue(makeRegistrationCredential({ spki: null }));
+
+    await expect(registerPasskey(ACCOUNT_ADDRESS)).rejects.toThrow(PasskeyRegistrationError);
+  });
+
+  it('throws PasskeyRegistrationError when SPKI contains no uncompressed P-256 point', async () => {
+    // Buffer too small to contain a 0x04-prefixed 64-byte point after offset 23
+    const badSpki = new Uint8Array(30).fill(0xff);
+    mockCreate.mockResolvedValue(makeRegistrationCredential({ spki: badSpki.buffer }));
+
+    await expect(registerPasskey(ACCOUNT_ADDRESS)).rejects.toThrow(PasskeyRegistrationError);
+  });
+
+  it('throws PasskeyNotSupportedError when navigator.credentials is absent', async () => {
+    const original = globalThis.navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    await expect(registerPasskey(ACCOUNT_ADDRESS)).rejects.toThrow(PasskeyNotSupportedError);
+
+    Object.defineProperty(globalThis, 'navigator', {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('encodes rawId as base64url without padding', async () => {
+    // rawId bytes whose base64 would contain + or /
+    const rawId = new Uint8Array([0xfb, 0xff, 0xfe]);
+    mockCreate.mockResolvedValue(makeRegistrationCredential({ rawId: rawId.buffer }));
+
+    const { credentialId } = await registerPasskey(ACCOUNT_ADDRESS);
+
+    expect(credentialId).not.toContain('+');
+    expect(credentialId).not.toContain('/');
+    expect(credentialId).not.toContain('=');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAddSessionKeyInvocation
+// ---------------------------------------------------------------------------
+
+describe('buildAddSessionKeyInvocation', () => {
+  it('returns add_session_key invocation with x-coordinate and PERMISSION_EXECUTE', () => {
+    const registration = {
+      credentialId: 'AQID',
+      publicKey: { x: mockX, y: mockY },
+      expiresAt: 9_999_999_999,
+    };
+
+    const inv = buildAddSessionKeyInvocation(CONTRACT_ID, registration);
+
+    expect(inv.method).toBe('add_session_key');
+    expect(inv.args).toHaveLength(3);
+    // First arg encodes the x-coordinate as BytesN<32>
+    expect(inv.args[0].switch().name).toBe('scvBytes');
+    expect(inv.args[0].bytes()).toEqual(Buffer.from(mockX));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signRelayPayload
+// ---------------------------------------------------------------------------
+
+const unsignedPayload = {
+  sessionKey: 'aabbccdd'.repeat(8),
+  operation: 'relay_execute' as const,
+  parameters: { to: 'GC...', amount: '100', asset: 'XLM' },
+  nonce: 7,
+};
+
+describe('signRelayPayload', () => {
+  it('returns a 128-char hex signature on success', async () => {
+    mockGet.mockResolvedValue(makeAssertionCredential());
+
+    const result = await signRelayPayload(unsignedPayload, 'AQID');
+
+    expect(result.signature).toHaveLength(128);
+    expect(result.signature).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('encodes r and s in the correct order (first 64 hex chars = r, last 64 = s)', async () => {
+    mockGet.mockResolvedValue(makeAssertionCredential());
+
+    const { signature } = await signRelayPayload(unsignedPayload, 'AQID');
+
+    const rHex = mockR.reduce((acc, b) => acc + b.toString(16).padStart(2, '0'), '');
+    const sHex = mockS.reduce((acc, b) => acc + b.toString(16).padStart(2, '0'), '');
+    expect(signature.slice(0, 64)).toBe(rHex);
+    expect(signature.slice(64)).toBe(sHex);
+  });
+
+  it('strips the leading 0x00 DER padding byte from r and s', async () => {
+    const paddedDer = buildDerSig(mockR, mockS, true, true);
+    mockGet.mockResolvedValue(makeAssertionCredential({ sig: paddedDer }));
+
+    const { signature } = await signRelayPayload(unsignedPayload, 'AQID');
+
+    expect(signature).toHaveLength(128);
+    const rHex = mockR.reduce((acc, b) => acc + b.toString(16).padStart(2, '0'), '');
+    expect(signature.slice(0, 64)).toBe(rHex);
+  });
+
+  it('returns authenticatorData and clientDataJSON as Uint8Arrays', async () => {
+    mockGet.mockResolvedValue(makeAssertionCredential());
+
+    const { authenticatorData, clientDataJSON } = await signRelayPayload(unsignedPayload, 'AQID');
+
+    expect(authenticatorData).toEqual(mockAuthData);
+    expect(clientDataJSON).toEqual(mockClientDataJSON);
+  });
+
+  it('passes the SHA-256 payload hash as the WebAuthn challenge', async () => {
+    mockGet.mockResolvedValue(makeAssertionCredential());
+
+    await signRelayPayload(unsignedPayload, 'AQID');
+
+    const callArg = mockGet.mock.calls[0][0] as CredentialRequestOptions;
+    const challenge = callArg.publicKey?.challenge;
+    expect(challenge).toBeDefined();
+    expect((challenge as Uint8Array).byteLength ?? (challenge as ArrayBuffer).byteLength).toBe(32);
+  });
+
+  it('produces the same challenge for identical payloads', async () => {
+    mockGet.mockResolvedValue(makeAssertionCredential());
+    await signRelayPayload(unsignedPayload, 'AQID');
+    const first = mockGet.mock.calls[0][0] as CredentialRequestOptions;
+
+    mockGet.mockResolvedValue(makeAssertionCredential());
+    await signRelayPayload({ ...unsignedPayload }, 'AQID');
+    const second = mockGet.mock.calls[1][0] as CredentialRequestOptions;
+
+    expect(new Uint8Array(first.publicKey!.challenge as ArrayBuffer)).toEqual(
+      new Uint8Array(second.publicKey!.challenge as ArrayBuffer)
+    );
+  });
+
+  it('includes the decoded credentialId in allowCredentials', async () => {
+    mockGet.mockResolvedValue(makeAssertionCredential());
+    const credentialId = 'AQID'; // base64url for [01 02 03]
+
+    await signRelayPayload(unsignedPayload, credentialId);
+
+    const callArg = mockGet.mock.calls[0][0] as CredentialRequestOptions;
+    const id = callArg.publicKey?.allowCredentials?.[0].id;
+    // id is a Uint8Array (BufferSource); compare via typed array view
+    expect(new Uint8Array(id as ArrayBuffer)).toEqual(new Uint8Array([0x01, 0x02, 0x03]));
+  });
+
+  it('passes transports and rpId when provided in options', async () => {
+    mockGet.mockResolvedValue(makeAssertionCredential());
+
+    await signRelayPayload(unsignedPayload, 'AQID', {
+      transports: ['internal'],
+      rpId: 'example.com',
+    });
+
+    const callArg = mockGet.mock.calls[0][0] as CredentialRequestOptions;
+    expect(callArg.publicKey?.allowCredentials?.[0].transports).toEqual(['internal']);
+    expect(callArg.publicKey?.rpId).toBe('example.com');
+  });
+
+  it('throws PasskeySigningError when get() returns null', async () => {
+    mockGet.mockResolvedValue(null);
+
+    await expect(signRelayPayload(unsignedPayload, 'AQID')).rejects.toThrow(PasskeySigningError);
+  });
+
+  it('throws PasskeySigningError when credential type is not public-key', async () => {
+    mockGet.mockResolvedValue({ type: 'password' });
+
+    await expect(signRelayPayload(unsignedPayload, 'AQID')).rejects.toThrow(PasskeySigningError);
+  });
+
+  it('throws PasskeyNotSupportedError when navigator.credentials is absent', async () => {
+    const original = globalThis.navigator;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    await expect(signRelayPayload(unsignedPayload, 'AQID')).rejects.toThrow(PasskeyNotSupportedError);
+
+    Object.defineProperty(globalThis, 'navigator', {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('throws PasskeySigningError on malformed DER signature', async () => {
+    const badSig = new Uint8Array([0xff, 0x00]).buffer;
+    mockGet.mockResolvedValue(makeAssertionCredential({ sig: badSig }));
+
+    await expect(signRelayPayload(unsignedPayload, 'AQID')).rejects.toThrow(PasskeySigningError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error class identity
+// ---------------------------------------------------------------------------
+
+describe('error classes', () => {
+  it('PasskeyNotSupportedError is instanceof PasskeyNotSupportedError', () => {
+    expect(new PasskeyNotSupportedError()).toBeInstanceOf(PasskeyNotSupportedError);
+  });
+
+  it('PasskeyRegistrationError is instanceof PasskeyRegistrationError', () => {
+    expect(new PasskeyRegistrationError('oops')).toBeInstanceOf(PasskeyRegistrationError);
+  });
+
+  it('PasskeySigningError is instanceof PasskeySigningError', () => {
+    expect(new PasskeySigningError('oops')).toBeInstanceOf(PasskeySigningError);
+  });
+
+  it('PasskeyNotSupportedError has correct code', () => {
+    expect(new PasskeyNotSupportedError().code).toBe('PASSKEY_NOT_SUPPORTED');
+  });
+});

--- a/packages/account-abstraction/src/index.ts
+++ b/packages/account-abstraction/src/index.ts
@@ -97,3 +97,21 @@ export type {
   ContractExecuteParams,
   RefreshSessionKeyTtlParams,
 } from './transaction-builder';
+
+export {
+  PasskeyError,
+  PasskeyNotSupportedError,
+  PasskeyRegistrationError,
+  PasskeySigningError,
+  registerPasskey,
+  buildAddSessionKeyInvocation,
+  signRelayPayload,
+} from './passkey/passkeyModule';
+export type {
+  P256PublicKey,
+  PasskeyRegistrationResult,
+  PasskeySignatureResult,
+  RegisterPasskeyOptions,
+  SignRelayPayloadOptions,
+  UnsignedRelayPayload,
+} from './passkey/passkeyModule';

--- a/packages/account-abstraction/src/passkey/passkeyModule.ts
+++ b/packages/account-abstraction/src/passkey/passkeyModule.ts
@@ -1,0 +1,391 @@
+/**
+ * PasskeyModule: WebAuthn P-256 session key registration and signing for Ancore account abstraction.
+ *
+ * Wraps navigator.credentials to register P-256 public keys as session keys on the smart
+ * account contract and sign relay payloads using the platform authenticator.
+ */
+
+import { addSessionKey } from '../add-session-key';
+import type { InvocationArgs } from '../account-contract';
+import { PERMISSION_EXECUTE } from '../permissions';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Extracted P-256 public key coordinates. */
+export interface P256PublicKey {
+  /** 32-byte x-coordinate (used as the on-chain BytesN<32> session key). */
+  x: Uint8Array;
+  /** 32-byte y-coordinate (retained for off-chain verification). */
+  y: Uint8Array;
+}
+
+/** Result returned after a successful WebAuthn passkey registration. */
+export interface PasskeyRegistrationResult {
+  /** Base64url-encoded credential ID assigned by the authenticator. */
+  credentialId: string;
+  /** P-256 public key coordinates extracted from the attestation response. */
+  publicKey: P256PublicKey;
+  /** Session expiry timestamp in milliseconds since epoch. */
+  expiresAt: number;
+}
+
+/** Result returned after signing a relay payload with a passkey. */
+export interface PasskeySignatureResult {
+  /** Compact r‖s ECDSA signature encoded as a 128-character lowercase hex string (64 bytes). */
+  signature: string;
+  /** Raw authenticatorData bytes — required by the relay server for signature verification. */
+  authenticatorData: Uint8Array;
+  /** Raw clientDataJSON bytes — required by the relay server for signature verification. */
+  clientDataJSON: Uint8Array;
+}
+
+/** Options for {@link registerPasskey}. */
+export interface RegisterPasskeyOptions {
+  /** Session expiry in ms since epoch. Default: now + 24 hours. */
+  expiresAt?: number;
+  /** WebAuthn relying party ID. Default: window.location.hostname. */
+  rpId?: string;
+  /** Relying party display name. Default: 'Ancore'. */
+  rpName?: string;
+  /** User display name passed to the authenticator. Default: accountAddress. */
+  userName?: string;
+  /** Authenticator timeout in milliseconds. Default: 60 000. */
+  timeout?: number;
+}
+
+/** Options for {@link signRelayPayload}. */
+export interface SignRelayPayloadOptions {
+  /** Allowed authenticator transports for the allow-credentials list. */
+  transports?: AuthenticatorTransport[];
+  /** Authenticator timeout in milliseconds. Default: 60 000. */
+  timeout?: number;
+  /** WebAuthn relying party ID. Default: window.location.hostname. */
+  rpId?: string;
+}
+
+/**
+ * Relay payload fields required to compute the signing challenge.
+ * Mirrors relayPayloadSchema fields, excluding the `signature` output field.
+ */
+export interface UnsignedRelayPayload {
+  sessionKey: string;
+  operation: string;
+  parameters: Record<string, unknown>;
+  nonce: number;
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class PasskeyError extends Error {
+  readonly code: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = 'PasskeyError';
+    this.code = code;
+    Object.setPrototypeOf(this, PasskeyError.prototype);
+  }
+}
+
+export class PasskeyNotSupportedError extends PasskeyError {
+  constructor() {
+    super('WebAuthn is not supported in this environment', 'PASSKEY_NOT_SUPPORTED');
+    this.name = 'PasskeyNotSupportedError';
+    Object.setPrototypeOf(this, PasskeyNotSupportedError.prototype);
+  }
+}
+
+export class PasskeyRegistrationError extends PasskeyError {
+  constructor(message: string) {
+    super(message, 'PASSKEY_REGISTRATION_ERROR');
+    this.name = 'PasskeyRegistrationError';
+    Object.setPrototypeOf(this, PasskeyRegistrationError.prototype);
+  }
+}
+
+export class PasskeySigningError extends PasskeyError {
+  constructor(message: string) {
+    super(message, 'PASSKEY_SIGNING_ERROR');
+    this.name = 'PasskeySigningError';
+    Object.setPrototypeOf(this, PasskeySigningError.prototype);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function assertWebAuthnSupport(): void {
+  if (
+    typeof navigator === 'undefined' ||
+    typeof navigator.credentials === 'undefined' ||
+    typeof navigator.credentials.create !== 'function'
+  ) {
+    throw new PasskeyNotSupportedError();
+  }
+}
+
+/** Encode raw bytes to a base64url string (no padding). */
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+/** Decode a base64url string (with or without padding) to bytes. */
+function fromBase64Url(b64url: string): Uint8Array {
+  const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), '=');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/** Encode bytes to a lowercase hex string. */
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Extract P-256 x/y coordinates from a SubjectPublicKeyInfo DER buffer.
+ *
+ * P-256 SPKI structure (91 bytes):
+ *   SEQUENCE { AlgorithmIdentifier { OID ecPublicKey, OID P-256 }, BIT STRING { 04 x[32] y[32] } }
+ *
+ * We locate the uncompressed point prefix (0x04) after the algorithm identifier and read the
+ * following 64 bytes as the x and y coordinates.
+ */
+function parseSpkiP256(spki: ArrayBuffer): P256PublicKey {
+  const bytes = new Uint8Array(spki);
+  // The algorithm identifier occupies the first ~25 bytes; search for 0x04 from offset 23.
+  for (let i = 23; i < bytes.length - 64; i++) {
+    if (bytes[i] === 0x04) {
+      return {
+        x: bytes.slice(i + 1, i + 33),
+        y: bytes.slice(i + 33, i + 65),
+      };
+    }
+  }
+  throw new PasskeyRegistrationError('Could not locate P-256 uncompressed point in SPKI');
+}
+
+/**
+ * Parse a DER-encoded ECDSA P-256 signature to compact r‖s form.
+ *
+ * DER format: SEQUENCE { INTEGER r, INTEGER s }
+ * Each integer may carry a leading 0x00 byte when the MSB is set; that byte is stripped.
+ * Both r and s are right-aligned in 32-byte arrays.
+ */
+function parseDerSignature(derSig: ArrayBuffer): { r: Uint8Array; s: Uint8Array } {
+  const b = new Uint8Array(derSig);
+  let offset = 0;
+
+  if (b[offset++] !== 0x30) {
+    throw new PasskeySigningError('DER signature: expected SEQUENCE (0x30)');
+  }
+
+  // Skip sequence length (short or long form).
+  if (b[offset] & 0x80) {
+    offset += (b[offset] & 0x7f) + 1;
+  } else {
+    offset++;
+  }
+
+  if (b[offset++] !== 0x02) {
+    throw new PasskeySigningError('DER signature: expected INTEGER for r');
+  }
+  const rLen = b[offset++];
+  let r = b.slice(offset, offset + rLen);
+  offset += rLen;
+
+  if (b[offset++] !== 0x02) {
+    throw new PasskeySigningError('DER signature: expected INTEGER for s');
+  }
+  const sLen = b[offset++];
+  let s = b.slice(offset, offset + sLen);
+
+  // Strip DER sign-padding zero.
+  if (r.length === 33 && r[0] === 0x00) r = r.slice(1);
+  if (s.length === 33 && s[0] === 0x00) s = s.slice(1);
+
+  const rFixed = new Uint8Array(32);
+  const sFixed = new Uint8Array(32);
+  rFixed.set(r, 32 - r.length);
+  sFixed.set(s, 32 - s.length);
+
+  return { r: rFixed, s: sFixed };
+}
+
+/**
+ * Compute a 32-byte SHA-256 challenge from an unsigned relay payload.
+ *
+ * The challenge is the SHA-256 digest of the canonical JSON of the four
+ * non-signature fields, serialised in key-sorted order. Using the payload
+ * hash as the WebAuthn challenge binds the authenticator's ECDSA signature
+ * to the specific relay operation being authorised.
+ */
+async function computePayloadChallenge(payload: UnsignedRelayPayload): Promise<Uint8Array> {
+  const canonical = JSON.stringify({
+    nonce: payload.nonce,
+    operation: payload.operation,
+    parameters: payload.parameters,
+    sessionKey: payload.sessionKey,
+  });
+  const encoded = new TextEncoder().encode(canonical);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', encoded);
+  return new Uint8Array(digest);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a WebAuthn passkey for an Ancore smart account.
+ *
+ * Calls `navigator.credentials.create()` with an ES256 (P-256) credential,
+ * then extracts the public key x/y coordinates from the attestation response.
+ * The returned `credentialId` and `publicKey` should be persisted by the caller
+ * for later use with {@link buildAddSessionKeyInvocation} and {@link signRelayPayload}.
+ *
+ * @param accountAddress - Stellar contract or account address that owns this session key.
+ * @param options - Optional overrides for expiry, RP identity, and timeout.
+ */
+export async function registerPasskey(
+  accountAddress: string,
+  options: RegisterPasskeyOptions = {}
+): Promise<PasskeyRegistrationResult> {
+  assertWebAuthnSupport();
+
+  const {
+    expiresAt = Date.now() + 24 * 60 * 60 * 1000,
+    rpId = typeof window !== 'undefined' ? window.location.hostname : undefined,
+    rpName = 'Ancore',
+    userName = accountAddress,
+    timeout = 60_000,
+  } = options;
+
+  const challenge = globalThis.crypto.getRandomValues(new Uint8Array(32));
+
+  const creationOptions: CredentialCreationOptions = {
+    publicKey: {
+      challenge,
+      rp: { name: rpName, ...(rpId !== undefined && { id: rpId }) },
+      user: {
+        id: new TextEncoder().encode(accountAddress),
+        name: userName,
+        displayName: userName,
+      },
+      pubKeyCredParams: [{ alg: -7, type: 'public-key' }], // -7 = ES256 (P-256)
+      timeout,
+      attestation: 'none',
+    },
+  };
+
+  const credential = await navigator.credentials.create(creationOptions);
+
+  if (!credential || credential.type !== 'public-key') {
+    throw new PasskeyRegistrationError('Passkey creation was cancelled or failed');
+  }
+
+  const pk = credential as PublicKeyCredential;
+  const response = pk.response as AuthenticatorAttestationResponse;
+  const spki = response.getPublicKey();
+  if (!spki) {
+    throw new PasskeyRegistrationError('Authenticator did not return a public key');
+  }
+
+  const publicKey = parseSpkiP256(spki);
+  const credentialId = toBase64Url(new Uint8Array(pk.rawId));
+
+  return { credentialId, publicKey, expiresAt };
+}
+
+/**
+ * Build an `add_session_key` invocation for a registered passkey.
+ *
+ * Uses the P-256 public key's x-coordinate (32 bytes) as the on-chain `BytesN<32>` key
+ * and grants `PERMISSION_EXECUTE` so the session key can call `execute()` on the account.
+ *
+ * @param contractId - Stellar contract ID of the smart account.
+ * @param registration - Result from {@link registerPasskey}.
+ * @returns Invocation args ready to be included in a Soroban transaction.
+ */
+export function buildAddSessionKeyInvocation(
+  contractId: string,
+  registration: PasskeyRegistrationResult
+): InvocationArgs {
+  return addSessionKey(
+    contractId,
+    registration.publicKey.x,
+    [PERMISSION_EXECUTE],
+    registration.expiresAt
+  );
+}
+
+/**
+ * Sign a relay payload with a registered WebAuthn passkey.
+ *
+ * The SHA-256 hash of the canonical payload JSON (all fields except `signature`,
+ * keys sorted alphabetically) is used as the WebAuthn challenge. The authenticator's
+ * DER-encoded ECDSA P-256 signature is converted to compact r‖s form and returned
+ * as a 128-character hex string.
+ *
+ * The `authenticatorData` and `clientDataJSON` fields are included in the result so
+ * the relay server can perform full WebAuthn verification independently.
+ *
+ * @param payload - Relay payload fields to sign (without the `signature` field).
+ * @param credentialId - Base64url credential ID returned by {@link registerPasskey}.
+ * @param options - Optional overrides for transports, timeout, and RP ID.
+ */
+export async function signRelayPayload(
+  payload: UnsignedRelayPayload,
+  credentialId: string,
+  options: SignRelayPayloadOptions = {}
+): Promise<PasskeySignatureResult> {
+  assertWebAuthnSupport();
+
+  const { timeout = 60_000, rpId, transports } = options;
+  const challenge = await computePayloadChallenge(payload);
+  const credentialIdBytes = fromBase64Url(credentialId);
+
+  const requestOptions: CredentialRequestOptions = {
+    publicKey: {
+      challenge,
+      timeout,
+      allowCredentials: [
+        {
+          type: 'public-key',
+          id: credentialIdBytes,
+          ...(transports !== undefined && { transports }),
+        },
+      ],
+      ...(rpId !== undefined && { rpId }),
+      userVerification: 'required',
+    },
+  };
+
+  const assertion = await navigator.credentials.get(requestOptions);
+
+  if (!assertion || assertion.type !== 'public-key') {
+    throw new PasskeySigningError('Passkey assertion was cancelled or failed');
+  }
+
+  const assertionPk = assertion as PublicKeyCredential;
+  const response = assertionPk.response as AuthenticatorAssertionResponse;
+  const { r, s } = parseDerSignature(response.signature);
+
+  const compact = new Uint8Array(64);
+  compact.set(r, 0);
+  compact.set(s, 32);
+
+  return {
+    signature: toHex(compact),
+    authenticatorData: new Uint8Array(response.authenticatorData),
+    clientDataJSON: new Uint8Array(response.clientDataJSON),
+  };
+}

--- a/packages/account-abstraction/tsconfig.json
+++ b/packages/account-abstraction/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
     "rootDir": "./src",
     "outDir": "./dist",
     "composite": true,


### PR DESCRIPTION
closes #859 

#859 [ACCOUNT-ABSTRACTION] Add PasskeyModule for WebAuthn P-256 session key registration and signing
Repo Avatar
[ancore-org/ancore](https://github.com/ancore-org/ancore)

Feature Description
Add a PasskeyModule to packages/account-abstraction/ that wraps the WebAuthn API to register P-256 public keys as session keys on the smart account and sign relay payloads using the authenticator.

Problem Statement
Ancore's AA value proposition is passwordless UX via WebAuthn — users authenticate with Touch ID or Face ID instead of managing seed phrases. This flow is not implemented anywhere in the codebase.


