### PR TITLE
fix(indexer): reject malformed cursor fields with 400 instead of 500

### DIFF
--- a/services/indexer/src/repositories/account_activity.rs
+++ b/services/indexer/src/repositories/account_activity.rs
@@ -128,18 +128,19 @@ pub struct PageResult<T> {
     pub prev_cursor: Option<String>,
 }
 
-/// Decoded cursor structure
+/// Decoded cursor structure. `t` and `i` are validated at decode time so a
+/// malformed cursor can never reach the query builder and surface as a 500.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct DecodedCursor {
-    t: String, // ISO8601 timestamp
-    i: String, // UUID as string
+    t: DateTime<Utc>, // keyset timestamp, RFC3339 on the wire
+    i: Uuid,          // keyset tie-breaker id
 }
 
 /// Encode cursor from created_at and id
 fn encode_cursor(created_at: DateTime<Utc>, id: Uuid) -> String {
     let cursor = DecodedCursor {
-        t: created_at.to_rfc3339(),
-        i: id.to_string(),
+        t: created_at,
+        i: id,
     };
     let json = serde_json::to_string(&cursor).expect("Failed to serialize cursor");
     base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json)
@@ -154,6 +155,8 @@ fn decode_cursor(cursor: &str) -> Result<DecodedCursor> {
     let json_str = std::str::from_utf8(&decoded)
         .map_err(|_| ApiError::InvalidCursor("Invalid UTF-8".to_string()))?;
 
+    // serde_json validates the full shape here: `t` must parse as an RFC3339
+    // timestamp and `i` as a UUID, otherwise decoding fails with a 400.
     let cursor_obj: DecodedCursor = serde_json::from_str(json_str)
         .map_err(|_| ApiError::InvalidCursor("Invalid JSON structure".to_string()))?;
 
@@ -201,21 +204,15 @@ pub async fn get_account_activity(
     // Apply cursor condition (keyset pagination)
     if let Some(ref decoded) = decoded_after {
         query.push(" AND (created_at, id) < (");
-        query.push_bind(decoded.t.clone());
+        query.push_bind(decoded.t);
         query.push(", ");
-        query.push_bind(
-            Uuid::parse_str(&decoded.i)
-                .map_err(|_| ApiError::InvalidCursor("Invalid UUID in cursor".to_string()))?,
-        );
+        query.push_bind(decoded.i);
         query.push(")");
     } else if let Some(ref decoded) = decoded_before {
         query.push(" AND (created_at, id) > (");
-        query.push_bind(decoded.t.clone());
+        query.push_bind(decoded.t);
         query.push(", ");
-        query.push_bind(
-            Uuid::parse_str(&decoded.i)
-                .map_err(|_| ApiError::InvalidCursor("Invalid UUID in cursor".to_string()))?,
-        );
+        query.push_bind(decoded.i);
         query.push(")");
     }
 
@@ -432,8 +429,8 @@ mod tests {
         let encoded = encode_cursor(created_at, id);
         let decoded = decode_cursor(&encoded).unwrap();
 
-        assert_eq!(decoded.t, created_at.to_rfc3339());
-        assert_eq!(decoded.i, id.to_string());
+        assert_eq!(decoded.t, created_at);
+        assert_eq!(decoded.i, id);
     }
 
     #[test]
@@ -486,10 +483,44 @@ mod tests {
         let encoded = encode_cursor(created_at, id);
         let decoded = decode_cursor(&encoded).unwrap();
 
-        // Verify timezone offset preserved in RFC 3339 format
-        assert!(
-            decoded.t.ends_with('Z') || decoded.t.contains('+') || decoded.t.contains("-00:00")
+        // Decoded value must round-trip to the exact same instant
+        assert_eq!(decoded.t, created_at);
+        let wire = decoded.t.to_rfc3339();
+        assert!(wire.ends_with('Z') || wire.contains('+') || wire.contains("-00:00"));
+    }
+
+    #[test]
+    fn test_decode_cursor_garbage_timestamp_returns_error() {
+        // Valid base64 + valid JSON shape, but `t` is not a timestamp. This
+        // used to pass decode and 500 on the Postgres comparison.
+        let garbage = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"t": "not-a-timestamp", "i": "550e8400-e29b-41d4-a716-446655440000"}"#);
+        assert!(decode_cursor(&garbage).is_err());
+
+        // Timestamp-shaped string with impossible values
+        let impossible = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            r#"{"t": "2024-13-99T99:99:99Z", "i": "550e8400-e29b-41d4-a716-446655440000"}"#,
         );
+        assert!(decode_cursor(&impossible).is_err());
+    }
+
+    #[test]
+    fn test_decode_cursor_garbage_uuid_returns_error() {
+        // Valid base64 + valid JSON + valid timestamp, but `i` is not a UUID.
+        let garbage = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"t": "2024-01-15T10:30:00Z", "i": "not-a-uuid"}"#);
+        assert!(decode_cursor(&garbage).is_err());
+    }
+
+    #[test]
+    fn test_decode_cursor_accepts_offset_timestamps() {
+        // Clients may echo back a cursor serialized with a non-Z offset.
+        let offset = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            r#"{"t": "2024-01-15T12:30:00+02:00", "i": "550e8400-e29b-41d4-a716-446655440000"}"#,
+        );
+        let decoded = decode_cursor(&offset).unwrap();
+        let expected = Utc.with_ymd_and_hms(2024, 1, 15, 10, 30, 0).unwrap();
+        assert_eq!(decoded.t, expected);
     }
 
     // ── Limit validation ──────────────────────────────────────────────────────

