### PR TITLE
feat(indexer): report schema version and migration status on /health

### DIFF
--- a/services/indexer/docs/QUERY_ARCHITECTURE.md
+++ b/services/indexer/docs/QUERY_ARCHITECTURE.md
@@ -481,6 +481,9 @@ RUST_LOG=info,ancore_indexer=debug
 
 The `/health` endpoint exposes:
 - Indexer lag (blocks and estimated seconds)
+- Schema migration status (`schema_version`, `migrations_applied`,
+  `migrations_pending`) read from the `schema_migrations` table; the fields
+  are null and status is "degraded" until migration 005 has run
 - Database connectivity
 - Service availability
 

--- a/services/indexer/migrations/005_create_schema_migrations_table.sql
+++ b/services/indexer/migrations/005_create_schema_migrations_table.sql
@@ -1,0 +1,14 @@
+-- Migration tracking table. The psql-based migration workflow has no
+-- bookkeeping of its own, so each migration records itself here and the
+-- /health endpoint reads this table to report schema version and pending
+-- migrations for deploy verification.
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version VARCHAR(3) PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Backfill rows for migrations that predate tracking, then record this one.
+-- Future migrations append their own INSERT line at the bottom of their file.
+INSERT INTO schema_migrations (version) VALUES
+    ('001'), ('002'), ('003'), ('004'), ('005')
+ON CONFLICT (version) DO NOTHING;

--- a/services/indexer/src/api/health.rs
+++ b/services/indexer/src/api/health.rs
@@ -10,13 +10,15 @@ use crate::metrics::record_lag;
 ///
 /// Reports the latest ledger the indexer has processed, the current chain
 /// head (latest ledger on the network), the block-level lag between them,
-/// and an estimated lag in seconds derived from the Stellar ledger close time
-/// of roughly 5 seconds per ledger.
+/// an estimated lag in seconds derived from the Stellar ledger close time
+/// of roughly 5 seconds per ledger, and the state of schema migrations so
+/// deploys can be verified against the expected schema version.
 #[derive(Debug, Serialize)]
 pub struct HealthResponse {
     /// ISO-8601 timestamp of when this response was generated.
     pub timestamp: String,
-    /// Status: "ok" when lag is within acceptable range, "degraded" otherwise.
+    /// Status: "ok" when lag is within acceptable range and no known
+    /// migration is pending, "degraded" otherwise.
     pub status: String,
     /// Latest ledger sequence number persisted by the indexer.
     pub latest_indexed_ledger: i64,
@@ -29,6 +31,15 @@ pub struct HealthResponse {
     /// Estimated seconds the indexer is behind the chain head.
     /// Calculated as lag_blocks × STELLAR_LEDGER_CLOSE_SECONDS.
     pub lag_seconds: i64,
+    /// Highest applied migration version from the schema_migrations table,
+    /// or null when the tracking table does not exist yet (pre-005 database).
+    pub schema_version: Option<String>,
+    /// Number of migrations recorded in schema_migrations, or null when the
+    /// tracking table does not exist yet.
+    pub migrations_applied: Option<i64>,
+    /// Number of known migrations not yet recorded as applied, or null when
+    /// the tracking table does not exist yet.
+    pub migrations_pending: Option<i64>,
 }
 
 /// Approximate Stellar ledger close time used for lag estimation.
@@ -37,9 +48,23 @@ const STELLAR_LEDGER_CLOSE_SECONDS: i64 = 5;
 /// Lag threshold above which the service is considered "degraded".
 const DEGRADED_LAG_BLOCKS: i64 = 100;
 
+/// Migration versions known to this build, in apply order. Keep in sync with
+/// the numeric prefixes of the files in services/indexer/migrations/.
+const KNOWN_MIGRATIONS: [&str; 5] = ["001", "002", "003", "004", "005"];
+
+/// Known migrations missing from the applied set, in apply order.
+fn pending_migrations<'a>(expected: &[&'a str], applied: &[String]) -> Vec<&'a str> {
+    expected
+        .iter()
+        .copied()
+        .filter(|v| !applied.iter().any(|a| a == v))
+        .collect()
+}
+
 /// GET /health
 ///
