### PR TITLE
fix(ci): remove duplicate cargo/services/indexer dependabot entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,19 +45,6 @@ updates:
       - 'dependencies'
       - 'rust'
 
-  - package-ecosystem: "cargo"
-    directory: "/services/indexer"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 2
-    groups:
-      cargo-dependencies:
-        patterns:
-          - "*"
-    labels:
-      - "dependencies"
-      - "rust"
-
   # Enable version updates for GitHub Actions
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
## Summary

- Removes a duplicate `package-ecosystem: cargo` / `directory: /services/indexer` block from `.github/dependabot.yml` (one single-quoted, one double-quoted copy of the same entry).
- GitHub was rejecting the config as invalid, which failed the Dependabot configuration check on PRs (including after #978).

## Test plan

- [x] YAML still has exactly one cargo entry each for `/contracts` and `/services/indexer`, plus npm and github-actions.
- [ ] Confirm Dependabot config check is green on this PR (no more “Your .github/dependabot.yml contained invalid details”).
- [ ] Optional: after merge, Dependabot can open indexer cargo update PRs again without config errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized formatting in the automated dependency update configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->