### PR TITLE
feat: implement issues #73, #74, #99, #472 — storage, UI components, wallet orchestration, rate-limiting

### DIFF
--- a/apps/extension-wallet/src/background/storage.ts
+++ b/apps/extension-wallet/src/background/storage.ts
@@ -1,0 +1,31 @@
+/**
+ * background/storage.ts
+ *
+ * Background-context entry point for the SecureStorageManager singleton.
+ *
+ * The actual singleton lives in `@/security/storage-manager` so it can be
+ * shared across the security module and the background handlers without
+ * creating multiple instances.  This file is the canonical import path for
+ * background service-worker code; it re-exports everything the background
+ * needs so callers only have to import from one place.
+ *
+ * Security note: the SecureStorageManager holds the derived CryptoKey
+ * in memory only for the duration of the active session.  Calling lock()
+ * (or waiting for the auto-lock timeout) clears the key from memory.
+ * The raw password and key material are never persisted.
+ *
+ * Usage in a background handler:
+ *
+ *   import { getStorageManager } from '@/background/storage';
+ *
+ *   const manager = getStorageManager();
+ *   const unlocked = await manager.unlock(password);
+ *   if (unlocked) {
+ *     const account = await manager.getAccount();
+ *   }
+ */
+
+export {
+  getSharedStorageManager as getStorageManager,
+  resetSharedStorageManagerForTests,
+} from '@/security/storage-manager';

--- a/packages/core-sdk/jest.config.cjs
+++ b/packages/core-sdk/jest.config.cjs
@@ -15,6 +15,8 @@ module.exports = {
     '^@ancore/stellar/(.*)$': '<rootDir>/../stellar/src/$1',
     '^@ancore/types$': '<rootDir>/../types/src/index.ts',
     '^@ancore/types/(.*)$': '<rootDir>/../types/src/$1',
+    '^@ancore/crypto$': '<rootDir>/../crypto/src/index.ts',
+    '^@ancore/crypto/(.*)$': '<rootDir>/../crypto/src/$1',
   },
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts', '!src/**/__tests__/**', '!src/index.ts'],

--- a/packages/core-sdk/src/__tests__/create-wallet.test.ts
+++ b/packages/core-sdk/src/__tests__/create-wallet.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for create-wallet.ts orchestration.
+ *
+ * All @ancore/crypto dependencies are mocked so tests run in pure Node without
+ * needing WASM, real entropy, or real PBKDF2. The AncoreClient.createWallet
+ * delegation path is also exercised via a separate describe block.
+ *
+ * Uses Jest globals (no import from 'jest'/'vitest') — consistent with the
+ * rest of the core-sdk test suite.
+ */
+
+// ─── Mock @ancore/crypto ──────────────────────────────────────────────────────
+
+const MOCK_MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+const MOCK_KEYPAIR = {
+  publicKey: () => 'GABC1234PUBLICKEY',
+  secret: () => 'SABC1234SECRETKEY',
+};
+
+const MOCK_ENCRYPTED_PAYLOAD = {
+  salt: 'mock-salt',
+  iv: 'mock-iv',
+  data: 'mock-ciphertext',
+};
+
+jest.mock('@ancore/crypto', () => ({
+  generateMnemonic: jest.fn(() => MOCK_MNEMONIC),
+  deriveKeypairFromMnemonic: jest.fn(() => MOCK_KEYPAIR),
+  encryptSecretKey: jest.fn(async () => MOCK_ENCRYPTED_PAYLOAD),
+}));
+
+// ─── Mock deriveContractId from wallet.ts ────────────────────────────────────
+
+jest.mock('../wallet', () => ({
+  deriveContractId: jest.fn((publicKey: string) => `C${publicKey.slice(1)}`),
+}));
+
+// ─── Mock @ancore/account-abstraction (needed by AncoreClient) ────────────────
+
+jest.mock('@ancore/account-abstraction', () => ({
+  AccountContract: jest.fn().mockImplementation(() => ({})),
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+import { generateMnemonic, deriveKeypairFromMnemonic, encryptSecretKey } from '@ancore/crypto';
+import { deriveContractId } from '../wallet';
+import { createWallet, type CreateWalletResult } from '../create-wallet';
+import { AncoreClient } from '../ancore-client';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function expectValidShape(result: CreateWalletResult): void {
+  expect(result.mnemonic).toBe(MOCK_MNEMONIC);
+  expect(result.publicKey).toBe('GABC1234PUBLICKEY');
+  expect(result.secretKey).toBe('SABC1234SECRETKEY');
+  expect(result.contractId).toBe('CABC1234PUBLICKEY');
+}
+
+// ─── createWallet() ───────────────────────────────────────────────────────────
+
+describe('createWallet orchestration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the correct wallet shape with default options', async () => {
+    const result = await createWallet();
+
+    expectValidShape(result);
+    expect(result.accountIndex).toBe(0);
+    expect(result.encryptedMnemonic).toBeUndefined();
+  });
+
+  it('calls generateMnemonic exactly once', async () => {
+    await createWallet();
+    expect(generateMnemonic).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls deriveKeypairFromMnemonic with the generated mnemonic and default accountIndex 0', async () => {
+    await createWallet();
+    expect(deriveKeypairFromMnemonic).toHaveBeenCalledWith(MOCK_MNEMONIC, 0);
+  });
+
+  it('calls deriveKeypairFromMnemonic with the provided accountIndex', async () => {
+    await createWallet({ accountIndex: 3 });
+    expect(deriveKeypairFromMnemonic).toHaveBeenCalledWith(MOCK_MNEMONIC, 3);
+  });
+
+  it('returns the correct accountIndex in the result', async () => {
+    const result = await createWallet({ accountIndex: 5 });
+    expect(result.accountIndex).toBe(5);
+  });
+
+  it('does NOT call encryptSecretKey when no password is provided', async () => {
+    await createWallet();
+    expect(encryptSecretKey).not.toHaveBeenCalled();
+  });
+
+  it('calls encryptSecretKey with the mnemonic and password when password is provided', async () => {
+    await createWallet({ password: 'hunter2' });
+    expect(encryptSecretKey).toHaveBeenCalledWith(MOCK_MNEMONIC, 'hunter2');
+  });
+
+  it('includes encryptedMnemonic in result when password is provided', async () => {
+    const result = await createWallet({ password: 'hunter2' });
+    expect(result.encryptedMnemonic).toStrictEqual(MOCK_ENCRYPTED_PAYLOAD);
+  });
+
+  it('encryptedMnemonic is undefined when password is omitted', async () => {
+    const result = await createWallet({});
+    expect(result.encryptedMnemonic).toBeUndefined();
+  });
+
+  it('calls deriveContractId with the derived public key', async () => {
+    await createWallet();
+    expect(deriveContractId).toHaveBeenCalledWith('GABC1234PUBLICKEY');
+  });
+
+  it('returns contractId derived from publicKey via mock', async () => {
+    const result = await createWallet();
+    // mock: deriveContractId returns 'C' + publicKey.slice(1)
+    expect(result.contractId).toBe('CABC1234PUBLICKEY');
+  });
+
+  it('throws when accountIndex is negative', async () => {
+    await expect(createWallet({ accountIndex: -1 })).rejects.toThrow(
+      'accountIndex must be a non-negative integer.'
+    );
+  });
+
+  it('throws when accountIndex is a float', async () => {
+    await expect(createWallet({ accountIndex: 1.5 })).rejects.toThrow(
+      'accountIndex must be a non-negative integer.'
+    );
+  });
+
+  it('accepts accountIndex of 0 (lower boundary)', async () => {
+    const result = await createWallet({ accountIndex: 0 });
+    expect(result.accountIndex).toBe(0);
+  });
+
+  it('accepts large accountIndex values', async () => {
+    const result = await createWallet({ accountIndex: 999 });
+    expect(result.accountIndex).toBe(999);
+    expect(deriveKeypairFromMnemonic).toHaveBeenCalledWith(MOCK_MNEMONIC, 999);
+  });
+});
+
+// ─── AncoreClient.createWallet delegation ────────────────────────────────────
+
+describe('AncoreClient.createWallet', () => {
+  let client: AncoreClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new AncoreClient({ accountContractId: 'CTEST123' });
+  });
+
+  it('exists on the AncoreClient instance', () => {
+    expect(typeof client.createWallet).toBe('function');
+  });
+
+  it('delegates to the createWallet orchestration function', async () => {
+    const result = await client.createWallet();
+
+    expect(generateMnemonic).toHaveBeenCalledTimes(1);
+    expect(deriveKeypairFromMnemonic).toHaveBeenCalledWith(MOCK_MNEMONIC, 0);
+    expectValidShape(result);
+  });
+
+  it('passes params through to the orchestration layer', async () => {
+    await client.createWallet({ password: 'pass123', accountIndex: 2 });
+
+    expect(deriveKeypairFromMnemonic).toHaveBeenCalledWith(MOCK_MNEMONIC, 2);
+    expect(encryptSecretKey).toHaveBeenCalledWith(MOCK_MNEMONIC, 'pass123');
+  });
+
+  it('returns encryptedMnemonic when password is provided', async () => {
+    const result = await client.createWallet({ password: 'pass123' });
+    expect(result.encryptedMnemonic).toStrictEqual(MOCK_ENCRYPTED_PAYLOAD);
+  });
+
+  it('returns undefined encryptedMnemonic when no password is provided', async () => {
+    const result = await client.createWallet();
+    expect(result.encryptedMnemonic).toBeUndefined();
+  });
+
+  it('throws for negative accountIndex', async () => {
+    await expect(client.createWallet({ accountIndex: -5 })).rejects.toThrow(
+      'accountIndex must be a non-negative integer.'
+    );
+  });
+});

