### PR TITLE
feat(relayer): structured error codes enum for relay execute failures (#1064)

### DIFF
--- a/services/relayer/openapi.yaml
+++ b/services/relayer/openapi.yaml
@@ -502,6 +502,9 @@ components:
             - NONCE_REPLAY
             - GAS_LIMIT_EXCEEDED
             - SIMULATION_FAILED
+            - TRANSFER_LIMIT_EXCEEDED
+            - POLICY_DENIED
+            - RPC_DOWN
             - UNAUTHORIZED
             - INTERNAL_ERROR
           description: Machine-readable error code

--- a/services/relayer/src/services/mapSimulationError.ts
+++ b/services/relayer/src/services/mapSimulationError.ts
@@ -1,4 +1,5 @@
 import type { RelayError } from '../types';
+import { RelayErrorCodes } from '../types/errorCodes';
 
 /**
  * Map Soroban simulation failures to typed relay errors.
@@ -21,7 +22,7 @@ export function mapSimulationError(error: unknown): RelayError | null {
     haystack.includes('budget exceeded') ||
     haystack.includes('out of gas')
   ) {
-    return { code: 'GAS_LIMIT_EXCEEDED', message };
+    return { code: RelayErrorCodes.GAS_LIMIT_EXCEEDED, message };
   }
 
   if (
@@ -31,7 +32,7 @@ export function mapSimulationError(error: unknown): RelayError | null {
     haystack.includes('invokehostfunction') ||
     haystack.includes('insufficient balance')
   ) {
-    return { code: 'SIMULATION_FAILED', message };
+    return { code: RelayErrorCodes.SIMULATION_FAILED, message };
   }
 
   return null;

--- a/services/relayer/src/services/mapSubmissionError.ts
+++ b/services/relayer/src/services/mapSubmissionError.ts
@@ -1,5 +1,13 @@
 import { NetworkError, SimulationFailedError, TransactionError } from '@ancore/stellar';
 import type { RelayError } from '../types';
+import { RelayErrorCodes } from '../types/errorCodes';
+
+const RPC_DOWN_PATTERN =
+  /econnrefused|econnreset|etimedout|enotfound|eai_again|fetch failed|socket hang up|unreachable|timed? ?out|bad gateway|service unavailable|\b50[234]\b|rpc (error|down|failure)/i;
+
+function isRpcDownMessage(message: string): boolean {
+  return RPC_DOWN_PATTERN.test(message);
+}
 
 /**
  * Map Stellar network / submission errors to typed relay error responses.
@@ -7,7 +15,7 @@ import type { RelayError } from '../types';
 export function mapSubmissionError(error: unknown): RelayError {
   if (error instanceof SimulationFailedError) {
     return {
-      code: 'SIMULATION_FAILED',
+      code: RelayErrorCodes.SIMULATION_FAILED,
       message: error.message,
     };
   }
@@ -22,7 +30,7 @@ export function mapSubmissionError(error: unknown): RelayError {
       code === 'tx_insufficient_fee'
     ) {
       return {
-        code: 'GAS_LIMIT_EXCEEDED',
+        code: RelayErrorCodes.GAS_LIMIT_EXCEEDED,
         message: error.message,
       };
     }
@@ -34,24 +42,27 @@ export function mapSubmissionError(error: unknown): RelayError {
       code.includes('invalid')
     ) {
       return {
-        code: 'SIMULATION_FAILED',
+        code: RelayErrorCodes.SIMULATION_FAILED,
         message: error.message,
       };
     }
 
     return {
-      code: 'INTERNAL_ERROR',
+      code: RelayErrorCodes.INTERNAL_ERROR,
       message: error.message,
     };
   }
 
   if (error instanceof NetworkError) {
     return {
-      code: 'INTERNAL_ERROR',
+      code: RelayErrorCodes.RPC_DOWN,
       message: error.message,
     };
   }
 
   const message = error instanceof Error ? error.message : 'Transaction submission failed';
-  return { code: 'INTERNAL_ERROR', message };
+  if (isRpcDownMessage(message)) {
+    return { code: RelayErrorCodes.RPC_DOWN, message };
+  }
+  return { code: RelayErrorCodes.INTERNAL_ERROR, message };
 }

--- a/services/relayer/src/services/relayService.ts
+++ b/services/relayer/src/services/relayService.ts
@@ -18,6 +18,7 @@ import type {
   DependencyStatus,
   RelayError,
 } from '../types';
+import { RelayErrorCodes, transferPolicyBlockCode } from '../types/errorCodes';
 import { mapSimulationError } from './mapSimulationError';
 import { mapSubmissionError } from './mapSubmissionError';
 
@@ -66,12 +67,15 @@ export class RelayService implements RelayServiceContract {
       try {
         const keyError = this.validateSessionKey(request.sessionKey);
         if (keyError) {
-          const error: RelayError = { code: 'INVALID_SIGNATURE', message: keyError };
+          const error: RelayError = { code: RelayErrorCodes.INVALID_SIGNATURE, message: keyError };
           return { valid: false, error };
         }
 
         if (request.nonce < 0) {
-          const error: RelayError = { code: 'NONCE_REPLAY', message: 'Nonce must be non-negative' };
+          const error: RelayError = {
+            code: RelayErrorCodes.NONCE_REPLAY,
+            message: 'Nonce must be non-negative',
+          };
           return { valid: false, error };
         }
 
@@ -80,7 +84,7 @@ export class RelayService implements RelayServiceContract {
             await this.nonceStore.assertFresh(request.sessionKey, request.nonce);
           } catch (err) {
             const message = err instanceof Error ? err.message : 'Nonce already used';
-            const error: RelayError = { code: 'NONCE_REPLAY', message };
+            const error: RelayError = { code: RelayErrorCodes.NONCE_REPLAY, message };
             return { valid: false, error };
           }
         }
@@ -99,7 +103,10 @@ export class RelayService implements RelayServiceContract {
           if (!onChainKey) {
             return {
               valid: false,
-              error: { code: 'INVALID_SIGNATURE', message: 'Session key not found on chain' },
+              error: {
+                code: RelayErrorCodes.INVALID_SIGNATURE,
+                message: 'Session key not found on chain',
+              },
             };
           }
         } catch (e: unknown) {
@@ -112,7 +119,10 @@ export class RelayService implements RelayServiceContract {
         if (!ok) {
           return {
             valid: false,
-            error: { code: 'INVALID_SIGNATURE', message: 'Signature verification failed' },
+            error: {
+              code: RelayErrorCodes.INVALID_SIGNATURE,
+              message: 'Signature verification failed',
+            },
           };
         }
 
@@ -122,7 +132,10 @@ export class RelayService implements RelayServiceContract {
           if (policyResult.action === 'block') {
             return {
               valid: false,
-              error: { code: 'TRANSFER_LIMIT_EXCEEDED', message: policyResult.message },
+              error: {
+                code: transferPolicyBlockCode(amount, todayTotal, policy.dailyLimit),
+                message: policyResult.message,
+              },
             };
           }
         }
@@ -152,7 +165,7 @@ export class RelayService implements RelayServiceContract {
       return {
         success: false,
         error: {
-          code: 'INTERNAL_ERROR',
+          code: RelayErrorCodes.INTERNAL_ERROR,
           message: 'Transaction submitter is not configured',
         },
         gasUsed: 0,
@@ -164,7 +177,7 @@ export class RelayService implements RelayServiceContract {
       return {
         success: false,
         error: {
-          code: 'INTERNAL_ERROR',
+          code: RelayErrorCodes.INTERNAL_ERROR,
           message: `Missing required parameter: ${SIGNED_TX_PARAMETER}`,
         },
         gasUsed: 0,

--- a/services/relayer/src/types/errorCodes.ts
+++ b/services/relayer/src/types/errorCodes.ts
@@ -1,0 +1,33 @@
+/**
+ * Stable machine-readable error codes for relayer failures (#1064).
+ * Clients should branch on `code`, never on the human-readable `message`.
+ */
+export const RelayErrorCodes = {
+  INVALID_SIGNATURE: 'INVALID_SIGNATURE',
+  SESSION_KEY_EXPIRED: 'SESSION_KEY_EXPIRED',
+  NONCE_REPLAY: 'NONCE_REPLAY',
+  GAS_LIMIT_EXCEEDED: 'GAS_LIMIT_EXCEEDED',
+  SIMULATION_FAILED: 'SIMULATION_FAILED',
+  TRANSFER_LIMIT_EXCEEDED: 'TRANSFER_LIMIT_EXCEEDED',
+  POLICY_DENIED: 'POLICY_DENIED',
+  RPC_DOWN: 'RPC_DOWN',
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+} as const;
+
+export type RelayErrorCode = (typeof RelayErrorCodes)[keyof typeof RelayErrorCodes];
+
+/** Classify a transfer-policy block: daily-limit breach vs any other policy denial. */
+export function transferPolicyBlockCode(
+  amount: number,
+  todayTotal: number,
+  dailyLimit: number
+): RelayErrorCode {
+  const overDailyLimit =
+    Number.isFinite(amount) &&
+    Number.isFinite(todayTotal) &&
+    amount > 0 &&
+    todayTotal >= 0 &&
+    todayTotal + amount > dailyLimit;
+  return overDailyLimit ? RelayErrorCodes.TRANSFER_LIMIT_EXCEEDED : RelayErrorCodes.POLICY_DENIED;
+}

--- a/services/relayer/src/types/responses.ts
+++ b/services/relayer/src/types/responses.ts
@@ -2,15 +2,10 @@
  * Typed response interfaces for the Relayer Service.
  */
 
-export type RelayErrorCode =
-  | 'INVALID_SIGNATURE'
-  | 'SESSION_KEY_EXPIRED'
-  | 'NONCE_REPLAY'
-  | 'GAS_LIMIT_EXCEEDED'
-  | 'SIMULATION_FAILED'
-  | 'TRANSFER_LIMIT_EXCEEDED'
-  | 'UNAUTHORIZED'
-  | 'INTERNAL_ERROR';
+import type { RelayErrorCode } from './errorCodes';
+
+export { RelayErrorCodes, transferPolicyBlockCode } from './errorCodes';
+export type { RelayErrorCode };
 
 export interface RelayError {
   code: RelayErrorCode;

--- a/services/relayer/src/validation/transferPolicy.ts
+++ b/services/relayer/src/validation/transferPolicy.ts
@@ -1,5 +1,6 @@
 import { validateTransferPolicy, type TransferPolicy } from '@ancore/types';
 import type { RelayError } from '../types';
+import { transferPolicyBlockCode } from '../types/errorCodes';
 
 export interface TransferValidationContext {
   amount: number;
@@ -26,7 +27,11 @@ export function validateTransferPolicyConstraints(
     return {
       valid: false,
       error: {
-        code: 'TRANSFER_LIMIT_EXCEEDED',
+        code: transferPolicyBlockCode(
+          context.amount,
+          context.todayTotal,
+          context.policy.dailyLimit
+        ),
         message: result.message,
       },
     };

--- a/services/relayer/tests/contract/relay-error-codes.test.ts
+++ b/services/relayer/tests/contract/relay-error-codes.test.ts
@@ -1,0 +1,93 @@
+import request from 'supertest';
+import { NetworkError } from '@ancore/stellar';
+import { createApp } from '../../src/server';
+import { RelayErrorCodes } from '../../src/types/errorCodes';
+import type {
+  AuthServiceContract,
+  SignatureServiceContract,
+  TransactionSubmitterContract,
+} from '../../src/types';
+
+const VALID_KEY = 'a'.repeat(64);
+const VALID_SIG = 'b'.repeat(128);
+
+const validBody = {
+  sessionKey: VALID_KEY,
+  operation: 'relay_execute',
+  parameters: { signedTransactionXdr: 'AAAA-xdr' },
+  signature: VALID_SIG,
+  nonce: 1,
+};
+
+const KNOWN_CODES = Object.values(RelayErrorCodes);
+
+function makeApp(
+  sigValid: boolean,
+  transactionSubmitter?: TransactionSubmitterContract,
+  relayOptions?: { useMockSubmission?: boolean; startScheduler?: boolean }
+) {
+  const authService: AuthServiceContract = {
+    verifyToken: jest.fn().mockResolvedValue({ callerId: 'test-caller' }),
+  };
+  const signatureService: SignatureServiceContract = {
+    verify: jest.fn().mockReturnValue(sigValid),
+  };
+  return createApp(authService, signatureService, undefined, transactionSubmitter, {
+    startScheduler: false,
+    ...relayOptions,
+  });
+}
+
+describe('relay error codes contract (issue #1064)', () => {
+  it('INVALID_SIGNATURE on /relay/execute when verification fails', async () => {
+    const app = makeApp(false, undefined, { useMockSubmission: true });
+    const res = await request(app)
+      .post('/relay/execute')
+      .set('Authorization', 'Bearer token')
+      .send(validBody);
+    expect(res.status).toBe(422);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('INVALID_SIGNATURE');
+  });
+
+  it('RPC_DOWN on /relay/execute when the RPC submitter is unreachable', async () => {
+    const submitter: TransactionSubmitterContract = {
+      simulateAndAssembleTransaction: jest
+        .fn()
+        .mockRejectedValue(new NetworkError('Soroban RPC unreachable')),
+      submitSignedTransaction: jest.fn(),
+      isHealthy: jest.fn().mockResolvedValue({ healthy: false, latencyMs: 1 }),
+    };
+    const app = makeApp(true, submitter);
+    const res = await request(app)
+      .post('/relay/execute')
+      .set('Authorization', 'Bearer token')
+      .send(validBody);
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('RPC_DOWN');
+  });
+
+  it('INTERNAL_ERROR on /relay/execute for unexpected submitter failures', async () => {
+    const submitter: TransactionSubmitterContract = {
+      simulateAndAssembleTransaction: jest.fn().mockRejectedValue(new Error('unexpected boom')),
+      submitSignedTransaction: jest.fn(),
+      isHealthy: jest.fn().mockResolvedValue({ healthy: true, latencyMs: 1 }),
+    };
+    const app = makeApp(true, submitter);
+    const res = await request(app)
+      .post('/relay/execute')
+      .set('Authorization', 'Bearer token')
+      .send(validBody);
+    expect(res.status).toBe(422);
+    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('every error code on the wire is a member of RelayErrorCodes', async () => {
+    const app = makeApp(false, undefined, { useMockSubmission: true });
+    const res = await request(app)
+      .post('/relay/execute')
+      .set('Authorization', 'Bearer token')
+      .send(validBody);
+    expect(KNOWN_CODES).toContain(res.body.error.code);
+  });
+});

--- a/services/relayer/tests/integration/relay.test.ts
+++ b/services/relayer/tests/integration/relay.test.ts
@@ -128,7 +128,7 @@ describe('POST /relay/execute', () => {
 
     expect(res.status).toBe(422);
     expect(res.body.success).toBe(false);
-    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+    expect(res.body.error.code).toBe('RPC_DOWN');
     expect(res.body.error.message).toBe('Horizon unavailable');
   });
 

--- a/services/relayer/tests/unit/mapSubmissionError.test.ts
+++ b/services/relayer/tests/unit/mapSubmissionError.test.ts
@@ -26,11 +26,22 @@ describe('mapSubmissionError', () => {
     });
   });
 
-  it('maps network errors to INTERNAL_ERROR', () => {
+  it('maps network errors to RPC_DOWN', () => {
     const error = new NetworkError('Horizon unreachable');
     expect(mapSubmissionError(error)).toEqual({
-      code: 'INTERNAL_ERROR',
+      code: 'RPC_DOWN',
       message: 'Horizon unreachable',
+    });
+  });
+
+  it('maps network-shaped generic errors to RPC_DOWN', () => {
+    expect(mapSubmissionError(new Error('fetch failed'))).toEqual({
+      code: 'RPC_DOWN',
+      message: 'fetch failed',
+    });
+    expect(mapSubmissionError(new Error('connect ECONNREFUSED 127.0.0.1:8000'))).toEqual({
+      code: 'RPC_DOWN',
+      message: 'connect ECONNREFUSED 127.0.0.1:8000',
     });
   });
 

--- a/services/relayer/tests/unit/relayService.test.ts
+++ b/services/relayer/tests/unit/relayService.test.ts
@@ -91,6 +91,36 @@ describe('RelayService', () => {
       expect(result.error?.code).toBe('NONCE_REPLAY');
       expect(result.error?.message).toBe('Nonce already used');
     });
+
+    it('returns TRANSFER_LIMIT_EXCEEDED when the daily limit is breached', async () => {
+      const svc = new RelayService(makeSignatureService(true));
+      const result = await svc.validateRelay(
+        makeRequest({
+          transferPolicy: {
+            policy: { dailyLimit: 100, stepUpThreshold: 250 },
+            amount: 60,
+            todayTotal: 50,
+          },
+        })
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error?.code).toBe('TRANSFER_LIMIT_EXCEEDED');
+    });
+
+    it('returns POLICY_DENIED for policy blocks that are not limit breaches', async () => {
+      const svc = new RelayService(makeSignatureService(true));
+      const result = await svc.validateRelay(
+        makeRequest({
+          transferPolicy: {
+            policy: { dailyLimit: 100, stepUpThreshold: 50 },
+            amount: 0,
+            todayTotal: 0,
+          },
+        })
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error?.code).toBe('POLICY_DENIED');
+    });
   });
 
   describe('executeRelay', () => {
@@ -154,7 +184,7 @@ describe('RelayService', () => {
       expect(result.gasUsed).toBe(0);
     });
 
-    it('maps submitter network errors to typed relay errors', async () => {
+    it('maps submitter network errors to RPC_DOWN', async () => {
       const submitter = makeSubmitter({
         submitSignedTransaction: jest.fn().mockRejectedValue(new NetworkError('Horizon down')),
       });
@@ -164,7 +194,7 @@ describe('RelayService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error?.code).toBe('INTERNAL_ERROR');
+      expect(result.error?.code).toBe('RPC_DOWN');
       expect(result.error?.message).toBe('Horizon down');
     });
 


### PR DESCRIPTION
Closes #1064.

Error codes were string literals scattered across relayService and the two error mappers, and two codes from the issue didn't exist: POLICY_DENIED and RPC_DOWN.

- New `src/types/errorCodes.ts` exports a `RelayErrorCodes` const enum as the single source of truth, plus `transferPolicyBlockCode`, which splits policy blocks into TRANSFER_LIMIT_EXCEEDED (daily limit breached) and POLICY_DENIED (anything else, e.g. non-positive amount). Before, every policy block reported TRANSFER_LIMIT_EXCEEDED.
- `mapSubmissionError` maps `NetworkError` and network-shaped messages (ECONNREFUSED, fetch failed, timeouts, 502/503/504) to RPC_DOWN instead of INTERNAL_ERROR.
- openapi.yaml RelayError enum updated to the full set; it was also missing TRANSFER_LIMIT_EXCEEDED.

Contract tests in `tests/contract/relay-error-codes.test.ts` pin the codes at the HTTP boundary through the real app (INVALID_SIGNATURE, RPC_DOWN, INTERNAL_ERROR, enum membership). Updated the two existing tests that asserted INTERNAL_ERROR for network failures.

`pnpm test`: 31 suites, 339 passed. `pnpm build` clean, eslint 0 errors (7 pre-existing warnings, same as main), prettier clean on touched files. One note: `jest --coverage` exits non-zero locally because some suites keep open handles; that also happens on a clean checkout of main, not introduced here.

One thing I noticed while wiring this up: `relayRequestSchema` strips unknown keys, so `transferPolicy` never survives the HTTP boundary today and the policy codes are only reachable through direct service calls. I left the schema alone since passing it through changes API behavior, but flagging it in case it's an oversight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stable, machine-readable relay error codes for transfer-limit breaches, policy denials, RPC outages, signature failures, and other relay outcomes.
  - Transfer-policy errors now distinguish daily-limit violations from other policy denials.
  - Network and RPC failures are consistently reported as `RPC_DOWN`.

- **Bug Fixes**
  - Standardized error responses across relay validation, simulation, and transaction submission flows.
  - Improved detection of common network connection failures.

- **Tests**
  - Added contract and unit coverage for the new error-code behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->