### PR TITLE
Add mobile Maestro e2e scaffolding

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -1,0 +1,17 @@
+name: Mobile e2e
+
+on:
+  workflow_dispatch:
+
+jobs:
+  maestro-placeholder:
+    name: Maestro placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Report pending mobile Maestro setup
+        run: |
+          echo "Maestro mobile e2e flows are scaffolded in apps/mobile-wallet/e2e/flows."
+          echo "The onboarding and send flows remain gated behind the corresponding mobile issues and are not executed in CI yet."

--- a/apps/mobile-wallet/e2e/flows/create-wallet.yaml
+++ b/apps/mobile-wallet/e2e/flows/create-wallet.yaml
@@ -1,0 +1,18 @@
+appId: org.ancore.wallet.dev
+---
+# TODO: requires #783 (mobile-wire-onboarding) — enable in CI after that ships
+- launchApp
+- tapOn: "Create a new wallet"
+- assertVisible: "Create a new wallet"
+- tapOn: "Wallet name"
+- inputText: ${E2E_TEST_WALLET_NAME}
+- tapOn: "Continue"
+- assertVisible: "Your recovery phrase"
+- tapOn: "I wrote it down"
+- assertVisible: "Verify your recovery phrase"
+- tapOn: "Password"
+- inputText: ${E2E_TEST_PASSWORD}
+- tapOn: "Confirm password"
+- inputText: ${E2E_TEST_PASSWORD}
+- tapOn: "Continue"
+- assertVisible: "Wallet setup complete"

--- a/apps/mobile-wallet/e2e/flows/import-wallet.yaml
+++ b/apps/mobile-wallet/e2e/flows/import-wallet.yaml
@@ -1,0 +1,16 @@
+appId: org.ancore.wallet.dev
+---
+# TODO: requires #783 (mobile-wire-onboarding) — enable in CI after that ships
+- launchApp
+- tapOn: "Import an existing wallet"
+- assertVisible: "Import an existing wallet"
+- tapOn: "Recovery phrase"
+- inputText: ${E2E_TEST_MNEMONIC}
+- tapOn: "Continue"
+- assertVisible: "Set a password"
+- tapOn: "Password"
+- inputText: ${E2E_TEST_PASSWORD}
+- tapOn: "Confirm password"
+- inputText: ${E2E_TEST_PASSWORD}
+- tapOn: "Continue"
+- assertVisible: ${E2E_TEST_ADDRESS}

--- a/apps/mobile-wallet/e2e/flows/lock-unlock.yaml
+++ b/apps/mobile-wallet/e2e/flows/lock-unlock.yaml
@@ -1,0 +1,17 @@
+appId: org.ancore.wallet.dev
+---
+- launchApp
+- tapOn: "Unlock Wallet"
+- tapOn: "Use Password Instead"
+- tapOn: "Password"
+- inputText: ${E2E_TEST_PASSWORD}
+- tapOn: "Continue"
+- assertVisible: "Settings"
+- tapOn: "Settings"
+- tapOn: "Lock wallet"
+- assertVisible: "Unlock Wallet"
+- tapOn: "Use Password Instead"
+- tapOn: "Password"
+- inputText: ${E2E_TEST_PASSWORD}
+- tapOn: "Continue"
+- assertVisible: "Account"

--- a/apps/mobile-wallet/e2e/flows/send-payment.yaml
+++ b/apps/mobile-wallet/e2e/flows/send-payment.yaml
@@ -1,0 +1,16 @@
+appId: org.ancore.wallet.dev
+---
+# TODO: requires #785 (mobile-sign-send) — enable in CI after that ships
+- launchApp
+- tapOn: "Unlock Wallet"
+- tapOn: "Use Password Instead"
+- tapOn: "Password"
+- inputText: ${E2E_TEST_PASSWORD}
+- tapOn: "Continue"
+- assertVisible: "Send"
+- tapOn: "Send"
+- tapOn: "Recipient"
+- inputText: ${E2E_RECIPIENT_ADDRESS}
+- tapOn: "Continue"
+- assertVisible: "Transaction Submitted"
+- assertVisible: "Transaction hash"

--- a/apps/mobile-wallet/maestro.config.yaml
+++ b/apps/mobile-wallet/maestro.config.yaml
@@ -1,0 +1,4 @@
+appId: org.ancore.wallet.dev
+name: Ancore mobile wallet Maestro flows
+flows:
+  - e2e/flows

--- a/docs/testing/mobile-e2e-setup.md
+++ b/docs/testing/mobile-e2e-setup.md
@@ -1,0 +1,54 @@
+# Mobile e2e test setup
+
+Maestro flow specs for the mobile wallet live under apps/mobile-wallet/e2e/flows and are intended for device-level validation of the highest-risk wallet journeys.
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm 9+
+- Maestro CLI installed and available on your PATH
+- A development build of the mobile wallet installed on a device or simulator with bundle id `org.ancore.wallet.dev`
+
+## Environment variables
+
+Set these before running the flows locally or in CI.
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `E2E_TEST_PASSWORD` | Yes | Password used to unlock and complete onboarding steps. |
+| `E2E_TEST_MNEMONIC` | Yes | 12-word recovery phrase for the import-wallet flow. Never commit or share real secrets. |
+| `E2E_TEST_WALLET_NAME` | Yes | Display name used in the create-wallet flow. |
+| `E2E_TEST_ADDRESS` | Yes | Expected address asserted after import. |
+| `E2E_RECIPIENT_ADDRESS` | Yes for send flow | Destination testnet address used by the send-payment flow. |
+
+Use dedicated testnet-only values. Do not reuse production wallets or mainnet credentials.
+
+## Testnet faucet
+
+Fund the import/send test account with testnet lumens before exercising the send flow:
+
+```bash
+curl "https://friendbot.stellar.org/?addr=${E2E_TEST_ADDRESS}"
+```
+
+If your wallet uses a different network, replace the URL with the matching testnet faucet endpoint.
+
+## Running the flows
+
+From the repository root:
+
+```bash
+maestro test apps/mobile-wallet/e2e/flows/create-wallet.yaml
+maestro test apps/mobile-wallet/e2e/flows/import-wallet.yaml
+maestro test apps/mobile-wallet/e2e/flows/lock-unlock.yaml
+```
+
+The send-payment flow is scaffolded and documented for when the signing/send feature ships:
+
+```bash
+maestro test apps/mobile-wallet/e2e/flows/send-payment.yaml
+```
+
+## CI status
+
+The mobile e2e workflow is intentionally manual-only until the onboarding and send flows are stable enough for automated execution. The `send-payment` and onboarding-driven flows are marked with TODO comments and are skipped from CI until the underlying issues ship.


### PR DESCRIPTION
## Summary
- add Maestro flow specs for create/import/send/lock-unlock
- add mobile e2e setup docs and environment guidance
- add a manual-only CI workflow for mobile Maestro flows

Closes #786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scaffolded mobile wallet end-to-end test flows for creating a wallet, importing a wallet, locking/unlocking, and sending a payment.
  * Added a mobile test runner setup so these flows can be launched consistently.

* **Documentation**
  * Added setup and usage instructions for running mobile end-to-end tests locally.
  * Included required environment variables, test account funding guidance, and CI availability notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->