--- a/packages/core-sdk/src/ancore-client.ts
+++ b/packages/core-sdk/src/ancore-client.ts
@@ -1,6 +1,11 @@
 import { AccountContract, type InvocationArgs } from '@ancore/account-abstraction';
 
 import { addSessionKey, type AddSessionKeyParams, type SessionKeyWriter } from './add-session-key';
+import {
+  createWallet as createWalletOrchestration,
+  type CreateWalletParams,
+  type CreateWalletResult,
+} from './create-wallet';
 import { BuilderValidationError } from './errors';
 import {
   refreshSessionKeyTtl,
@@ -30,6 +35,24 @@ export class AncoreClient {
     }
 
     this.accountContract = new AccountContract(options.accountContractId);
+  }
+
+  /**
+   * Creates a new Ancore wallet by generating a fresh BIP39 mnemonic, deriving
+   * an Ed25519 keypair via BIP-44 HD derivation, and optionally encrypting the
+   * mnemonic with the provided password.
+   *
+   * @example
+   * ```typescript
+   * const client = new AncoreClient({ accountContractId: 'C...' });
+   * const wallet = await client.createWallet({ password: 'hunter2' });
+   * // wallet.publicKey  → G…  (safe to persist)
+   * // wallet.contractId → C…  (safe to persist)
+   * // wallet.encryptedMnemonic → persist this; do NOT persist wallet.secretKey
+   * ```
+   */
+  createWallet(params?: CreateWalletParams): Promise<CreateWalletResult> {
+    return createWalletOrchestration(params);
   }
 
   addSessionKey(params: AddSessionKeyParams): InvocationArgs {

--- a/packages/core-sdk/src/create-wallet.ts
+++ b/packages/core-sdk/src/create-wallet.ts
@@ -1,0 +1,116 @@
+/**
+ * create-wallet.ts
+ *
+ * Orchestration layer for the "create wallet" flow in @ancore/core-sdk.
+ *
+ * Wires together:
+ *  1. BIP39 mnemonic generation          (@ancore/crypto → generateMnemonic)
+ *  2. HD keypair derivation              (@ancore/crypto → deriveKeypairFromMnemonic)
+ *  3. Optional secret-material encryption (@ancore/crypto → encryptSecretKey)
+ *
+ * Security contract:
+ * - When `password` is provided the mnemonic is encrypted before being
+ *   returned in `encryptedMnemonic`. Persist ONLY the encrypted form.
+ * - When `password` is omitted, `encryptedMnemonic` is `undefined`. The
+ *   caller is responsible for securing `secretKey` and `mnemonic`.
+ *
+ * @example
+ * ```typescript
+ * import { createWallet } from '@ancore/core-sdk';
+ *
+ * const wallet = await createWallet({ password: 'hunter2' });
+ * console.log(wallet.publicKey);   // G…
+ * console.log(wallet.contractId);  // C…
+ * // Persist wallet.encryptedMnemonic only; do NOT persist wallet.secretKey
+ * ```
+ */
+
+import {
+  deriveKeypairFromMnemonic,
+  encryptSecretKey,
+  generateMnemonic,
+  type EncryptedSecretKeyPayload,
+} from '@ancore/crypto';
+
+import { deriveContractId } from './wallet';
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/**
+ * Options for {@link createWallet}.
+ */
+export interface CreateWalletParams {
+  /**
+   * Password used to encrypt the mnemonic. When omitted the wallet is created
+   * without encryption — `encryptedMnemonic` will be `undefined` in the result.
+   */
+  password?: string;
+  /**
+   * BIP-44 account index used for HD derivation (default: 0).
+   * Must be a non-negative integer.
+   */
+  accountIndex?: number;
+}
+
+/**
+ * Typed result returned by {@link createWallet}.
+ *
+ * - `publicKey` and `contractId` are safe to persist and share.
+ * - `mnemonic` and `secretKey` are **sensitive** — handle in-memory only.
+ * - `encryptedMnemonic` is the encrypted form of `mnemonic` (only present
+ *   when a password was supplied). Persist this instead of the raw mnemonic.
+ */
+export interface CreateWalletResult {
+  /** BIP39 mnemonic phrase. Treat as a secret. */
+  mnemonic: string;
+  /** Stellar Ed25519 public key (G…). Safe to share. */
+  publicKey: string;
+  /** Stellar Ed25519 secret key (S…). Treat as a secret. */
+  secretKey: string;
+  /** HD account index used during derivation. */
+  accountIndex: number;
+  /** Deterministic contract ID derived from the public key (C…). Safe to share. */
+  contractId: string;
+  /**
+   * PBKDF2-encrypted mnemonic. Present only when a `password` was provided.
+   * Persist this value to durable storage instead of the raw mnemonic.
+   */
+  encryptedMnemonic?: EncryptedSecretKeyPayload;
+}
+
+// ─── Orchestration ────────────────────────────────────────────────────────────
+
+/**
+ * Creates a new Ancore wallet by:
+ * 1. Generating a fresh BIP39 mnemonic
+ * 2. Deriving an Ed25519 keypair via BIP-44 HD derivation
+ * 3. Optionally encrypting the mnemonic with PBKDF2 + AES-GCM
+ *
+ * @throws {Error} If `accountIndex` is not a non-negative integer.
+ */
+export async function createWallet(params: CreateWalletParams = {}): Promise<CreateWalletResult> {
+  const { password, accountIndex: rawIndex = 0 } = params;
+
+  if (!Number.isInteger(rawIndex) || rawIndex < 0) {
+    throw new Error('accountIndex must be a non-negative integer.');
+  }
+
+  // Step 1: Generate fresh BIP39 mnemonic
+  const mnemonic = generateMnemonic();
+
+  // Step 2: Derive keypair at the requested HD account index
+  const keypair = deriveKeypairFromMnemonic(mnemonic, rawIndex);
+
+  // Step 3: Encrypt the mnemonic if a password was supplied
+  const encryptedMnemonic =
+    password !== undefined ? await encryptSecretKey(mnemonic, password) : undefined;
+
+  return {
+    mnemonic,
+    publicKey: keypair.publicKey(),
+    secretKey: keypair.secret(),
+    accountIndex: rawIndex,
+    contractId: deriveContractId(keypair.publicKey()),
+    encryptedMnemonic,
+  };
+}

--- a/packages/core-sdk/src/index.ts
+++ b/packages/core-sdk/src/index.ts
@@ -16,6 +16,13 @@ export {
   type WalletMaterial,
 } from './wallet';
 
+// Create wallet orchestration (standalone + exposed via AncoreClient.createWallet)
+export {
+  createWallet as createWalletOrchestration,
+  type CreateWalletParams,
+  type CreateWalletResult,
+} from './create-wallet';
+
 // Client
 export { AncoreClient, type AncoreClientOptions } from './ancore-client';
 

--- a/packages/core-sdk/src/storage/__tests__/chrome-compat.test.ts
+++ b/packages/core-sdk/src/storage/__tests__/chrome-compat.test.ts
@@ -1,0 +1,298 @@
+/**
+ * chrome-compat.test.ts
+ *
+ * Smoke tests for the storage adapter selection logic.
+ * Validates that createStorageAdapter() wires up the correct adapter
+ * (Chrome, Firefox/browser, or localStorage fallback) based on the
+ * available runtime globals, and that the SecureStorageManager works
+ * end-to-end with both the Chrome and Firefox adapter mocks.
+ */
+
+import { webcrypto } from 'crypto';
+
+if (!globalThis.crypto) {
+  // @ts-expect-error - Polyfill for Node.js test environment
+  globalThis.crypto = webcrypto;
+}
+if (!globalThis.btoa) {
+  globalThis.btoa = (str: string) => Buffer.from(str, 'binary').toString('base64');
+}
+if (!globalThis.atob) {
+  globalThis.atob = (str: string) => Buffer.from(str, 'base64').toString('binary');
+}
+
+import {
+  ChromeStorageAdapter,
+  BrowserStorageAdapter,
+  LocalStorageAdapter,
+  createStorageAdapter,
+} from '../storage-adapter';
+import { SecureStorageManager } from '../secure-storage-manager';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeChromeStorageArea(store: Record<string, unknown> = {}) {
+  return {
+    get: jest.fn((key: string, cb: (r: Record<string, unknown>) => void) => {
+      cb({ [key]: store[key] });
+    }),
+    set: jest.fn((items: Record<string, unknown>, cb: () => void) => {
+      Object.assign(store, items);
+      cb();
+    }),
+    remove: jest.fn((key: string, cb: () => void) => {
+      delete store[key];
+      cb();
+    }),
+    getBytesInUse: jest.fn((_: null, cb: (n: number) => void) => cb(0)),
+    QUOTA_BYTES: 5242880,
+  };
+}
+
+function makeBrowserStorageArea(store: Record<string, unknown> = {}) {
+  return {
+    get: jest.fn(async (key: string) => ({ [key]: store[key] })),
+    set: jest.fn(async (items: Record<string, unknown>) => {
+      Object.assign(store, items);
+    }),
+    remove: jest.fn(async (key: string) => {
+      delete store[key];
+    }),
+  };
+}
+
+function installMemoryLocalStorage(): void {
+  const data = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    get length() {
+      return data.size;
+    },
+    clear(): void {
+      data.clear();
+    },
+    getItem(key: string): string | null {
+      return data.has(key) ? (data.get(key) as string) : null;
+    },
+    key(index: number): string | null {
+      return [...data.keys()][index] ?? null;
+    },
+    removeItem(key: string): void {
+      data.delete(key);
+    },
+    setItem(key: string, value: string): void {
+      data.set(key, value);
+    },
+  } as Storage;
+}
+
+// ─── createStorageAdapter selection ──────────────────────────────────────────
+
+describe('createStorageAdapter — runtime adapter selection', () => {
+  let savedChrome: unknown;
+  let savedBrowser: unknown;
+
+  beforeEach(() => {
+    savedChrome = (globalThis as Record<string, unknown>).chrome;
+    savedBrowser = (globalThis as Record<string, unknown>).browser;
+    delete (globalThis as Record<string, unknown>).chrome;
+    delete (globalThis as Record<string, unknown>).browser;
+    installMemoryLocalStorage();
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).chrome = savedChrome;
+    (globalThis as Record<string, unknown>).browser = savedBrowser;
+  });
+
+  it('returns LocalStorageAdapter when neither chrome nor browser globals are present', () => {
+    const adapter = createStorageAdapter();
+    expect(adapter).toBeInstanceOf(LocalStorageAdapter);
+  });
+
+  it('returns ChromeStorageAdapter when chrome.storage.local is available', () => {
+    (globalThis as Record<string, unknown>).chrome = {
+      storage: { local: makeChromeStorageArea() },
+      runtime: { lastError: undefined },
+    };
+
+    const adapter = createStorageAdapter();
+    expect(adapter).toBeInstanceOf(ChromeStorageAdapter);
+  });
+
+  it('returns BrowserStorageAdapter when browser.storage.local is available (Firefox)', () => {
+    (globalThis as Record<string, unknown>).browser = {
+      storage: { local: makeBrowserStorageArea() },
+    };
+
+    const adapter = createStorageAdapter();
+    expect(adapter).toBeInstanceOf(BrowserStorageAdapter);
+  });
+
+  it('prefers BrowserStorageAdapter over ChromeStorageAdapter when both are present', () => {
+    (globalThis as Record<string, unknown>).browser = {
+      storage: { local: makeBrowserStorageArea() },
+    };
+    (globalThis as Record<string, unknown>).chrome = {
+      storage: { local: makeChromeStorageArea() },
+      runtime: { lastError: undefined },
+    };
+
+    const adapter = createStorageAdapter();
+    // browser namespace (Firefox) takes precedence per createStorageAdapter() logic
+    expect(adapter).toBeInstanceOf(BrowserStorageAdapter);
+  });
+});
+
+// ─── SecureStorageManager + ChromeStorageAdapter ─────────────────────────────
+
+describe('SecureStorageManager with ChromeStorageAdapter (Chrome smoke test)', () => {
+  let area: ReturnType<typeof makeChromeStorageArea>;
+  let adapter: ChromeStorageAdapter;
+  let manager: SecureStorageManager;
+  const password = 'chrome-test-password-123!';
+
+  beforeEach(() => {
+    area = makeChromeStorageArea();
+    (globalThis as Record<string, unknown>).chrome = {
+      storage: { local: area },
+      runtime: { lastError: undefined },
+    };
+    adapter = new ChromeStorageAdapter(
+      area as Parameters<typeof ChromeStorageAdapter.prototype.constructor>[0]
+    );
+    manager = new SecureStorageManager(adapter);
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).chrome;
+  });
+
+  it('unlocks successfully on first use (no existing vault)', async () => {
+    const result = await manager.unlock(password);
+    expect(result).toBe(true);
+    expect(manager.isUnlocked).toBe(true);
+  });
+
+  it('saves and retrieves account data encrypted via Chrome storage', async () => {
+    await manager.unlock(password);
+    await manager.saveAccount({ privateKey: 'STEST_CHROME_KEY_ABCDEF' });
+
+    // The raw stored value must NOT contain the plaintext private key
+    const rawStored = area.set.mock.calls.find(
+      ([items]: [Record<string, unknown>]) => 'account' in items
+    );
+    expect(rawStored).toBeDefined();
+    const rawJson = JSON.stringify(rawStored![0]);
+    expect(rawJson).not.toContain('STEST_CHROME_KEY_ABCDEF');
+
+    // Re-unlock with a fresh manager instance to confirm round-trip
+    manager.lock();
+    const manager2 = new SecureStorageManager(adapter);
+    await manager2.unlock(password);
+    const account = await manager2.getAccount();
+    expect(account?.privateKey).toBe('STEST_CHROME_KEY_ABCDEF');
+  });
+
+  it('lock() clears the in-memory key and subsequent reads throw', async () => {
+    await manager.unlock(password);
+    manager.lock();
+    expect(manager.isUnlocked).toBe(false);
+    await expect(manager.getAccount()).rejects.toThrow('Storage manager is locked');
+  });
+
+  it('hasVault() returns false before first unlock and true afterwards', async () => {
+    expect(await manager.hasVault()).toBe(false);
+    await manager.unlock(password);
+    expect(await manager.hasVault()).toBe(true);
+  });
+});
+
+// ─── SecureStorageManager + BrowserStorageAdapter ────────────────────────────
+
+describe('SecureStorageManager with BrowserStorageAdapter (Firefox smoke test)', () => {
+  let area: ReturnType<typeof makeBrowserStorageArea>;
+  let adapter: BrowserStorageAdapter;
+  let manager: SecureStorageManager;
+  const password = 'firefox-test-password-456!';
+
+  beforeEach(() => {
+    area = makeBrowserStorageArea();
+    (globalThis as Record<string, unknown>).browser = {
+      storage: { local: area },
+    };
+    adapter = new BrowserStorageAdapter(
+      area as Parameters<typeof BrowserStorageAdapter.prototype.constructor>[0]
+    );
+    manager = new SecureStorageManager(adapter);
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).browser;
+  });
+
+  it('unlocks successfully on first use (no existing vault)', async () => {
+    const result = await manager.unlock(password);
+    expect(result).toBe(true);
+    expect(manager.isUnlocked).toBe(true);
+  });
+
+  it('saves and retrieves session keys encrypted via Firefox storage', async () => {
+    await manager.unlock(password);
+    await manager.saveSessionKeys({ keys: { sessionA: 'SECRET_KEY_FIREFOX' } });
+
+    // Verify the raw stored data does not expose plaintext
+    const rawCalls = area.set.mock.calls as Array<[Record<string, unknown>]>;
+    const sessionKeyCall = rawCalls.find(([items]) => 'sessionKeys' in items);
+    expect(sessionKeyCall).toBeDefined();
+    expect(JSON.stringify(sessionKeyCall![0])).not.toContain('SECRET_KEY_FIREFOX');
+
+    // Re-unlock with a fresh manager and verify decrypted round-trip
+    manager.lock();
+    const manager2 = new SecureStorageManager(adapter);
+    await manager2.unlock(password);
+    const sessionKeys = await manager2.getSessionKeys();
+    expect(sessionKeys?.keys?.sessionA).toBe('SECRET_KEY_FIREFOX');
+  });
+
+  it('wrong password returns false and leaves manager locked', async () => {
+    await manager.unlock(password);
+    manager.lock();
+
+    const manager2 = new SecureStorageManager(adapter);
+    const result = await manager2.unlock('totally-wrong-password');
+    expect(result).toBe(false);
+    expect(manager2.isUnlocked).toBe(false);
+  });
+
+  it('lock() clears the in-memory key and subsequent reads throw', async () => {
+    await manager.unlock(password);
+    manager.lock();
+    expect(manager.isUnlocked).toBe(false);
+    await expect(manager.getAccount()).rejects.toThrow('Storage manager is locked');
+  });
+});
+
+// ─── SecureStorageManager + LocalStorageAdapter (fallback) ───────────────────
+
+describe('SecureStorageManager with LocalStorageAdapter (fallback / dev env)', () => {
+  let manager: SecureStorageManager;
+  const password = 'local-storage-password-789!';
+
+  beforeEach(() => {
+    installMemoryLocalStorage();
+    globalThis.localStorage.clear();
+    manager = new SecureStorageManager(new LocalStorageAdapter());
+  });
+
+  it('unlocks and saves/retrieves data via localStorage fallback', async () => {
+    await manager.unlock(password);
+    await manager.saveAccount({ privateKey: 'STEST_LOCAL_KEY' });
+
+    manager.lock();
+    const manager2 = new SecureStorageManager(new LocalStorageAdapter());
+    await manager2.unlock(password);
+
+    const account = await manager2.getAccount();
+    expect(account?.privateKey).toBe('STEST_LOCAL_KEY');
+  });
+});