--- a/services/indexer/tests/account_activity_api_test.rs
+++ b/services/indexer/tests/account_activity_api_test.rs
@@ -257,7 +257,42 @@ async fn integration_test_invalid_cursor_returns_400() {
     let body = response_body_bytes(response).await;
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(json["error"], "invalid_cursor");
+    assert_eq!(json["code"], "INVALID_CURSOR");
+}
+
+#[tokio::test]
+#[ignore]
+async fn integration_test_wellformed_cursor_with_garbage_fields_returns_400() {
+    let (app, _pool) = setup_test_app().await;
+
+    let account_id = "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+
+    // Valid base64 + valid JSON shape, but `t` is not a timestamp and `i` is
+    // not a UUID. This used to pass cursor decoding and 500 on the Postgres
+    // (created_at, id) comparison.
+    use base64::Engine as _;
+    let cursor = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(r#"{"t": "not-a-timestamp", "i": "not-a-uuid"}"#);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(&format!(
+                    "/api/v1/accounts/{}/activity?cursor_after={}",
+                    account_id, cursor
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response_body_bytes(response).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["code"], "INVALID_CURSOR");
 }
 
 #[tokio::test]
@@ -285,7 +320,7 @@ async fn integration_test_both_cursors_returns_400() {
     let body = response_body_bytes(response).await;
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(json["error"], "invalid_filter");
+    assert_eq!(json["code"], "INVALID_FILTER");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1068

## Summary

`decode_cursor` only validated the JSON shape of the cursor, so a well-formed base64/JSON cursor with a garbage timestamp or UUID passed validation and was bound as a raw string against `(created_at, id)`. Postgres rejected the comparison and the route returned a 500.

The cursor now decodes into typed `DateTime<Utc>` / `Uuid`, so serde rejects bad values at the boundary with 400 `INVALID_CURSOR` (envelope from #581), and the query builder binds typed values instead of parsing strings mid-build.

The issue text says `ERROR_INVALID_CURSOR`; I went with the existing `INVALID_CURSOR` code from the error envelope to keep codes consistent. Happy to rename if you'd rather have the new one.

## Test plan

- [x] `cargo test --lib` — 72 passed, 0 failed (incl. new unit tests: garbage timestamp, impossible date, garbage UUID, offset timestamps, exact roundtrip)
- [x] `cargo clippy --all-targets` — no new warnings on touched files (baseline carries pre-existing ones)
- [x] `cargo fmt` clean
- [x] Added an `#[ignore]`d integration test for the well-formed-but-garbage cursor that used to 500; can't run it here (no Postgres), same status as the existing integration tests
- [x] Fixed two stale assertions in existing cursor integration tests (`json["error"]` vs the current `{code, message}` envelope)