-/// Returns indexer lag metrics derived from the activity_records table.
+/// Returns indexer lag metrics derived from the activity_records table plus
+/// schema migration status read from the schema_migrations table.
 /// In production, `chain_head` should be fetched from a live Horizon or
 /// Stellar RPC endpoint; here we use the MAX(ledger_seq) in the DB as a
 /// stand-in so the endpoint is fully self-contained.
@@ -66,7 +91,33 @@ pub async fn health_handler(State(db): State<PgPool>) -> Result<Json<HealthRespo
     let lag_blocks = (chain_head - latest_indexed_ledger).max(0);
     let lag_seconds = lag_blocks * STELLAR_LEDGER_CLOSE_SECONDS;
 
-    let status = if lag_blocks >= DEGRADED_LAG_BLOCKS {
+    // Migration status. The tracking table only exists once migration 005 has
+    // run, so a missing table is reported as null fields instead of an error.
+    let migration_rows = sqlx::query("SELECT version FROM schema_migrations")
+        .fetch_all(&db)
+        .await;
+
+    let (schema_version, migrations_applied, migrations_pending) = match migration_rows {
+        Ok(rows) => {
+            let applied: Vec<String> = rows
+                .iter()
+                .map(|r| r.try_get::<String, _>("version"))
+                .collect::<std::result::Result<_, _>>()?;
+            let latest = applied.iter().max().cloned();
+            let pending = pending_migrations(&KNOWN_MIGRATIONS, &applied);
+            (
+                latest,
+                Some(applied.len() as i64),
+                Some(pending.len() as i64),
+            )
+        }
+        Err(_) => (None, None, None),
+    };
+
+    let degraded =
+        lag_blocks >= DEGRADED_LAG_BLOCKS || migrations_pending.map(|p| p > 0).unwrap_or(true);
+
+    let status = if degraded {
         "degraded".to_string()
     } else {
         "ok".to_string()
@@ -82,5 +133,43 @@ pub async fn health_handler(State(db): State<PgPool>) -> Result<Json<HealthRespo
         chain_head,
         lag_blocks,
         lag_seconds,
+        schema_version,
+        migrations_applied,
+        migrations_pending,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn applied(versions: &[&str]) -> Vec<String> {
+        versions.iter().map(|v| v.to_string()).collect()
+    }
+
+    #[test]
+    fn pending_empty_when_all_known_migrations_applied() {
+        let pending = pending_migrations(&KNOWN_MIGRATIONS, &applied(&KNOWN_MIGRATIONS));
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn pending_lists_missing_migrations_in_order() {
+        let pending = pending_migrations(&KNOWN_MIGRATIONS, &applied(&["001", "002", "004"]));
+        assert_eq!(pending, vec!["003", "005"]);
+    }
+
+    #[test]
+    fn pending_ignores_rows_newer_than_this_build() {
+        let mut applied = applied(&KNOWN_MIGRATIONS);
+        applied.push("006".to_string());
+        let pending = pending_migrations(&KNOWN_MIGRATIONS, &applied);
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn pending_full_when_table_empty() {
+        let pending = pending_migrations(&KNOWN_MIGRATIONS, &[]);
+        assert_eq!(pending.len(), KNOWN_MIGRATIONS.len());
+    }
 }


### PR DESCRIPTION
Closes #1067

## Summary

Migrations are applied as raw psql scripts with no bookkeeping, so there was nothing to read back at runtime. Migration 005 adds a `schema_migrations` table and backfills rows for 001-004; future migrations append their own INSERT line (noted in the file header).

`/health` now returns `schema_version`, `migrations_applied`, and `migrations_pending` alongside the existing lag fields. Status goes `degraded` when a known migration is pending, which also covers the mid-migrate case from the issue. On a database that has not run 005 yet the three fields are null and status is `degraded` — from the tracker's point of view 005 is pending, and applying it flips the endpoint back to `ok`.

`KNOWN_MIGRATIONS` in health.rs mirrors the migration file prefixes; comment says to keep it in sync.

## Test plan

- [x] `cargo test --lib` — 73 passed, 0 failed (4 new unit tests: all applied, missing subset in order, rows newer than this build ignored, empty table)
- [x] `cargo clippy --all-targets` — no new warnings on touched files (baseline carries pre-existing ones in tests/)
- [x] `cargo fmt` clean
- [x] `cargo build` clean
- [ ] End-to-end against a live Postgres — none on this box, same limitation as the existing integration tests; the migration SQL is idempotent and follows the check-migrations.sh workflow