--- a/packages/ui-kit/src/components/Identicon.stories.tsx
+++ b/packages/ui-kit/src/components/Identicon.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Identicon } from './Identicon';
+
+const meta = {
+  title: 'Wallet/Identicon',
+  component: Identicon,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Renders a deterministic 5×5 mirrored pixel-art avatar from any string value (typically a Stellar address). Identical inputs always produce identical output; different inputs produce visually distinct icons.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: 'text',
+      description: 'The address or string to derive the identicon from.',
+    },
+    size: {
+      control: { type: 'number', min: 16, max: 128, step: 8 },
+      description: 'Width and height of the SVG in pixels.',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label. Defaults to "Identicon for address <value>".',
+    },
+  },
+} satisfies Meta<typeof Identicon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleAddress = 'GCZJM35NKGVK47BB4SPBDV25477PZYIYPVVG453LPYFNXLS3FGHDXOCM';
+
+// ─── Single instances ─────────────────────────────────────────────────────────
+
+export const Default: Story = {
+  args: { value: sampleAddress },
+};
+
+export const Small: Story = {
+  args: { value: sampleAddress, size: 24 },
+};
+
+export const Large: Story = {
+  args: { value: sampleAddress, size: 80 },
+};
+
+export const CustomLabel: Story = {
+  args: { value: sampleAddress, size: 48, label: 'Primary wallet avatar' },
+};
+
+// ─── Uniqueness showcase ──────────────────────────────────────────────────────
+
+export const UniquePerAddress: Story = {
+  name: 'Unique per Address',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Every address produces a visually distinct identicon.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-wrap gap-3">
+      {[
+        'GCZJM35NKGVK47BB4SPBDV25477PZYIYPVVG453LPYFNXLS3FGHDXOCM',
+        'GBVFCZE3VZQJPTXDZH3UZEJWIXJLXGCQFXHZCEBR3Q2RVCZ3QGYQJKGH',
+        'GABC123STELLARWALLETADDRESSEXAMPLEXXX',
+        'GDEZQSCR4BEVIAR5BSBI2ZV7EVSHJBPZWXHQKMD3XKZXZLBM',
+        'GASDQWERTYJKLMNBVCXZZAQWSEDFRTGYHUJIKLOP',
+        'GTEST456DIFFERENTHASHPRODUCESDIFFERENTCOLORS',
+      ].map((addr) => (
+        <div key={addr} className="flex flex-col items-center gap-1">
+          <Identicon value={addr} size={40} />
+          <code className="text-[9px] text-muted-foreground">{addr.slice(0, 6)}</code>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+// ─── Sizes ────────────────────────────────────────────────────────────────────
+
+export const SizeScale: Story = {
+  name: 'Size Scale',
+  render: () => (
+    <div className="flex items-end gap-4">
+      {[16, 24, 32, 40, 48, 64, 80].map((size) => (
+        <div key={size} className="flex flex-col items-center gap-1">
+          <Identicon value={sampleAddress} size={size} />
+          <span className="text-[10px] text-muted-foreground">{size}px</span>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui-kit/src/components/QRCode.stories.tsx
+++ b/packages/ui-kit/src/components/QRCode.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QRCode } from './QRCode';
+
+const meta = {
+  title: 'Wallet/QRCode',
+  component: QRCode,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Renders a styled, accessible SVG QR code for Stellar addresses or payment URIs. Uses `qrcode.react` under the hood with error-correction level M.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: 'text',
+      description: 'The address or URI to encode in the QR code.',
+    },
+    size: {
+      control: { type: 'number', min: 64, max: 512, step: 32 },
+      description: 'Width and height of the QR code SVG in pixels.',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label. Defaults to "QR code for address <value>".',
+    },
+  },
+} satisfies Meta<typeof QRCode>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sampleAddress = 'GCZJM35NKGVK47BB4SPBDV25477PZYIYPVVG453LPYFNXLS3FGHDXOCM';
+
+// ─── Core variants ────────────────────────────────────────────────────────────
+
+export const Default: Story = {
+  args: { value: sampleAddress },
+};
+
+export const Small: Story = {
+  args: { value: sampleAddress, size: 128 },
+};
+
+export const Large: Story = {
+  args: { value: sampleAddress, size: 320 },
+};
+
+export const CustomLabel: Story = {
+  args: { value: sampleAddress, size: 192, label: 'Scan to send XLM' },
+};
+
+// ─── Payment URI ──────────────────────────────────────────────────────────────
+
+export const PaymentURI: Story = {
+  name: 'Payment URI',
+  args: {
+    value: `web+stellar:pay?destination=${sampleAddress}&amount=10&asset_code=XLM`,
+    label: 'Pay 10 XLM',
+    size: 224,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'QR codes can encode SEP-0007 payment URIs, allowing wallets to pre-fill send forms when scanned.',
+      },
+    },
+  },
+};
+
+// ─── Sizes ────────────────────────────────────────────────────────────────────
+
+export const SizeScale: Story = {
+  name: 'Size Scale',
+  render: () => (
+    <div className="flex items-end gap-6">
+      {[96, 128, 192, 256].map((size) => (
+        <div key={size} className="flex flex-col items-center gap-2">
+          <QRCode value={sampleAddress} size={size} />
+          <span className="text-xs text-muted-foreground">{size}px</span>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+// ─── In context ──────────────────────────────────────────────────────────────
+
+export const ReceiveCard: Story = {
+  name: 'Receive Card',
+  render: () => (
+    <div className="w-[300px] rounded-xl border bg-card text-card-foreground shadow-sm p-6 flex flex-col items-center gap-4">
+      <h3 className="text-base font-semibold">Receive XLM</h3>
+      <QRCode value={sampleAddress} size={200} label="Scan to send to this wallet" />
+      <div className="w-full rounded-md border border-input bg-background px-3 py-2">
+        <code className="block text-xs font-mono text-muted-foreground text-center break-all">
+          {sampleAddress.slice(0, 12)}...{sampleAddress.slice(-12)}
+        </code>
+      </div>
+      <p className="text-xs text-muted-foreground text-center">
+        Scan the QR code or share your address to receive funds.
+      </p>
+    </div>
+  ),
+};

--- a/packages/ui-kit/src/components/address-display.stories.tsx
+++ b/packages/ui-kit/src/components/address-display.stories.tsx
@@ -6,8 +6,27 @@ const meta = {
   component: AddressDisplay,
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Displays a Stellar address with optional truncation, copy-to-clipboard, identicon avatar, full-address tooltip on hover, and validation state feedback.',
+      },
+    },
   },
   tags: ['autodocs'],
+  argTypes: {
+    truncate: {
+      control: { type: 'number', min: 4, max: 20, step: 1 },
+      description: 'Characters shown at each end of the truncated address.',
+    },
+    copyable: { control: 'boolean' },
+    showIdenticon: { control: 'boolean' },
+    isValid: {
+      control: 'select',
+      options: [undefined, true, false],
+      description: 'When false, renders a destructive border and alert icon.',
+    },
+  },
 } satisfies Meta<typeof AddressDisplay>;
 
 export default meta;
@@ -15,78 +34,140 @@ type Story = StoryObj<typeof meta>;
 
 const sampleAddress = 'GCZJM35NKGVK47BB4SPBDV25477PZYIYPVVG453LPYFNXLS3FGHDXOCM';
 
+// ─── Core variants ────────────────────────────────────────────────────────────
+
 export const Default: Story = {
-  args: {
-    address: sampleAddress,
-  },
+  args: { address: sampleAddress },
   render: (args) => (
-    <div className="w-[350px]">
+    <div className="w-[380px]">
       <AddressDisplay {...args} />
     </div>
   ),
 };
 
 export const WithLabel: Story = {
-  args: {
-    address: sampleAddress,
-    label: 'Wallet Address',
-  },
+  args: { address: sampleAddress, label: 'Wallet Address' },
   render: (args) => (
-    <div className="w-[350px]">
+    <div className="w-[380px]">
       <AddressDisplay {...args} />
     </div>
   ),
 };
 
 export const NoCopy: Story = {
-  args: {
-    address: sampleAddress,
-    copyable: false,
-    label: 'Read-only Address',
-  },
+  args: { address: sampleAddress, copyable: false, label: 'Read-only Address' },
   render: (args) => (
-    <div className="w-[350px]">
+    <div className="w-[380px]">
       <AddressDisplay {...args} />
     </div>
   ),
 };
 
 export const CustomTruncation: Story = {
-  args: {
-    address: sampleAddress,
-    truncate: 10,
-    label: 'More Characters Visible',
-  },
+  args: { address: sampleAddress, truncate: 10, label: 'More Characters Visible' },
   render: (args) => (
-    <div className="w-[350px]">
+    <div className="w-[380px]">
       <AddressDisplay {...args} />
     </div>
   ),
 };
 
 export const ShortAddress: Story = {
-  args: {
-    address: 'SHORT',
-    label: 'Short Address (No Truncation)',
-  },
+  args: { address: 'SHORT', label: 'Short Address (No Truncation)' },
   render: (args) => (
-    <div className="w-[350px]">
+    <div className="w-[380px]">
       <AddressDisplay {...args} />
     </div>
   ),
 };
 
+// ─── Identicon ────────────────────────────────────────────────────────────────
+
+export const WithIdenticon: Story = {
+  name: 'With Identicon',
+  args: { address: sampleAddress, label: 'Your Wallet', showIdenticon: true },
+  render: (args) => (
+    <div className="w-[380px]">
+      <AddressDisplay {...args} />
+    </div>
+  ),
+};
+
+export const WithIdenticonNoCopy: Story = {
+  name: 'Identicon — Read-only',
+  args: {
+    address: sampleAddress,
+    label: 'Recipient Address',
+    showIdenticon: true,
+    copyable: false,
+  },
+  render: (args) => (
+    <div className="w-[380px]">
+      <AddressDisplay {...args} />
+    </div>
+  ),
+};
+
+// ─── Validation feedback ─────────────────────────────────────────────────────
+
+export const ValidAddress: Story = {
+  name: 'Validation — Valid',
+  args: {
+    address: sampleAddress,
+    label: 'Validated Address',
+    isValid: true,
+  },
+  render: (args) => (
+    <div className="w-[380px]">
+      <AddressDisplay {...args} />
+    </div>
+  ),
+};
+
+export const InvalidAddress: Story = {
+  name: 'Validation — Invalid',
+  args: {
+    address: 'not-a-stellar-address',
+    label: 'Invalid Address',
+    isValid: false,
+  },
+  render: (args) => (
+    <div className="w-[380px]">
+      <AddressDisplay {...args} />
+    </div>
+  ),
+};
+
+export const InvalidWithIdenticon: Story = {
+  name: 'Validation — Invalid + Identicon',
+  args: {
+    address: 'bad-address',
+    label: 'Unresolved Address',
+    isValid: false,
+    showIdenticon: true,
+  },
+  render: (args) => (
+    <div className="w-[380px]">
+      <AddressDisplay {...args} />
+    </div>
+  ),
+};
+
+// ─── Compound examples ────────────────────────────────────────────────────────
+
 export const MultipleAddresses: Story = {
   render: () => (
-    <div className="w-[400px] space-y-4">
-      <AddressDisplay address={sampleAddress} label="From Address" />
+    <div className="w-[420px] space-y-4">
+      <AddressDisplay address={sampleAddress} label="From Address" showIdenticon />
       <AddressDisplay
         address="GBVFCZE3VZQJPTXDZH3UZEJWIXJLXGCQFXHZCEBR3Q2RVCZ3QGYQJKGH"
         label="To Address"
+        showIdenticon
       />
       <AddressDisplay
-        address="GASDQWERTYJKLMNBVCXZZAQWSEDFRTGYHUJIKLOP"
-        label="Memo"
+        address="bad-address"
+        label="Memo Address (invalid)"
+        isValid={false}
         copyable={false}
       />
     </div>
@@ -95,9 +176,9 @@ export const MultipleAddresses: Story = {
 
 export const InCard: Story = {
   render: () => (
-    <div className="w-[400px] rounded-lg border bg-card text-card-foreground shadow-sm p-6 space-y-4">
+    <div className="w-[420px] rounded-lg border bg-card text-card-foreground shadow-sm p-6 space-y-4">
       <h3 className="text-lg font-semibold">Account Information</h3>
-      <AddressDisplay address={sampleAddress} label="Your Wallet Address" />
+      <AddressDisplay address={sampleAddress} label="Your Wallet Address" showIdenticon />
       <div className="flex justify-between text-sm">
         <span className="text-muted-foreground">Balance:</span>
         <span className="font-semibold">100.50 XLM</span>

--- a/packages/ui-kit/src/components/address-display.test.tsx
+++ b/packages/ui-kit/src/components/address-display.test.tsx
@@ -7,7 +7,6 @@ const sampleAddress = 'GCZJM35NKGVK47BB4SPBDV25477PZYIYPVVG453LPYFNXLS3FGHDXOCM'
 
 describe('AddressDisplay', () => {
   beforeEach(() => {
-    // Mock clipboard API
     Object.defineProperty(navigator, 'clipboard', {
       value: {
         writeText: vi.fn().mockResolvedValue(undefined),
@@ -17,51 +16,163 @@ describe('AddressDisplay', () => {
     });
   });
 
-  it('renders address with truncation', () => {
+  // ─── Truncation ──────────────────────────────────────────────────────────
+
+  it('renders address with default truncation', () => {
     render(<AddressDisplay address={sampleAddress} />);
     expect(screen.getByText(/GCZJM3...HDXOCM/)).toBeInTheDocument();
   });
+
+  it('renders full short addresses without truncation', () => {
+    render(<AddressDisplay address="SHORT" />);
+    // The tooltip duplicates the content, so query the <code> element specifically
+    const code = document.querySelector('code');
+    expect(code).toHaveTextContent('SHORT');
+  });
+
+  it('respects custom truncation length', () => {
+    render(<AddressDisplay address={sampleAddress} truncate={10} />);
+    expect(screen.getByText(/GCZJM35NKG...S3FGHDXOCM/)).toBeInTheDocument();
+  });
+
+  // ─── Label ───────────────────────────────────────────────────────────────
 
   it('renders label when provided', () => {
     render(<AddressDisplay address={sampleAddress} label="Wallet Address" />);
     expect(screen.getByText('Wallet Address')).toBeInTheDocument();
   });
 
-  it('shows full short addresses without truncation', () => {
-    const shortAddress = 'SHORT';
-    render(<AddressDisplay address={shortAddress} />);
-    expect(screen.getByText('SHORT')).toBeInTheDocument();
+  it('does not render a label element when omitted', () => {
+    const { container } = render(<AddressDisplay address={sampleAddress} />);
+    expect(container.querySelector('label')).toBeNull();
   });
+
+  // ─── Copy button ─────────────────────────────────────────────────────────
 
   it('renders copy button by default', () => {
     render(<AddressDisplay address={sampleAddress} />);
-    const copyButton = screen.getByLabelText('Copy address');
-    expect(copyButton).toBeInTheDocument();
+    expect(screen.getByLabelText('Copy address')).toBeInTheDocument();
   });
 
   it('hides copy button when copyable is false', () => {
     render(<AddressDisplay address={sampleAddress} copyable={false} />);
-    const copyButton = screen.queryByLabelText('Copy address');
-    expect(copyButton).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Copy address')).not.toBeInTheDocument();
   });
 
-  it('handles copy to clipboard', async () => {
+  it('copies full address to clipboard on click', async () => {
     const user = userEvent.setup();
     const writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText');
 
     render(<AddressDisplay address={sampleAddress} />);
-    const copyButton = screen.getByLabelText('Copy address');
-
-    await user.click(copyButton);
+    await user.click(screen.getByLabelText('Copy address'));
 
     await waitFor(() => {
       expect(writeTextSpy).toHaveBeenCalledWith(sampleAddress);
     });
   });
 
-  it('respects custom truncation length', () => {
-    render(<AddressDisplay address={sampleAddress} truncate={10} />);
-    // With truncate=10, we show 10 characters at start and end
-    expect(screen.getByText(/GCZJM35NKG...S3FGHDXOCM/)).toBeInTheDocument();
+  it('updates aria-label to "Copied!" after clicking', async () => {
+    const user = userEvent.setup();
+    render(<AddressDisplay address={sampleAddress} />);
+
+    await user.click(screen.getByLabelText('Copy address'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Copied!')).toBeInTheDocument();
+    });
+  });
+
+  it('announces copy to screen readers via aria-live region', async () => {
+    const user = userEvent.setup();
+    render(<AddressDisplay address={sampleAddress} />);
+
+    await user.click(screen.getByLabelText('Copy address'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Address copied to clipboard')).toBeInTheDocument();
+    });
+  });
+
+  it('calls custom onCopy handler instead of clipboard when provided', async () => {
+    const user = userEvent.setup();
+    const onCopy = vi.fn();
+    const writeTextSpy = vi.spyOn(navigator.clipboard, 'writeText');
+
+    render(<AddressDisplay address={sampleAddress} onCopy={onCopy} />);
+    await user.click(screen.getByLabelText('Copy address'));
+
+    expect(onCopy).toHaveBeenCalledOnce();
+    expect(writeTextSpy).not.toHaveBeenCalled();
+  });
+
+  it('respects controlled copied prop', () => {
+    render(<AddressDisplay address={sampleAddress} copied={true} />);
+    expect(screen.getByLabelText('Copied!')).toBeInTheDocument();
+  });
+
+  // ─── Tooltip (full address on hover) ─────────────────────────────────────
+
+  it('renders the full address in the tooltip content', () => {
+    const { container } = render(<AddressDisplay address={sampleAddress} />);
+    // The Tooltip renders the full address in a div inside .group
+    expect(container.textContent).toContain(sampleAddress);
+  });
+
+  it('exposes the full address via aria-label on the code element', () => {
+    render(<AddressDisplay address={sampleAddress} />);
+    expect(screen.getByLabelText(`Address: ${sampleAddress}`)).toBeInTheDocument();
+  });
+
+  // ─── Identicon ───────────────────────────────────────────────────────────
+
+  it('does not render identicon by default', () => {
+    render(<AddressDisplay address={sampleAddress} />);
+    // Identicon renders as an <svg role="img">; there should be none by default
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('renders identicon when showIdenticon is true', () => {
+    render(<AddressDisplay address={sampleAddress} showIdenticon />);
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  // ─── Validation feedback ─────────────────────────────────────────────────
+
+  it('shows no validation indicator by default (isValid undefined)', () => {
+    render(<AddressDisplay address={sampleAddress} />);
+    expect(screen.queryByLabelText('Invalid address')).not.toBeInTheDocument();
+  });
+
+  it('shows no validation indicator when isValid is true', () => {
+    render(<AddressDisplay address={sampleAddress} isValid={true} />);
+    expect(screen.queryByLabelText('Invalid address')).not.toBeInTheDocument();
+  });
+
+  it('shows AlertCircle icon when isValid is false', () => {
+    render(<AddressDisplay address={sampleAddress} isValid={false} />);
+    expect(screen.getByLabelText('Invalid address')).toBeInTheDocument();
+  });
+
+  it('applies destructive border class when isValid is false', () => {
+    const { container } = render(<AddressDisplay address={sampleAddress} isValid={false} />);
+    // The inner row div should carry the destructive border class
+    const row = container.querySelector('.border-destructive');
+    expect(row).toBeInTheDocument();
+  });
+
+  it('applies normal border class when isValid is true', () => {
+    const { container } = render(<AddressDisplay address={sampleAddress} isValid={true} />);
+    const row = container.querySelector('.border-input');
+    expect(row).toBeInTheDocument();
+  });
+
+  // ─── className passthrough ────────────────────────────────────────────────
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <AddressDisplay address={sampleAddress} className="my-custom-class" />
+    );
+    expect(container.firstChild).toHaveClass('my-custom-class');
   });
 });

--- a/packages/ui-kit/src/components/address-display.tsx
+++ b/packages/ui-kit/src/components/address-display.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
-import { Copy, Check } from 'lucide-react';
+import { Copy, Check, AlertCircle } from 'lucide-react';
+import { Identicon } from './Identicon';
+import { Tooltip } from './ui/tooltip';
 
 export interface AddressDisplayProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -27,11 +29,27 @@ export interface AddressDisplayProps extends React.HTMLAttributes<HTMLDivElement
    * Controlled copied state when using onCopy
    */
   copied?: boolean;
+  /**
+   * Whether to show an identicon avatar derived from the address
+   */
+  showIdenticon?: boolean;
+  /**
+   * Whether the address is valid. When explicitly set to false, renders a red error ring
+   * and an alert icon. When undefined (default), no validation indicator is shown.
+   */
+  isValid?: boolean;
 }
 
 /**
- * AddressDisplay - A component for displaying blockchain addresses
- * Features truncation, copy-to-clipboard functionality, and responsive design
+ * AddressDisplay - A component for displaying blockchain addresses.
+ *
+ * Features:
+ * - Truncation (configurable characters at each end)
+ * - Copy-to-clipboard with confirmation state
+ * - Full-address tooltip on hover / focus-within
+ * - Optional deterministic identicon avatar
+ * - Address validation visual feedback (isValid prop)
+ * - Fully accessible (labels, aria-live, keyboard navigable)
  */
 const AddressDisplay = React.forwardRef<HTMLDivElement, AddressDisplayProps>(
   (
@@ -42,6 +60,8 @@ const AddressDisplay = React.forwardRef<HTMLDivElement, AddressDisplayProps>(
       label,
       onCopy,
       copied: copiedProp,
+      showIdenticon = false,
+      isValid,
       className,
       ...props
     },
@@ -71,6 +91,10 @@ const AddressDisplay = React.forwardRef<HTMLDivElement, AddressDisplayProps>(
       }
     }, [address, onCopy]);
 
+    // Derive border / ring class from validation state
+    const borderClass =
+      isValid === false ? 'border-destructive ring-1 ring-destructive' : 'border-input';
+
     return (
       <div ref={ref} className={cn('space-y-1', className)} {...props}>
         {label && (
@@ -78,20 +102,56 @@ const AddressDisplay = React.forwardRef<HTMLDivElement, AddressDisplayProps>(
             {label}
           </label>
         )}
-        <div className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2">
-          <code className="flex-1 text-sm font-mono text-foreground break-all">
-            {displayAddress}
-          </code>
+
+        <div
+          className={cn(
+            'flex items-center gap-2 rounded-md border bg-background px-3 py-2 transition-colors',
+            borderClass
+          )}
+        >
+          {/* Identicon avatar */}
+          {showIdenticon && (
+            <Identicon value={address} size={24} className="shrink-0" aria-hidden="true" />
+          )}
+
+          {/* Truncated address with full-address tooltip */}
+          <Tooltip content={address}>
+            <code
+              className="flex-1 text-sm font-mono text-foreground break-all cursor-default"
+              aria-label={`Address: ${address}`}
+            >
+              {displayAddress}
+            </code>
+          </Tooltip>
+
+          {/* Validation error icon */}
+          {isValid === false && (
+            <AlertCircle
+              className="h-4 w-4 shrink-0 text-destructive"
+              aria-label="Invalid address"
+            />
+          )}
+
+          {/* Copy button */}
           {copyable && (
             <button
               type="button"
               onClick={handleCopy}
-              className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground h-8 w-8"
-              aria-label="Copy address"
+              className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground h-8 w-8 shrink-0"
+              aria-label={copied ? 'Copied!' : 'Copy address'}
             >
-              {copied ? <Check className="h-4 w-4 text-success" /> : <Copy className="h-4 w-4" />}
+              {copied ? (
+                <Check className="h-4 w-4 text-success" aria-hidden="true" />
+              ) : (
+                <Copy className="h-4 w-4" aria-hidden="true" />
+              )}
             </button>
           )}
+        </div>
+
+        {/* Live region announces copy success to screen readers */}
+        <div aria-live="polite" aria-atomic="true" className="sr-only">
+          {copied ? 'Address copied to clipboard' : ''}
         </div>
       </div>
     );

--- a/services/relayer/src/middleware/__tests__/routeRateLimiter.test.ts
+++ b/services/relayer/src/middleware/__tests__/routeRateLimiter.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for routeRateLimiter.ts
+ *
+ * Covers:
+ *  - Config map: expected rpm for each named route
+ *  - DEFAULT_ROUTE_CONFIG: applied for unknown routes
+ *  - createRouteRateLimiter: allows requests up to the limit, blocks (limit+1)th
+ *  - Per-route isolation: different routes maintain independent counters
+ *  - Per-account isolation: different account keys have independent counters
+ *  - Response headers: RateLimit-* draft headers present on allowed requests
+ *  - 429 body: includes error, route, retryAfter on blocked requests
+ *  - Override: rpm override takes precedence over the config map entry
+ *  - resolveRouteConfig: returns correct merged config for tests/introspection
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+import {
+  ROUTE_RATE_LIMIT_CONFIG,
+  DEFAULT_ROUTE_CONFIG,
+  createRouteRateLimiter,
+  resolveRouteConfig,
+} from '../routeRateLimiter';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildApp(route: string, rpm: number) {
+  const app = express();
+  app.use(express.json());
+  app.post(route, createRouteRateLimiter(route, { rpm }), (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+  return app;
+}
+
+function buildMultiRouteApp(routes: Array<{ path: string; rpm: number }>) {
+  const app = express();
+  app.use(express.json());
+  for (const { path, rpm } of routes) {
+    app.post(path, createRouteRateLimiter(path, { rpm }), (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+  }
+  return app;
+}
+
+const SESSION_KEY_A = 'a'.repeat(64);
+const SESSION_KEY_B = 'b'.repeat(64);
+
+// ─── Config map ───────────────────────────────────────────────────────────────
+
+describe('ROUTE_RATE_LIMIT_CONFIG', () => {
+  it('contains an entry for /relay/execute with rpm 30', () => {
+    expect(ROUTE_RATE_LIMIT_CONFIG['/relay/execute']?.rpm).toBe(30);
+  });
+
+  it('contains an entry for /relay/validate with rpm 60', () => {
+    expect(ROUTE_RATE_LIMIT_CONFIG['/relay/validate']?.rpm).toBe(60);
+  });
+
+  it('contains an entry for /relay/session-key with rpm 10 (stricter)', () => {
+    expect(ROUTE_RATE_LIMIT_CONFIG['/relay/session-key']?.rpm).toBe(10);
+  });
+
+  it('contains an entry for /relay/revoke-session-key with rpm 10 (stricter)', () => {
+    expect(ROUTE_RATE_LIMIT_CONFIG['/relay/revoke-session-key']?.rpm).toBe(10);
+  });
+
+  it('contains an entry for /relay/status with rpm 120 (permissive)', () => {
+    expect(ROUTE_RATE_LIMIT_CONFIG['/relay/status']?.rpm).toBe(120);
+  });
+
+  it('contains an entry for /health with rpm 120 (permissive)', () => {
+    expect(ROUTE_RATE_LIMIT_CONFIG['/health']?.rpm).toBe(120);
+  });
+
+  it('session-key routes are stricter than the execute route', () => {
+    expect(ROUTE_RATE_LIMIT_CONFIG['/relay/session-key']!.rpm).toBeLessThan(
+      ROUTE_RATE_LIMIT_CONFIG['/relay/execute']!.rpm
+    );
+    expect(ROUTE_RATE_LIMIT_CONFIG['/relay/revoke-session-key']!.rpm).toBeLessThan(
+      ROUTE_RATE_LIMIT_CONFIG['/relay/execute']!.rpm
+    );
+  });
+
+  it('monitoring routes are more permissive than execute', () => {
+    expect(ROUTE_RATE_LIMIT_CONFIG['/relay/status']!.rpm).toBeGreaterThan(
+      ROUTE_RATE_LIMIT_CONFIG['/relay/execute']!.rpm
+    );
+    expect(ROUTE_RATE_LIMIT_CONFIG['/health']!.rpm).toBeGreaterThan(
+      ROUTE_RATE_LIMIT_CONFIG['/relay/execute']!.rpm
+    );
+  });
+});
+
+// ─── DEFAULT_ROUTE_CONFIG ─────────────────────────────────────────────────────
+
+describe('DEFAULT_ROUTE_CONFIG', () => {
+  it('has an rpm value', () => {
+    expect(typeof DEFAULT_ROUTE_CONFIG.rpm).toBe('number');
+    expect(DEFAULT_ROUTE_CONFIG.rpm).toBeGreaterThan(0);
+  });
+
+  it('is more conservative than the execute route (fail-safe default)', () => {
+    expect(DEFAULT_ROUTE_CONFIG.rpm).toBeLessThanOrEqual(
+      ROUTE_RATE_LIMIT_CONFIG['/relay/execute']!.rpm
+    );
+  });
+});
+
+// ─── resolveRouteConfig ───────────────────────────────────────────────────────
+
+describe('resolveRouteConfig', () => {
+  it('returns the config map entry for a known route', () => {
+    const cfg = resolveRouteConfig('/relay/session-key');
+    expect(cfg.rpm).toBe(10);
+    expect(cfg.windowMs).toBe(60_000);
+  });
+
+  it('returns DEFAULT_ROUTE_CONFIG for an unknown route', () => {
+    const cfg = resolveRouteConfig('/relay/unknown-endpoint');
+    expect(cfg.rpm).toBe(DEFAULT_ROUTE_CONFIG.rpm);
+  });
+
+  it('applies rpm override over the map entry', () => {
+    const cfg = resolveRouteConfig('/relay/execute', { rpm: 5 });
+    expect(cfg.rpm).toBe(5);
+  });
+
+  it('applies windowMs override', () => {
+    const cfg = resolveRouteConfig('/relay/execute', { windowMs: 30_000 });
+    expect(cfg.windowMs).toBe(30_000);
+  });
+
+  it('override does not mutate the config map', () => {
+    resolveRouteConfig('/relay/execute', { rpm: 999 });
+    expect(ROUTE_RATE_LIMIT_CONFIG['/relay/execute']?.rpm).toBe(30);
+  });
+});
+
+// ─── Rate-limit enforcement ───────────────────────────────────────────────────
+
+describe('createRouteRateLimiter – enforcement', () => {
+  it('allows exactly rpm requests before blocking', async () => {
+    const RPM = 3;
+    const app = buildApp('/relay/execute', RPM);
+    const body = { sessionKey: SESSION_KEY_A };
+
+    for (let i = 0; i < RPM; i++) {
+      const res = await request(app).post('/relay/execute').send(body);
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await request(app).post('/relay/execute').send(body);
+    expect(blocked.status).toBe(429);
+  });
+
+  it('returns the correct 429 body with error, route, and retryAfter', async () => {
+    const RPM = 2;
+    const app = buildApp('/relay/session-key', RPM);
+    const body = { sessionKey: SESSION_KEY_A };
+
+    for (let i = 0; i < RPM; i++) {
+      await request(app).post('/relay/session-key').send(body);
+    }
+
+    const res = await request(app).post('/relay/session-key').send(body);
+    expect(res.status).toBe(429);
+    expect(res.body).toEqual({
+      error: 'RATE_LIMITED',
+      route: '/relay/session-key',
+      retryAfter: 60,
+    });
+  });
+
+  it('applies a stricter limit to session-key than execute (config validation)', () => {
+    const sessionCfg = resolveRouteConfig('/relay/session-key');
+    const executeCfg = resolveRouteConfig('/relay/execute');
+    expect(sessionCfg.rpm).toBeLessThan(executeCfg.rpm);
+  });
+});
+
+// ─── Per-account isolation ────────────────────────────────────────────────────
+
+describe('createRouteRateLimiter – per-account isolation', () => {
+  it('different account keys have independent counters on the same route', async () => {
+    const RPM = 2;
+    const app = buildApp('/relay/execute', RPM);
+    const bodyA = { sessionKey: SESSION_KEY_A };
+    const bodyB = { sessionKey: SESSION_KEY_B };
+
+    // Exhaust account A
+    for (let i = 0; i < RPM; i++) {
+      await request(app).post('/relay/execute').send(bodyA);
+    }
+    const blockedA = await request(app).post('/relay/execute').send(bodyA);
+    expect(blockedA.status).toBe(429);
+
+    // Account B should still have its own fresh quota
+    const resB = await request(app).post('/relay/execute').send(bodyB);
+    expect(resB.status).toBe(200);
+  });
+});
+
+// ─── Per-route isolation ──────────────────────────────────────────────────────
+
+describe('createRouteRateLimiter – per-route isolation', () => {
+  it('exhausting one route does not affect a different route', async () => {
+    const app = buildMultiRouteApp([
+      { path: '/relay/execute', rpm: 2 },
+      { path: '/relay/validate', rpm: 5 },
+    ]);
+    const body = { sessionKey: SESSION_KEY_A };
+
+    // Exhaust /relay/execute
+    for (let i = 0; i < 2; i++) {
+      await request(app).post('/relay/execute').send(body);
+    }
+    const blockedExecute = await request(app).post('/relay/execute').send(body);
+    expect(blockedExecute.status).toBe(429);
+
+    // /relay/validate should be unaffected (different store bucket)
+    const resValidate = await request(app).post('/relay/validate').send(body);
+    expect(resValidate.status).toBe(200);
+  });
+});
+
+// ─── Response headers ─────────────────────────────────────────────────────────
+
+describe('createRouteRateLimiter – RateLimit headers', () => {
+  it('sets RateLimit draft headers on successful responses', async () => {
+    const RPM = 5;
+    const app = buildApp('/relay/execute', RPM);
+    const body = { sessionKey: SESSION_KEY_A };
+
+    const res = await request(app).post('/relay/execute').send(body);
+    expect(res.status).toBe(200);
+
+    // express-rate-limit v7 standardHeaders emits ratelimit-* (lowercase) or
+    // RateLimit-* — accept either casing
+    const headerKeys = Object.keys(res.headers).map((k) => k.toLowerCase());
+    const hasLimit = headerKeys.some((k) => k.includes('ratelimit-limit'));
+    const hasRemaining = headerKeys.some((k) => k.includes('ratelimit-remaining'));
+    expect(hasLimit).toBe(true);
+    expect(hasRemaining).toBe(true);
+  });
+
+  it('does not emit legacy X-RateLimit-* headers', async () => {
+    const RPM = 5;
+    const app = buildApp('/relay/execute', RPM);
+    const body = { sessionKey: SESSION_KEY_A };
+
+    const res = await request(app).post('/relay/execute').send(body);
+    const headerKeys = Object.keys(res.headers).map((k) => k.toLowerCase());
+    const hasLegacy = headerKeys.some((k) => k.startsWith('x-ratelimit-'));
+    expect(hasLegacy).toBe(false);
+  });
+});
+
+// ─── Override behaviour ───────────────────────────────────────────────────────
+
+describe('createRouteRateLimiter – override', () => {
+  it('rpm override takes precedence over the config map', async () => {
+    // The config map says execute = 30 rpm; we override to 2 in this test
+    const RPM_OVERRIDE = 2;
+    const app = buildApp('/relay/execute', RPM_OVERRIDE);
+    const body = { sessionKey: SESSION_KEY_A };
+
+    for (let i = 0; i < RPM_OVERRIDE; i++) {
+      const res = await request(app).post('/relay/execute').send(body);
+      expect(res.status).toBe(200);
+    }
+    const blocked = await request(app).post('/relay/execute').send(body);
+    expect(blocked.status).toBe(429);
+  });
+
+  it('unknown route falls back to DEFAULT_ROUTE_CONFIG', async () => {
+    const cfg = resolveRouteConfig('/relay/totally-new-route');
+    expect(cfg.rpm).toBe(DEFAULT_ROUTE_CONFIG.rpm);
+  });
+});

--- a/services/relayer/src/middleware/routeRateLimiter.ts
+++ b/services/relayer/src/middleware/routeRateLimiter.ts
@@ -1,0 +1,175 @@
+/**
+ * routeRateLimiter.ts
+ *
+ * Per-route rate-limit configuration map and middleware factory for the
+ * Ancore relayer service.
+ *
+ * Design decisions:
+ * - All route limits are defined in one place (ROUTE_RATE_LIMIT_CONFIG) so
+ *   reviewers can audit the full security surface in a single diff.
+ * - Sensitive mutation routes (session-key add/revoke) get stricter defaults
+ *   than the read/execute routes.
+ * - A catch-all DEFAULT_ROUTE_CONFIG applies to any route not listed in the
+ *   map, preventing an unconfigured route from being unlimited.
+ * - Response headers follow the RateLimit-* draft spec (standardHeaders: true,
+ *   legacyHeaders: false) so clients can read X-RateLimit-* headers.
+ * - The keyGenerator uses the same account-resolution logic as the existing
+ *   accountRateLimiter so per-route and per-account limiting compose cleanly.
+ * - Storage is in-memory (express-rate-limit default). For multi-instance
+ *   deployments swap in `rate-limit-redis` without changing this file.
+ *
+ * Usage:
+ * ```typescript
+ * import { createRouteRateLimiter } from './middleware/routeRateLimiter';
+ *
+ * // Mount before route handlers:
+ * app.post('/relay/session-key', createRouteRateLimiter('/relay/session-key'), handler);
+ *
+ * // Or with a custom override (e.g. in tests):
+ * app.post('/relay/execute', createRouteRateLimiter('/relay/execute', { rpm: 5 }), handler);
+ * ```
+ */
+
+import rateLimit from 'express-rate-limit';
+import type { Request, Response, RequestHandler } from 'express';
+
+// ─── Route limit configuration ────────────────────────────────────────────────
+
+/**
+ * Per-route rate-limit parameters.
+ *
+ * `rpm`  – maximum requests per minute from the same account key.
+ * `windowMs` – override the default 60-second window if needed (optional).
+ */
+export interface RouteRateLimitConfig {
+  /** Requests per minute allowed per account key. */
+  rpm: number;
+  /** Sliding window in milliseconds (default: 60 000). */
+  windowMs?: number;
+}
+
+/**
+ * Central per-route rate-limit config map.
+ *
+ * Sensitive mutation routes (session-key management) are stricter than the
+ * general execute/read routes to limit the blast radius of credential abuse.
+ *
+ * Defaults rationale:
+ * | Route                       | rpm | Rationale                              |
+ * |-----------------------------|-----|----------------------------------------|
+ * | /relay/execute              |  30 | Normal operation; matches global floor |
+ * | /relay/validate             |  60 | Read-only probe; twice as permissive   |
+ * | /relay/session-key          |  10 | Sensitive: adds credentials            |
+ * | /relay/revoke-session-key   |  10 | Sensitive: removes credentials         |
+ * | /relay/status               | 120 | Health/monitoring; very permissive     |
+ * | /health                     | 120 | Health/monitoring; very permissive     |
+ */
+export const ROUTE_RATE_LIMIT_CONFIG: Record<string, RouteRateLimitConfig> = {
+  '/relay/execute': { rpm: 30 },
+  '/relay/validate': { rpm: 60 },
+  '/relay/session-key': { rpm: 10 },
+  '/relay/revoke-session-key': { rpm: 10 },
+  '/relay/status': { rpm: 120 },
+  '/health': { rpm: 120 },
+};
+
+/**
+ * Fallback config applied to any route not explicitly listed above.
+ * Conservative: 20 rpm — stricter than execute to fail safely.
+ */
+export const DEFAULT_ROUTE_CONFIG: RouteRateLimitConfig = { rpm: 20 };
+
+// ─── Account key resolver (mirrors accountRateLimiter.ts) ────────────────────
+
+/**
+ * Derives a stable per-account rate-limit key from the request body.
+ *
+ * Resolution order (first truthy value wins):
+ *   1. req.body.sender
+ *   2. req.body.parameters.sender
+ *   3. req.body.parameters.account
+ *   4. req.body.parameters.contractAddress
+ *   5. req.body.sessionKey  (primary identity in current relay schema)
+ *   6. 'unknown'
+ *
+ * We deliberately do NOT fall back to IP — the existing global IP-based
+ * limiter already covers that layer; mixing the two in the same keyGenerator
+ * causes express-rate-limit v7 IPv6 validation errors.
+ */
+function resolveAccountKey(req: Request): string {
+  const body = req.body as Record<string, unknown> | undefined;
+  const params = (body?.['parameters'] ?? {}) as Record<string, unknown>;
+
+  return (
+    (body?.['sender'] as string | undefined) ??
+    (params['sender'] as string | undefined) ??
+    (params['account'] as string | undefined) ??
+    (params['contractAddress'] as string | undefined) ??
+    (body?.['sessionKey'] as string | undefined) ??
+    'unknown'
+  );
+}
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a route-specific rate-limit middleware.
+ *
+ * Looks up `route` in {@link ROUTE_RATE_LIMIT_CONFIG}; falls back to
+ * {@link DEFAULT_ROUTE_CONFIG} for unknown routes. The caller may supply
+ * `override` to further customise (useful in tests or feature flags).
+ *
+ * Response headers set by this middleware:
+ *   RateLimit-Limit         – configured rpm
+ *   RateLimit-Remaining     – remaining requests in the current window
+ *   RateLimit-Reset         – UTC epoch seconds when the window resets
+ *
+ * On limit exceeded: HTTP 429 with JSON body
+ *   `{ error: 'RATE_LIMITED', route: '<route>', retryAfter: <windowSecs> }`
+ *
+ * @param route   Express-style route path (e.g. '/relay/session-key')
+ * @param override Optional partial config that takes precedence over the map entry
+ */
+export function createRouteRateLimiter(
+  route: string,
+  override?: Partial<RouteRateLimitConfig>
+): RequestHandler {
+  const base = ROUTE_RATE_LIMIT_CONFIG[route] ?? DEFAULT_ROUTE_CONFIG;
+  const resolved: RouteRateLimitConfig = {
+    rpm: override?.rpm ?? base.rpm,
+    windowMs: override?.windowMs ?? base.windowMs ?? 60_000,
+  };
+
+  const windowMs = resolved.windowMs!;
+
+  return rateLimit({
+    windowMs,
+    limit: resolved.rpm,
+    standardHeaders: true, // emits RateLimit-* draft headers
+    legacyHeaders: false, // suppresses deprecated X-RateLimit-* headers
+    keyGenerator: resolveAccountKey,
+    handler(_req: Request, res: Response) {
+      res.status(429).json({
+        error: 'RATE_LIMITED',
+        route,
+        retryAfter: Math.ceil(windowMs / 1000),
+      });
+    },
+  });
+}
+
+/**
+ * Returns the effective {@link RouteRateLimitConfig} for a given route,
+ * applying any override, without constructing a middleware instance.
+ * Useful for introspection and assertions in tests.
+ */
+export function resolveRouteConfig(
+  route: string,
+  override?: Partial<RouteRateLimitConfig>
+): RouteRateLimitConfig {
+  const base = ROUTE_RATE_LIMIT_CONFIG[route] ?? DEFAULT_ROUTE_CONFIG;
+  return {
+    rpm: override?.rpm ?? base.rpm,
+    windowMs: override?.windowMs ?? base.windowMs ?? 60_000,
+  };
+}


### PR DESCRIPTION
## Summary

This PR resolves four independent issues across the monorepo in a single batch. Every commit is independently scoped and all relevant tests pass.

---

## Changes

### #73 — Implement Secure Storage Manager for Browser Extension

**Commit:** `ec384b8`

**Files changed:**
- `packages/core-sdk/src/storage/__tests__/chrome-compat.test.ts` (new)
- `apps/extension-wallet/src/background/storage.ts` (new)

`SecureStorageManager` with PBKDF2 + AES-256-GCM encryption already existed. This commit adds the two missing deliverables:
- **chrome-compat.test.ts** — 13 smoke tests verifying `createStorageAdapter()` selects the correct adapter (Chrome/Firefox/localStorage fallback) based on runtime globals, and that the full unlock → save → lock → re-unlock → get round-trip works for each adapter.
- **background/storage.ts** — Canonical import path for background service-worker code; re-exports `getSharedStorageManager` as `getStorageManager` from the shared security singleton, eliminating import scatter.

---

### #74 — Create Address and QR Code Display Components

**Commit:** `46afaf1`

**Files changed:**
- `packages/ui-kit/src/components/address-display.tsx` (modified)
- `packages/ui-kit/src/components/address-display.test.tsx` (modified, 22 tests)
- `packages/ui-kit/src/components/address-display.stories.tsx` (modified)
- `packages/ui-kit/src/components/Identicon.stories.tsx` (new)
- `packages/ui-kit/src/components/QRCode.stories.tsx` (new)

**`AddressDisplay` additions:**
- `showIdenticon` — renders a 24 px deterministic `Identicon` avatar alongside the address
- `isValid` — `false` applies a destructive border + `AlertCircle` icon; `undefined` (default) shows nothing
- Full-address **Tooltip** on hover/focus-within (via existing `ui/tooltip.tsx`, no new deps)
- `aria-live="polite"` region announces "Address copied to clipboard"; copy-button `aria-label` toggles between "Copy address" and "Copied!"

**New Storybook stories:** Identicon (Default, Small, Large, UniquePerAddress, SizeScale) and QRCode (Default, PaymentURI, SizeScale, ReceiveCard).

All 190 ui-kit tests pass.

---

### #99 — Core SDK Create Wallet (mnemonic → keypair → encrypted output)

**Commit:** `8220efd`

**Files changed:**
- `packages/core-sdk/src/create-wallet.ts` (new)
- `packages/core-sdk/src/ancore-client.ts` (modified)
- `packages/core-sdk/src/index.ts` (modified)
- `packages/core-sdk/jest.config.cjs` (modified)
- `packages/core-sdk/src/__tests__/create-wallet.test.ts` (new, 21 tests)

`create-wallet.ts` orchestrates: `generateMnemonic()` → `deriveKeypairFromMnemonic(mnemonic, accountIndex)` → optional `encryptSecretKey(mnemonic, password)`. Returns a typed `CreateWalletResult` — `publicKey` and `contractId` are safe to persist; `mnemonic`, `secretKey`, and `encryptedMnemonic` must be handled in-memory only.

`AncoreClient.createWallet(params?)` is a thin delegation to the orchestration layer.

Adding `@ancore/crypto` to `moduleNameMapper` in `jest.config.cjs` also fixes the previously failing `wallet.test.ts` suite as a side-effect. All 31 core-sdk test suites (463 tests) pass.

---

### #472 — [RELAYER] Add per-route rate-limit config map and tests

**Commit:** `f173ace`

**Files changed:**
- `services/relayer/src/middleware/routeRateLimiter.ts` (new)
- `services/relayer/src/middleware/__tests__/routeRateLimiter.test.ts` (new, 24 tests)

Central `ROUTE_RATE_LIMIT_CONFIG` map:

| Route                       | rpm | Rationale                        |
|-----------------------------|-----|----------------------------------|
| `/relay/execute`            |  30 | Baseline                         |
| `/relay/validate`           |  60 | Read-only, more permissive       |
| `/relay/session-key`        |  10 | Sensitive mutation — stricter    |
| `/relay/revoke-session-key` |  10 | Sensitive mutation — stricter    |
| `/relay/status`             | 120 | Monitoring — very permissive     |
| `/health`                   | 120 | Monitoring — very permissive     |

`DEFAULT_ROUTE_CONFIG` (20 rpm) is a fail-safe for unconfigured routes. `createRouteRateLimiter(route, override?)` wires `express-rate-limit` with `standardHeaders: true` / `legacyHeaders: false` (RateLimit-* draft spec). 429 body: `{ error, route, retryAfter }`.

Tests cover: config map values, stricter session-key defaults, DEFAULT fallback, enforcement, per-account isolation, per-route isolation, RateLimit draft headers, no legacy X-RateLimit headers, override precedence.

---

## Test summary

| Package                    | Suites | Tests  |
|----------------------------|--------|--------|
| `@ancore/core-sdk`         | 31 ✅  | 463 ✅ |
| `@ancore/ui-kit`           | 18 ✅  | 190 ✅ |
| `@ancore/relayer`          | 20 ✅  | 235 ✅ |

---

Closes #73
Closes #74
Closes #99
Closes #472