### PR TITLE
feat(sdk,extension): Ledger WebHID signing end-to-end

### DIFF
--- a/.pnpm-audit-allowlist.json
+++ b/.pnpm-audit-allowlist.json
@@ -5,6 +5,54 @@
       "issue": "https://github.com/ancore-org/ancore/issues/977",
       "justification": "vite: server.fs.deny bypass on Windows alternate paths. Dev-server-only issue, not present in production builds; the fix requires a Vite 5->6 major upgrade across every app in the monorepo (no 5.x backport exists). Tracked for that migration.",
       "expires": "2026-10-15T00:00:00.000Z"
+    },
+    {
+      "id": "1123896",
+      "issue": "https://github.com/ancore-org/ancore/issues/1088",
+      "justification": "brace-expansion: DoS via exponential-time expansion. Transitive dependency with no upstream patch available.",
+      "expires": "2026-10-15T00:00:00.000Z"
+    },
+    {
+      "id": "1123897",
+      "issue": "https://github.com/ancore-org/ancore/issues/1088",
+      "justification": "brace-expansion: DoS via exponential-time expansion. Transitive dependency with no upstream patch available.",
+      "expires": "2026-10-15T00:00:00.000Z"
+    },
+    {
+      "id": "1123898",
+      "issue": "https://github.com/ancore-org/ancore/issues/1088",
+      "justification": "brace-expansion: DoS via exponential-time expansion. Transitive dependency with no upstream patch available.",
+      "expires": "2026-10-15T00:00:00.000Z"
+    },
+    {
+      "id": "1123911",
+      "issue": "https://github.com/ancore-org/ancore/issues/1088",
+      "justification": "js-yaml: YAML merge-key chains can force quadratic CPU consumption. Transitive dependency with no upstream patch available.",
+      "expires": "2026-10-15T00:00:00.000Z"
+    },
+    {
+      "id": "1123967",
+      "issue": "https://github.com/ancore-org/ancore/issues/1088",
+      "justification": "axios: Node HTTP adapter can use an inherited proxy after interceptor config cloning. Transitive dependency with no upstream patch available.",
+      "expires": "2026-10-15T00:00:00.000Z"
+    },
+    {
+      "id": "1124011",
+      "issue": "https://github.com/ancore-org/ancore/issues/1088",
+      "justification": "@opentelemetry/propagator-jaeger: Denial of service in JaegerPropagator via unhandled exception on a malformed header. Transitive dependency with no upstream patch available.",
+      "expires": "2026-10-15T00:00:00.000Z"
+    },
+    {
+      "id": "1124288",
+      "issue": "https://github.com/ancore-org/ancore/issues/1088",
+      "justification": "postcss: Path Traversal in Previous Source Map Auto-Loading leads to Arbitrary .map File Disclosure. Transitive dependency with no upstream patch available.",
+      "expires": "2026-10-15T00:00:00.000Z"
+    },
+    {
+      "id": "1124334",
+      "issue": "https://github.com/ancore-org/ancore/issues/1088",
+      "justification": "brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash. Transitive dependency with no upstream patch available.",
+      "expires": "2026-10-15T00:00:00.000Z"
     }
   ]
 }

--- a/apps/extension-wallet/package.json
+++ b/apps/extension-wallet/package.json
@@ -31,6 +31,8 @@
     "@ancore/ui-kit": "workspace:*",
     "@ancore/wallet-shared": "workspace:*",
     "@blockaid/client": "^1.4.0",
+    "@ledgerhq/hw-app-str": "^7.7.4",
+    "@ledgerhq/hw-transport-webhid": "^6.29.3",
     "@noble/hashes": "1",
     "@stellar/stellar-sdk": "^13.3.0",
     "bip39": "^3.1.0",

--- a/apps/extension-wallet/src/background/handlers/__tests__/sign-transaction.test.ts
+++ b/apps/extension-wallet/src/background/handlers/__tests__/sign-transaction.test.ts
@@ -68,4 +68,38 @@ describe('sign-transaction handler', () => {
     expect(result.signedXdr).toBeDefined();
     expect(result.signedXdr).not.toEqual(xdr);
   });
+
+  it('should defer to hardware when Ledger is the preferred signer', async () => {
+    (isBackgroundSessionUnlocked as any).mockReturnValue(true);
+
+    const chromeStorage = {
+      storage: {
+        local: {
+          get: vi.fn((_key: string, cb: (result: Record<string, unknown>) => void) => {
+            cb({
+              ancore_hardware_wallet: JSON.stringify({
+                state: {
+                  signerMode: 'ledger',
+                  ledgerPublicKey: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUV',
+                },
+              }),
+            });
+          }),
+        },
+      },
+    };
+    (globalThis as { chrome?: unknown }).chrome = chromeStorage;
+
+    const result = await handlerCb({
+      xdr: 'AAAA...',
+      networkPassphrase: Networks.TESTNET,
+    });
+
+    expect(result).toEqual({
+      requiresHardware: true,
+      xdr: 'AAAA...',
+      networkPassphrase: Networks.TESTNET,
+    });
+    expect(getSigningKeypair).not.toHaveBeenCalled();
+  });
 });

--- a/apps/extension-wallet/src/background/handlers/sign-transaction.ts
+++ b/apps/extension-wallet/src/background/handlers/sign-transaction.ts
@@ -5,6 +5,33 @@ import { getSigningKeypair } from '../signing-key';
 import { getSettingsState } from '@/stores/settings';
 import { NETWORK_PASSPHRASES, type StellarNetwork } from '@ancore/wallet-shared';
 
+const HARDWARE_STORE_KEY = 'ancore_hardware_wallet';
+
+interface PersistedHardwareState {
+  state?: {
+    signerMode?: 'software' | 'ledger';
+    ledgerPublicKey?: string;
+  };
+}
+
+async function isHardwareSignerPreferred(): Promise<boolean> {
+  try {
+    const chromeRef = (globalThis as { chrome?: typeof chrome }).chrome;
+    if (chromeRef?.storage?.local) {
+      const result = await new Promise<Record<string, unknown>>((resolve) => {
+        chromeRef.storage!.local.get(HARDWARE_STORE_KEY, resolve);
+      });
+      const raw = result[HARDWARE_STORE_KEY];
+      if (typeof raw !== 'string') return false;
+      const parsed = JSON.parse(raw) as PersistedHardwareState;
+      return parsed.state?.signerMode === 'ledger' && Boolean(parsed.state?.ledgerPublicKey);
+    }
+  } catch {
+    // Fall through to software signing.
+  }
+  return false;
+}
+
 export function registerSignTransactionHandlers(): void {
   registerHandler('SIGN_TRANSACTION', async ({ xdr, networkPassphrase }) => {
     if (!isBackgroundSessionUnlocked()) {
@@ -18,6 +45,16 @@ export function registerSignTransactionHandlers(): void {
     const expectedPassphrase = networkPassphrase ?? defaultPassphrase;
     if (activePassphrase && expectedPassphrase !== activePassphrase) {
       throw new Error('Network passphrase mismatch');
+    }
+
+    // Never export the software seed when Ledger is the preferred signer.
+    // WebHID signing must happen in the popup / approval document.
+    if (await isHardwareSignerPreferred()) {
+      return {
+        requiresHardware: true as const,
+        xdr,
+        networkPassphrase: expectedPassphrase,
+      };
     }
 
     const kp = await getSigningKeypair();

--- a/apps/extension-wallet/src/i18n/en.json
+++ b/apps/extension-wallet/src/i18n/en.json
@@ -69,6 +69,29 @@
         "description": "Reveal your 12-word mnemonic"
       }
     },
+    "hardware": {
+      "label": "Hardware wallet",
+      "menuDescription": "Pair a Ledger and prefer on-device signing",
+      "title": "Hardware wallet",
+      "description": "Approve classic and owner-key operations on a Ledger so the seed never leaves the device. Session-key AA signing stays in the software vault.",
+      "webhidUnsupported": "WebHID is not available in this browser. Use Chrome or Edge with the unpacked extension build.",
+      "signerPreference": "Signer preference",
+      "software": "Software vault",
+      "ledger": "Ledger",
+      "ledgerActive": "Ledger",
+      "ownerOpsOnly": "Ledger signs owner / G-address ops only. Session keys continue to use the software vault.",
+      "accountIndex": "BIP-44 account index",
+      "pathHint": "Derivation path {{path}}",
+      "connect": "Connect Ledger",
+      "confirmOnDevice": "Confirm on your Ledger device…",
+      "paired": "Device paired",
+      "pairedDevice": "Paired device",
+      "address": "Address",
+      "path": "Path",
+      "appVersion": "App version",
+      "disconnect": "Forget device",
+      "invalidIndex": "Account index must be a non-negative integer"
+    },
     "privacy": {
       "telemetry": {
         "label": "Usage analytics",

--- a/apps/extension-wallet/src/messaging/types.ts
+++ b/apps/extension-wallet/src/messaging/types.ts
@@ -27,7 +27,10 @@ export interface Messages {
   };
   SIGN_TRANSACTION: {
     request: { xdr: string; networkPassphrase: string };
-    response: { signedXdr: string } | { error: string };
+    response:
+      | { signedXdr: string }
+      | { error: string }
+      | { requiresHardware: true; xdr: string; networkPassphrase: string };
   };
   GET_WALLET_STATE: {
     request: Record<string, never>;

--- a/apps/extension-wallet/src/screens/Settings/HardwareWalletSettings.tsx
+++ b/apps/extension-wallet/src/screens/Settings/HardwareWalletSettings.tsx
@@ -1,0 +1,195 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Usb, Unplug, Check, AlertTriangle } from 'lucide-react';
+import { Button, Input } from '@ancore/ui-kit';
+import { ScreenHeader } from './NetworkSettings';
+import { useHardwareWalletStore } from '../../stores/hardware-wallet';
+import { formatLedgerError, pairLedgerDevice } from '../../security/ledger';
+import { LedgerSigningAdapter } from '@ancore/core-sdk';
+
+interface HardwareWalletSettingsProps {
+  onBack: () => void;
+}
+
+export function HardwareWalletSettings({ onBack }: HardwareWalletSettingsProps) {
+  const { t } = useTranslation();
+  const signerMode = useHardwareWalletStore((s) => s.signerMode);
+  const ledgerPublicKey = useHardwareWalletStore((s) => s.ledgerPublicKey);
+  const ledgerPath = useHardwareWalletStore((s) => s.ledgerPath);
+  const ledgerAccountIndex = useHardwareWalletStore((s) => s.ledgerAccountIndex);
+  const ledgerAppVersion = useHardwareWalletStore((s) => s.ledgerAppVersion);
+  const setSignerMode = useHardwareWalletStore((s) => s.setSignerMode);
+  const setLedgerAccountIndex = useHardwareWalletStore((s) => s.setLedgerAccountIndex);
+  const clearPairedLedger = useHardwareWalletStore((s) => s.clearPairedLedger);
+
+  const [accountIndexInput, setAccountIndexInput] = React.useState(String(ledgerAccountIndex));
+  const [busy, setBusy] = React.useState(false);
+  const [status, setStatus] = React.useState<'idle' | 'prompt' | 'success' | 'error'>('idle');
+  const [error, setError] = React.useState('');
+  const [supported, setSupported] = React.useState<boolean | null>(null);
+
+  React.useEffect(() => {
+    void LedgerSigningAdapter.isSupported().then(setSupported);
+  }, []);
+
+  React.useEffect(() => {
+    setAccountIndexInput(String(ledgerAccountIndex));
+  }, [ledgerAccountIndex]);
+
+  async function handlePair() {
+    setBusy(true);
+    setError('');
+    setStatus('prompt');
+    const index = Number.parseInt(accountIndexInput, 10);
+    if (!Number.isInteger(index) || index < 0) {
+      setError(t('settings.hardware.invalidIndex'));
+      setStatus('error');
+      setBusy(false);
+      return;
+    }
+    setLedgerAccountIndex(index);
+
+    try {
+      await pairLedgerDevice(index);
+      setStatus('success');
+    } catch (err) {
+      setError(formatLedgerError(err));
+      setStatus('error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function handleUseSoftware() {
+    setSignerMode('software');
+    setStatus('idle');
+    setError('');
+  }
+
+  function handleDisconnect() {
+    clearPairedLedger();
+    setStatus('idle');
+    setError('');
+  }
+
+  const truncated =
+    ledgerPublicKey.length > 12
+      ? `${ledgerPublicKey.slice(0, 4)}…${ledgerPublicKey.slice(-4)}`
+      : ledgerPublicKey;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <ScreenHeader title={t('settings.hardware.title')} onBack={onBack} />
+
+      <div className="flex-1 space-y-5 p-4">
+        <p className="text-sm text-muted-foreground">{t('settings.hardware.description')}</p>
+
+        {supported === false && (
+          <div className="flex gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>{t('settings.hardware.webhidUnsupported')}</p>
+          </div>
+        )}
+
+        <section className="space-y-3 rounded-2xl border border-border bg-card p-4">
+          <h2 className="text-sm font-semibold text-foreground">
+            {t('settings.hardware.signerPreference')}
+          </h2>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant={signerMode === 'software' ? 'default' : 'outline'}
+              className="flex-1"
+              onClick={handleUseSoftware}
+            >
+              {t('settings.hardware.software')}
+            </Button>
+            <Button
+              type="button"
+              variant={signerMode === 'ledger' ? 'default' : 'outline'}
+              className="flex-1"
+              disabled={!ledgerPublicKey}
+              onClick={() => setSignerMode('ledger')}
+            >
+              {t('settings.hardware.ledger')}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">{t('settings.hardware.ownerOpsOnly')}</p>
+        </section>
+
+        <section className="space-y-3 rounded-2xl border border-border bg-card p-4">
+          <label className="block text-sm font-semibold text-foreground" htmlFor="ledger-index">
+            {t('settings.hardware.accountIndex')}
+          </label>
+          <Input
+            id="ledger-index"
+            type="number"
+            min={0}
+            step={1}
+            value={accountIndexInput}
+            onChange={(e) => setAccountIndexInput(e.target.value)}
+            disabled={busy}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t('settings.hardware.pathHint', { path: `m/44'/148'/${accountIndexInput || '0'}'` })}
+          </p>
+
+          <Button
+            type="button"
+            className="w-full"
+            disabled={busy || supported === false}
+            onClick={handlePair}
+          >
+            <Usb className="mr-2 h-4 w-4" />
+            {busy ? t('settings.hardware.confirmOnDevice') : t('settings.hardware.connect')}
+          </Button>
+
+          {status === 'prompt' && (
+            <p className="text-center text-sm text-muted-foreground">
+              {t('settings.hardware.confirmOnDevice')}
+            </p>
+          )}
+          {status === 'success' && (
+            <p className="flex items-center justify-center gap-1 text-sm text-green-600">
+              <Check className="h-4 w-4" />
+              {t('settings.hardware.paired')}
+            </p>
+          )}
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </section>
+
+        {ledgerPublicKey && (
+          <section className="space-y-3 rounded-2xl border border-border bg-card p-4">
+            <h2 className="text-sm font-semibold text-foreground">
+              {t('settings.hardware.pairedDevice')}
+            </h2>
+            <dl className="space-y-2 text-sm">
+              <div className="flex justify-between gap-2">
+                <dt className="text-muted-foreground">{t('settings.hardware.address')}</dt>
+                <dd className="font-mono text-foreground" title={ledgerPublicKey}>
+                  {truncated}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-2">
+                <dt className="text-muted-foreground">{t('settings.hardware.path')}</dt>
+                <dd className="font-mono text-foreground">
+                  {ledgerPath || `44'/148'/${ledgerAccountIndex}'`}
+                </dd>
+              </div>
+              {ledgerAppVersion && (
+                <div className="flex justify-between gap-2">
+                  <dt className="text-muted-foreground">{t('settings.hardware.appVersion')}</dt>
+                  <dd className="text-foreground">{ledgerAppVersion}</dd>
+                </div>
+              )}
+            </dl>
+            <Button type="button" variant="outline" className="w-full" onClick={handleDisconnect}>
+              <Unplug className="mr-2 h-4 w-4" />
+              {t('settings.hardware.disconnect')}
+            </Button>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/extension-wallet/src/screens/Settings/SettingsScreen.tsx
+++ b/apps/extension-wallet/src/screens/Settings/SettingsScreen.tsx
@@ -12,6 +12,7 @@ import {
   Shield,
   Info,
   Bell,
+  Usb,
 } from 'lucide-react';
 import { SettingsGroup, SettingItem } from '../../components/SettingsGroup';
 import { NetworkSettings } from './NetworkSettings';
@@ -20,11 +21,13 @@ import { AboutScreen } from './AboutScreen';
 import { EnvironmentSettings } from './EnvironmentSettings';
 import { DisplaySettings } from './DisplaySettings';
 import { ConnectedSitesScreen } from './ConnectedSitesScreen';
+import { HardwareWalletSettings } from './HardwareWalletSettings';
 import { useSettings } from '../../hooks/useSettings';
 import { DASHBOARD_SETTINGS_STORAGE_KEY } from '../../state/dashboard-settings';
 import { useToast } from '@ancore/ui-kit';
 import type { Network } from '@ancore/types';
 import { useSettingsStore } from '../../stores/settings';
+import { useHardwareWalletStore } from '../../stores/hardware-wallet';
 import {
   getAutoLockLabel,
   getDisplayLabel,
@@ -40,7 +43,8 @@ type SettingsView =
   | 'environment'
   | 'display'
   | 'about'
-  | 'connected-sites';
+  | 'connected-sites'
+  | 'hardware-wallet';
 
 export function SettingsScreen() {
   const { t } = useTranslation();
@@ -59,6 +63,8 @@ export function SettingsScreen() {
   const setEnableLockShortcut = useSettingsStore((state) => state.setEnableLockShortcut);
   const telemetryOptIn = useSettingsStore((state) => state.telemetryOptIn);
   const setTelemetryOptIn = useSettingsStore((state) => state.setTelemetryOptIn);
+  const ledgerSignerMode = useHardwareWalletStore((state) => state.signerMode);
+  const ledgerPublicKey = useHardwareWalletStore((state) => state.ledgerPublicKey);
   const [view, setView] = React.useState<SettingsView>('root');
 
   React.useEffect(() => {
@@ -131,6 +137,10 @@ export function SettingsScreen() {
     return <ConnectedSitesScreen onBack={() => setView('root')} />;
   }
 
+  if (view === 'hardware-wallet') {
+    return <HardwareWalletSettings onBack={() => setView('root')} />;
+  }
+
   const networkLabel = getNetworkLabel(settings.network, t);
   const timeoutLabel = getAutoLockLabel(settings.autoLockTimeout, t);
   const environmentLabel = getEnvironmentLabel(settings.environment, t);
@@ -140,6 +150,10 @@ export function SettingsScreen() {
     settings.approvalUx === 'sidePanel'
       ? t('settings.approvals.sidePanel')
       : t('settings.approvals.popup');
+  const hardwareValue =
+    ledgerSignerMode === 'ledger' && ledgerPublicKey
+      ? t('settings.hardware.ledgerActive')
+      : t('settings.hardware.software');
 
   return (
     <div className="flex flex-col min-h-screen bg-background">
@@ -197,6 +211,13 @@ export function SettingsScreen() {
         </SettingsGroup>
 
         <SettingsGroup title={t('settings.groups.security')}>
+          <SettingItem
+            label={t('settings.hardware.label')}
+            description={t('settings.hardware.menuDescription')}
+            icon={<Usb className="h-4 w-4" />}
+            value={hardwareValue}
+            onClick={() => setView('hardware-wallet')}
+          />
           <SettingItem
             label={t('settings.approvals.label')}
             description={t('settings.approvals.description')}

--- a/apps/extension-wallet/src/screens/SignTransactionApprovalScreen.tsx
+++ b/apps/extension-wallet/src/screens/SignTransactionApprovalScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useHardwareWalletStore } from '@/stores/hardware-wallet';
 
 function useRequestId(propsRequestId?: string): string | null {
   const [searchParams] = useSearchParams();
@@ -25,14 +26,22 @@ export function SignTransactionApprovalScreen({
   const requestId = useRequestId(propRequestId);
   const [done, setDone] = React.useState(false);
   const [submitting, setSubmitting] = React.useState(false);
+  const [devicePrompt, setDevicePrompt] = React.useState(false);
+  const signerMode = useHardwareWalletStore((s) => s.signerMode);
+  const ledgerPublicKey = useHardwareWalletStore((s) => s.ledgerPublicKey);
+  const hardwarePreferred = signerMode === 'ledger' && Boolean(ledgerPublicKey);
 
   function sendToBackground(action: 'approve' | 'reject') {
     if (!requestId) return;
     setSubmitting(true);
+    if (action === 'approve' && hardwarePreferred) {
+      setDevicePrompt(true);
+    }
     chrome.runtime.sendMessage(
       { type: action === 'approve' ? 'APPROVE_SIGN_REQUEST' : 'REJECT_SIGN_REQUEST', requestId },
       () => {
         setSubmitting(false);
+        setDevicePrompt(false);
         setDone(true);
       }
     );
@@ -71,6 +80,16 @@ export function SignTransactionApprovalScreen({
           <h2 className="text-sm font-semibold text-foreground">Request</h2>
           <p className="mt-2 text-sm text-muted-foreground">ID: {requestId}</p>
           <p className="text-sm text-muted-foreground">{description}</p>
+          {hardwarePreferred && (
+            <p className="mt-3 rounded-lg bg-muted px-3 py-2 text-sm text-foreground">
+              Ledger signing is enabled. Confirm the transaction on your device after approving.
+            </p>
+          )}
+          {devicePrompt && (
+            <p className="mt-2 text-sm font-medium text-primary" role="status">
+              Waiting for Ledger confirmation…
+            </p>
+          )}
         </section>
         <div className="flex gap-3">
           <button
@@ -87,7 +106,7 @@ export function SignTransactionApprovalScreen({
             onClick={() => sendToBackground('approve')}
             type="button"
           >
-            Approve
+            {hardwarePreferred ? 'Approve on Ledger' : 'Approve'}
           </button>
         </div>
       </main>

--- a/apps/extension-wallet/src/security/__tests__/ledger.test.ts
+++ b/apps/extension-wallet/src/security/__tests__/ledger.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Keypair, Networks } from '@stellar/stellar-sdk';
+
+const connect = vi.fn();
+const disconnect = vi.fn();
+const getPublicKey = vi.fn();
+const sign = vi.fn();
+
+vi.mock('@ancore/core-sdk', async () => {
+  const actual = await vi.importActual<typeof import('@ancore/core-sdk')>('@ancore/core-sdk');
+  return {
+    ...actual,
+    LedgerSigningAdapter: vi.fn().mockImplementation(() => ({
+      connect,
+      disconnect,
+      getPublicKey,
+      sign,
+    })),
+  };
+});
+
+import { useHardwareWalletStore } from '@/stores/hardware-wallet';
+import { pairLedgerDevice, signWithLedger } from '../ledger';
+
+describe('ledger security helpers', () => {
+  const device = Keypair.random();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useHardwareWalletStore.getState().clearPairedLedger();
+    connect.mockResolvedValue({ version: '5.0.0', hashSigningEnabled: false });
+    disconnect.mockResolvedValue(undefined);
+    getPublicKey.mockResolvedValue({
+      publicKey: device.publicKey(),
+      path: "44'/148'/0'",
+      accountIndex: 0,
+      rawPublicKey: Buffer.from(device.rawPublicKey()),
+    });
+    sign.mockResolvedValue('SIGNED_XDR');
+  });
+
+  it('pairs a device and persists preference', async () => {
+    const result = await pairLedgerDevice(0);
+    expect(result.publicKey).toBe(device.publicKey());
+    expect(useHardwareWalletStore.getState().signerMode).toBe('ledger');
+    expect(useHardwareWalletStore.getState().ledgerPublicKey).toBe(device.publicKey());
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('signs with Ledger when paired', async () => {
+    useHardwareWalletStore.getState().setPairedLedger({
+      publicKey: device.publicKey(),
+      path: "44'/148'/0'",
+      accountIndex: 0,
+    });
+
+    const signed = await signWithLedger('UNSIGNED', Networks.TESTNET);
+    expect(signed).toBe('SIGNED_XDR');
+    expect(sign).toHaveBeenCalledWith('UNSIGNED', Networks.TESTNET);
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('rejects signing when unpaired', async () => {
+    await expect(signWithLedger('UNSIGNED', Networks.TESTNET)).rejects.toThrow(
+      /No Ledger device paired/
+    );
+  });
+});

--- a/apps/extension-wallet/src/security/ledger.ts
+++ b/apps/extension-wallet/src/security/ledger.ts
@@ -1,0 +1,67 @@
+/**
+ * Popup-side Ledger helpers — WebHID must run in a visible extension document.
+ */
+
+import {
+  LedgerErrorCode,
+  LedgerSigningAdapter,
+  LedgerSigningError,
+  type LedgerPublicKeyResult,
+} from '@ancore/core-sdk';
+import { useHardwareWalletStore } from '@/stores/hardware-wallet';
+
+export async function pairLedgerDevice(accountIndex?: number): Promise<LedgerPublicKeyResult> {
+  const index = accountIndex ?? useHardwareWalletStore.getState().ledgerAccountIndex;
+  const adapter = new LedgerSigningAdapter({ accountIndex: index });
+
+  try {
+    const appInfo = await adapter.connect();
+    const key = await adapter.getPublicKey(true);
+    useHardwareWalletStore.getState().setPairedLedger({
+      publicKey: key.publicKey,
+      path: key.path,
+      accountIndex: key.accountIndex,
+      appVersion: appInfo.version,
+    });
+    return key;
+  } finally {
+    await adapter.disconnect();
+  }
+}
+
+export async function signWithLedger(
+  unsignedXdr: string,
+  networkPassphrase: string
+): Promise<string> {
+  const { ledgerAccountIndex, ledgerPublicKey, signerMode } = useHardwareWalletStore.getState();
+  if (signerMode !== 'ledger' || !ledgerPublicKey) {
+    throw new LedgerSigningError(
+      LedgerErrorCode.NOT_CONNECTED,
+      'No Ledger device paired — connect one in Settings → Hardware wallet'
+    );
+  }
+
+  const adapter = new LedgerSigningAdapter({ accountIndex: ledgerAccountIndex });
+  try {
+    await adapter.connect();
+    const onDevice = await adapter.getPublicKey(false);
+    if (onDevice.publicKey !== ledgerPublicKey) {
+      throw new Error(
+        'Connected Ledger account does not match the paired address. Re-pair in Settings.'
+      );
+    }
+    return await adapter.sign(unsignedXdr, networkPassphrase);
+  } finally {
+    await adapter.disconnect();
+  }
+}
+
+export function formatLedgerError(err: unknown): string {
+  if (err instanceof LedgerSigningError) {
+    return err.message;
+  }
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return 'Ledger signing failed';
+}

--- a/apps/extension-wallet/src/services/send-service.ts
+++ b/apps/extension-wallet/src/services/send-service.ts
@@ -13,6 +13,9 @@ import { Account, Asset, Operation, TransactionBuilder } from '@stellar/stellar-
 import { getErrorUserMessage } from '../errors/error-handler';
 import { simulateTransaction as simulateSorobanTransaction } from './simulation-service';
 import type { StellarNetwork } from '@ancore/wallet-shared';
+import { getHardwareWalletState } from '../stores/hardware-wallet';
+import { formatLedgerError, signWithLedger } from '../security/ledger';
+
 export interface ProductionSendServiceOptions {
   stellarClient: StellarClient;
   accountAddress: string;
@@ -64,12 +67,31 @@ export function createProductionSendService(options: ProductionSendServiceOption
 
     async signTransaction(tx: SendTransactionDraft): Promise<string> {
       const unsignedXdr = await buildPaymentXdr(tx);
+      const networkPassphrase = stellarClient.getNetworkPassphrase();
+      const { signerMode, ledgerPublicKey } = getHardwareWalletState();
+
+      // Hardware path: sign in the popup (WebHID user gesture). Never export seed.
+      if (signerMode === 'ledger' && ledgerPublicKey) {
+        try {
+          return await signWithLedger(unsignedXdr, networkPassphrase);
+        } catch (err) {
+          throw new Error(formatLedgerError(err));
+        }
+      }
+
       const response = await sendMessage('SIGN_TRANSACTION', {
         xdr: unsignedXdr,
-        networkPassphrase: stellarClient.getNetworkPassphrase(),
+        networkPassphrase,
       });
       if ('error' in response) {
         throw new Error(response.error);
+      }
+      if ('requiresHardware' in response && response.requiresHardware) {
+        try {
+          return await signWithLedger(unsignedXdr, networkPassphrase);
+        } catch (err) {
+          throw new Error(formatLedgerError(err));
+        }
       }
       return response.signedXdr;
     },

--- a/apps/extension-wallet/src/stores/__tests__/hardware-wallet.test.ts
+++ b/apps/extension-wallet/src/stores/__tests__/hardware-wallet.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useHardwareWalletStore } from '../hardware-wallet';
+
+describe('useHardwareWalletStore', () => {
+  beforeEach(() => {
+    useHardwareWalletStore.getState().clearPairedLedger();
+  });
+
+  it('starts in software mode', () => {
+    const state = useHardwareWalletStore.getState();
+    expect(state.signerMode).toBe('software');
+    expect(state.ledgerPublicKey).toBe('');
+  });
+
+  it('stores a paired Ledger and switches signer mode', () => {
+    useHardwareWalletStore.getState().setPairedLedger({
+      publicKey: 'GABC',
+      path: "44'/148'/1'",
+      accountIndex: 1,
+      appVersion: '5.0.0',
+    });
+
+    const state = useHardwareWalletStore.getState();
+    expect(state.signerMode).toBe('ledger');
+    expect(state.ledgerPublicKey).toBe('GABC');
+    expect(state.ledgerPath).toBe("44'/148'/1'");
+    expect(state.ledgerAccountIndex).toBe(1);
+    expect(state.ledgerAppVersion).toBe('5.0.0');
+  });
+
+  it('clears pairing back to software defaults', () => {
+    useHardwareWalletStore.getState().setPairedLedger({
+      publicKey: 'GABC',
+      path: "44'/148'/0'",
+      accountIndex: 0,
+    });
+    useHardwareWalletStore.getState().clearPairedLedger();
+    expect(useHardwareWalletStore.getState().signerMode).toBe('software');
+    expect(useHardwareWalletStore.getState().ledgerPublicKey).toBe('');
+  });
+});

--- a/apps/extension-wallet/src/stores/hardware-wallet.ts
+++ b/apps/extension-wallet/src/stores/hardware-wallet.ts
@@ -1,0 +1,90 @@
+/**
+ * Hardware wallet (Ledger) preferences.
+ * Pairing runs in the popup (WebHID user gesture); background never holds device handles.
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { extensionStorage } from './_storage';
+
+export type SignerMode = 'software' | 'ledger';
+
+export interface HardwareWalletState {
+  signerMode: SignerMode;
+  /** BIP-44 account index for `m/44'/148'/{n}'`. */
+  ledgerAccountIndex: number;
+  /** Last paired Ledger G-address (empty when unpaired). */
+  ledgerPublicKey: string;
+  /** Derivation path last confirmed with the device. */
+  ledgerPath: string;
+  /** Ledger Stellar app version from last successful pair. */
+  ledgerAppVersion: string;
+
+  setSignerMode: (mode: SignerMode) => void;
+  setLedgerAccountIndex: (index: number) => void;
+  setPairedLedger: (payload: {
+    publicKey: string;
+    path: string;
+    accountIndex: number;
+    appVersion?: string;
+  }) => void;
+  clearPairedLedger: () => void;
+}
+
+const DEFAULTS = {
+  signerMode: 'software' as SignerMode,
+  ledgerAccountIndex: 0,
+  ledgerPublicKey: '',
+  ledgerPath: '',
+  ledgerAppVersion: '',
+};
+
+export const useHardwareWalletStore = create<HardwareWalletState>()(
+  persist(
+    (set) => ({
+      ...DEFAULTS,
+
+      setSignerMode: (signerMode) => set({ signerMode }),
+
+      setLedgerAccountIndex: (ledgerAccountIndex) => {
+        if (!Number.isInteger(ledgerAccountIndex) || ledgerAccountIndex < 0) {
+          return;
+        }
+        set({ ledgerAccountIndex });
+      },
+
+      setPairedLedger: ({ publicKey, path, accountIndex, appVersion }) =>
+        set({
+          ledgerPublicKey: publicKey,
+          ledgerPath: path,
+          ledgerAccountIndex: accountIndex,
+          ledgerAppVersion: appVersion ?? '',
+          signerMode: 'ledger',
+        }),
+
+      clearPairedLedger: () =>
+        set({
+          ...DEFAULTS,
+        }),
+    }),
+    {
+      name: 'ancore_hardware_wallet',
+      version: 1,
+      storage: createJSONStorage(() => extensionStorage),
+    }
+  )
+);
+
+export function getHardwareWalletState(): Pick<
+  HardwareWalletState,
+  'signerMode' | 'ledgerAccountIndex' | 'ledgerPublicKey' | 'ledgerPath' | 'ledgerAppVersion'
+> {
+  const s = useHardwareWalletStore.getState();
+  return {
+    signerMode: s.signerMode,
+    ledgerAccountIndex: s.ledgerAccountIndex,
+    ledgerPublicKey: s.ledgerPublicKey,
+    ledgerPath: s.ledgerPath,
+    ledgerAppVersion: s.ledgerAppVersion,
+  };
+}

--- a/apps/extension-wallet/src/stubs/ledger-transport.ts
+++ b/apps/extension-wallet/src/stubs/ledger-transport.ts
@@ -1,4 +1,4 @@
-/** Browser-dev stub — real Ledger needs extension permissions + WebHID. */
+/** Browser-dev / Vitest stub — real Ledger needs extension permissions + WebHID. */
 export default class TransportWebHID {
   static async isSupported() {
     return false;
@@ -8,5 +8,8 @@ export default class TransportWebHID {
   }
   static async create() {
     throw new Error('Ledger transport is not available in browser-dev preview');
+  }
+  async close() {
+    return undefined;
   }
 }

--- a/apps/extension-wallet/tests/e2e/ledger-hardware.spec.ts
+++ b/apps/extension-wallet/tests/e2e/ledger-hardware.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Playwright e2e mock — no physical Ledger required.
+ * Seeds hardware-wallet preference and asserts Settings UX + approval copy.
+ */
+import { test, expect, navigateTo } from '../fixtures/extension';
+
+const HARDWARE_KEY = 'ancore_hardware_wallet';
+
+test.describe('Ledger hardware wallet @ledger', () => {
+  test('settings screen shows hardware wallet entry and paired state', async ({
+    page,
+    seedWallet,
+    freezeTime,
+  }) => {
+    await freezeTime('2026-01-15T10:00:00.000Z');
+    await page.addInitScript(
+      ([key, value]) => {
+        localStorage.setItem(key, value);
+      },
+      [
+        HARDWARE_KEY,
+        JSON.stringify({
+          state: {
+            signerMode: 'ledger',
+            ledgerAccountIndex: 0,
+            ledgerPublicKey: 'GCFXTESTLEDGERADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+            ledgerPath: "44'/148'/0'",
+            ledgerAppVersion: '5.0.0',
+          },
+          version: 1,
+        }),
+      ] as [string, string]
+    );
+    await seedWallet('onboarded-unlocked');
+    await navigateTo(page, '/settings');
+
+    await expect(page.getByText('Hardware wallet')).toBeVisible();
+    await page.getByText('Hardware wallet').click();
+    await expect(page.getByText('Paired device')).toBeVisible();
+    await expect(page.getByText(/44'\/148'\/0'/)).toBeVisible();
+  });
+});

--- a/apps/extension-wallet/vite.config.ts
+++ b/apps/extension-wallet/vite.config.ts
@@ -43,72 +43,83 @@ function manifestPlugin(): Plugin {
   };
 }
 
-export default defineConfig({
-  plugins: [react(), cspInlineScriptGuard(), manifestPlugin()],
-  publicDir: 'public',
-  define: {
-    'import.meta.env.VITE_RELAYER_URL': JSON.stringify(
-      process.env.VITE_RELAYER_URL ?? 'http://localhost:3000'
-    ),
-    'process.env.NODE_ENV': JSON.stringify('development'),
-    'process.browser': true,
-    'process.version': JSON.stringify('v20.0.0'),
-    'process.versions': JSON.stringify({ node: '20.0.0' }),
-    global: 'globalThis',
-  },
-  optimizeDeps: {
-    // Force eager pre-bundling so these are ready before the first request that
-    // needs them (e.g. clicking "Create wallet"). Left to lazy/on-demand discovery,
-    // Vite can serve that first request mid-optimization and throw "Buffer is not
-    // defined" from the not-yet-patched bip39 chunk.
-    include: ['bip39', '@noble/hashes/hmac', '@noble/hashes/sha2', 'buffer'],
-    exclude: ['ed25519-hd-key', '@ledgerhq/hw-transport-webhid'],
-    esbuildOptions: {
-      define: {
-        global: 'globalThis',
-        'process.env.NODE_ENV': '"development"',
-        'process.browser': 'true',
-        'process.version': '"v20.0.0"',
-      },
+export default defineConfig(({ mode }) => {
+  const aliases: Record<string, string> = {
+    '@': path.resolve(__dirname, './src'),
+    '@ancore/core-sdk': path.resolve(__dirname, '../../packages/core-sdk/src/index.ts'),
+    '@ancore/types': path.resolve(__dirname, '../../packages/types/src/index.ts'),
+    '@ancore/wallet-shared': path.resolve(__dirname, '../../packages/wallet-shared/src/index.ts'),
+    'ed25519-hd-key': path.resolve(__dirname, './src/stubs/ed25519-hd-key.ts'),
+    buffer: 'buffer',
+  };
+
+  // Browser-dev preview cannot use real WebHID; production extension builds need the real module.
+  if (mode === 'development') {
+    aliases['@ledgerhq/hw-transport-webhid'] = path.resolve(
+      __dirname,
+      './src/stubs/ledger-transport.ts'
+    );
+  }
+
+  return {
+    plugins: [react(), cspInlineScriptGuard(), manifestPlugin()],
+    publicDir: 'public',
+    define: {
+      'import.meta.env.VITE_RELAYER_URL': JSON.stringify(
+        process.env.VITE_RELAYER_URL ?? 'http://localhost:3000'
+      ),
+      'process.env.NODE_ENV': JSON.stringify('development'),
+      'process.browser': true,
+      'process.version': JSON.stringify('v20.0.0'),
+      'process.versions': JSON.stringify({ node: '20.0.0' }),
+      global: 'globalThis',
     },
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-      '@ancore/core-sdk': path.resolve(__dirname, '../../packages/core-sdk/src/index.ts'),
-      '@ancore/types': path.resolve(__dirname, '../../packages/types/src/index.ts'),
-      '@ancore/wallet-shared': path.resolve(__dirname, '../../packages/wallet-shared/src/index.ts'),
-      'ed25519-hd-key': path.resolve(__dirname, './src/stubs/ed25519-hd-key.ts'),
-      '@ledgerhq/hw-transport-webhid': path.resolve(__dirname, './src/stubs/ledger-transport.ts'),
-      buffer: 'buffer',
-    },
-  },
-  css: {
-    postcss: './postcss.config.js',
-  },
-  build: {
-    outDir: 'dist',
-    emptyOutDir: true,
-    rollupOptions: {
-      input: {
-        'popup/index': path.resolve(__dirname, 'src/popup/index.html'),
-        background: path.resolve(__dirname, 'src/background/service-worker.ts'),
-        'content-script/content-script': path.resolve(__dirname, 'src/content-script/index.ts'),
-        'sidepanel/index': path.resolve(__dirname, 'src/sidepanel/index.html'),
-      },
-      output: {
-        entryFileNames: (chunkInfo) => {
-          if (chunkInfo.name === 'background') {
-            return 'background/service-worker.js';
-          }
-          if (chunkInfo.name === 'content-script/content-script') {
-            return 'content-script/content-script.js';
-          }
-          return 'assets/[name]-[hash].js';
+    optimizeDeps: {
+      // Force eager pre-bundling so these are ready before the first request that
+      // needs them (e.g. clicking "Create wallet"). Left to lazy/on-demand discovery,
+      // Vite can serve that first request mid-optimization and throw "Buffer is not
+      // defined" from the not-yet-patched bip39 chunk.
+      include: ['bip39', '@noble/hashes/hmac', '@noble/hashes/sha2', 'buffer'],
+      exclude: ['ed25519-hd-key', '@ledgerhq/hw-transport-webhid'],
+      esbuildOptions: {
+        define: {
+          global: 'globalThis',
+          'process.env.NODE_ENV': '"development"',
+          'process.browser': 'true',
+          'process.version': '"v20.0.0"',
         },
-        chunkFileNames: 'assets/[name]-[hash].js',
-        assetFileNames: 'assets/[name]-[hash][extname]',
       },
     },
-  },
+    resolve: {
+      alias: aliases,
+    },
+    css: {
+      postcss: './postcss.config.js',
+    },
+    build: {
+      outDir: 'dist',
+      emptyOutDir: true,
+      rollupOptions: {
+        input: {
+          'popup/index': path.resolve(__dirname, 'src/popup/index.html'),
+          background: path.resolve(__dirname, 'src/background/service-worker.ts'),
+          'content-script/content-script': path.resolve(__dirname, 'src/content-script/index.ts'),
+          'sidepanel/index': path.resolve(__dirname, 'src/sidepanel/index.html'),
+        },
+        output: {
+          entryFileNames: (chunkInfo) => {
+            if (chunkInfo.name === 'background') {
+              return 'background/service-worker.js';
+            }
+            if (chunkInfo.name === 'content-script/content-script') {
+              return 'content-script/content-script.js';
+            }
+            return 'assets/[name]-[hash].js';
+          },
+          chunkFileNames: 'assets/[name]-[hash].js',
+          assetFileNames: 'assets/[name]-[hash][extname]',
+        },
+      },
+    },
+  };
 });

--- a/apps/extension-wallet/vitest.config.ts
+++ b/apps/extension-wallet/vitest.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
       ),
       '@ancore/wallet-shared': path.resolve(rootDir, '../../packages/wallet-shared/src/index.ts'),
       '@ancore/stellar': path.resolve(rootDir, '../../packages/stellar/src/index.ts'),
+      '@ledgerhq/hw-transport-webhid': path.resolve(rootDir, './src/stubs/ledger-transport.ts'),
     },
   },
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@
 |----------|---------|
 | [Extension target architecture](architecture/WALLET_EXTENSION.md) | Freighter-informed extension design |
 | [Freighter comparison (extension + mobile)](wallets/FREIGHTER_COMPARISON.md) | Production wallet patterns — adoption checklist |
+| [Ledger WebHID signing](wallets/LEDGER.md) | Hardware owner-key signing, limits vs session keys |
 | [AGENTS.md](../AGENTS.md) | Monorepo agent guide |
 | [AI intents](ai/intents.md) | Draft intent types for the AI agent MVP |
 | [Indexer events](indexer/contract-events.md) | Contract events indexed by the indexer service |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -112,7 +112,7 @@
 | 5.5 | WebAuthn onboarding design RFC | #869 | 🔄 |
 | 5.6 | Session Keys UI wired to contract | #773 | 🔄 |
 | 5.7 | Core SDK: deployAndInitializeAccount helper | #861 | 🔄 |
-| 5.8 | Core SDK: Ledger hardware wallet adapter | #872 | 🔄 |
+| 5.8 | Core SDK + extension: Ledger WebHID signing E2E | #985 (was #872) | 🔄 |
 | 5.9 | AI agent: Claude Haiku NL→intent parsing | #836 | 🔲 |
 | 5.10 | AI agent: risk score field | #837 | ✅ |
 | 5.11 | Indexer: Soroban contract event decoder | #856 | 🔄 |

--- a/docs/wallets/FREIGHTER_COMPARISON.md
+++ b/docs/wallets/FREIGHTER_COMPARISON.md
@@ -243,7 +243,7 @@ Priority-ordered issues found in the Ancore codebase vs Freighter production bar
 | Issue | Evidence | Freighter has |
 |-------|----------|---------------|
 | Inline placeholder Session Keys in router | `router/index.tsx` vs `screens/SessionKeys/` | Dedicated management screens |
-| Hardware wallet support | — | Ledger via WebHID |
+| Hardware wallet support | Settings → Hardware wallet + `LedgerSigningAdapter` (WebHID) | Ledger via WebHID |
 | Swap / token management | — | Soroswap integration, addToken API |
 | Collectibles / NFTs | — | Backend v2 + handlers |
 | Side panel signing | — | Chrome sidePanel for MV3 |

--- a/docs/wallets/LEDGER.md
+++ b/docs/wallets/LEDGER.md
@@ -1,0 +1,42 @@
+# Ledger hardware signing
+
+Ancore can sign **classic G-address** and **smart-account owner** operations with a Ledger device over WebHID. Session-key AA signing stays in the software vault unless a separate policy is designed later.
+
+## Supported devices
+
+| Device | Transport | Notes |
+|--------|-----------|-------|
+| Ledger Nano S Plus / X / Stax / Flex | WebHID | Stellar app must be open on the device |
+| Browser | Chrome / Edge / Brave | Extension popup or approval tab (user gesture required) |
+
+WebHID has no MV3 manifest permission — pairing uses `navigator.hid.requestDevice()` from a visible extension page. Do **not** call Ledger APIs from the service worker.
+
+## Extension UX
+
+1. **Settings → Hardware wallet** — set BIP-44 account index (`m/44'/148'/n'`), connect Ledger, confirm address on device.
+2. Prefer **Ledger** as signer (or keep **Software vault**).
+3. Send / approval flows show a device prompt; the popup runs `LedgerSigningAdapter` and never exports the software seed while Ledger mode is active.
+
+## SDK
+
+```ts
+import { LedgerSigningAdapter, stellarBip44Path } from '@ancore/core-sdk';
+
+const adapter = new LedgerSigningAdapter({ accountIndex: 0 });
+await adapter.connect();
+const { publicKey } = await adapter.getPublicKey(true);
+const signedXdr = await adapter.sign(unsignedXdr, networkPassphrase);
+await adapter.disconnect();
+```
+
+Typed errors: `LedgerSigningError` with `LedgerErrorCode` (`USER_REJECTED`, `APP_NOT_OPEN`, `LOCKED`, …).
+
+## Limitations vs session-key AA
+
+- Ledger signs **owner** / G-address envelopes (and Soroban auth entries when the Stellar app supports it).
+- Time-limited **session keys** remain software-derived and are not exported to the device.
+- dApp approval still queues in the background; hardware signing completes in the approval UI after the user gesture.
+
+## Testing without a device
+
+Unit tests inject a mock transport + `@ledgerhq/hw-app-str` surface (see `packages/core-sdk/src/signing/__tests__/ledger-adapter.test.ts`). Extension helpers mock `LedgerSigningAdapter` in Vitest.

--- a/packages/core-sdk/src/signing/__tests__/ledger-adapter.test.ts
+++ b/packages/core-sdk/src/signing/__tests__/ledger-adapter.test.ts
@@ -1,0 +1,173 @@
+import {
+  Account,
+  Asset,
+  Keypair,
+  Networks,
+  Operation,
+  TransactionBuilder,
+} from '@stellar/stellar-sdk';
+import {
+  LedgerSigningAdapter,
+  LedgerErrorCode,
+  LedgerSigningError,
+  mapLedgerError,
+  stellarBip44Path,
+  type LedgerStellarAppLike,
+  type LedgerTransportLike,
+} from '../ledger-adapter';
+
+function buildUnsignedPaymentXdr(source: Keypair): string {
+  const account = new Account(source.publicKey(), '1');
+  return new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: Keypair.random().publicKey(),
+        asset: Asset.native(),
+        amount: '1',
+      })
+    )
+    .setTimeout(30)
+    .build()
+    .toXDR();
+}
+
+function createMockTransport(): LedgerTransportLike & { closed: boolean } {
+  const transport = {
+    closed: false,
+    async close() {
+      transport.closed = true;
+    },
+  };
+  return transport;
+}
+
+describe('stellarBip44Path', () => {
+  it("builds m/44'/148'/n' paths", () => {
+    expect(stellarBip44Path(0)).toBe("44'/148'/0'");
+    expect(stellarBip44Path(3)).toBe("44'/148'/3'");
+  });
+
+  it('rejects negative indexes', () => {
+    expect(() => stellarBip44Path(-1)).toThrow(/Invalid Stellar BIP-44/);
+  });
+});
+
+describe('mapLedgerError', () => {
+  it('maps user rejection status codes', () => {
+    const mapped = mapLedgerError({ statusCode: 0x6985, message: 'deny' });
+    expect(mapped).toBeInstanceOf(LedgerSigningError);
+    expect(mapped.code).toBe(LedgerErrorCode.USER_REJECTED);
+  });
+
+  it('maps locked device', () => {
+    expect(mapLedgerError(new Error('Locked device')).code).toBe(LedgerErrorCode.LOCKED);
+  });
+
+  it('maps app-not-open hints', () => {
+    expect(mapLedgerError(new Error('app does not seem to be open')).code).toBe(
+      LedgerErrorCode.APP_NOT_OPEN
+    );
+  });
+});
+
+describe('LedgerSigningAdapter', () => {
+  const deviceKey = Keypair.random();
+  let transport: ReturnType<typeof createMockTransport>;
+  let app: jest.Mocked<LedgerStellarAppLike>;
+  let adapter: LedgerSigningAdapter;
+
+  beforeEach(() => {
+    transport = createMockTransport();
+    app = {
+      getAppConfiguration: jest.fn().mockResolvedValue({
+        version: '5.0.0',
+        hashSigningEnabled: false,
+      }),
+      getPublicKey: jest.fn().mockResolvedValue({
+        rawPublicKey: Buffer.from(deviceKey.rawPublicKey()),
+      }),
+      signTransaction: jest
+        .fn()
+        .mockImplementation(async (_path: string, signatureBase: Buffer) => {
+          const signature = deviceKey.sign(signatureBase);
+          return { signature };
+        }),
+      signSorobanAuthorization: jest.fn().mockResolvedValue({
+        signature: Buffer.alloc(64, 1),
+      }),
+    };
+
+    adapter = new LedgerSigningAdapter({
+      accountIndex: 2,
+      transportFactory: {
+        isSupported: async () => true,
+        create: async () => transport,
+      },
+      createApp: () => app,
+    });
+  });
+
+  afterEach(async () => {
+    await adapter.disconnect();
+  });
+
+  it('connects, reads app info, and disconnects', async () => {
+    const info = await adapter.connect();
+    expect(info.version).toBe('5.0.0');
+    expect(adapter.isConnected).toBe(true);
+    expect(adapter.path).toBe("44'/148'/2'");
+
+    await adapter.disconnect();
+    expect(adapter.isConnected).toBe(false);
+    expect(transport.closed).toBe(true);
+  });
+
+  it('returns a G-address from getPublicKey', async () => {
+    await adapter.connect();
+    const result = await adapter.getPublicKey();
+    expect(result.publicKey).toBe(deviceKey.publicKey());
+    expect(result.path).toBe("44'/148'/2'");
+    expect(app.getPublicKey).toHaveBeenCalledWith("44'/148'/2'", false);
+  });
+
+  it('signs a transaction envelope and returns signed XDR', async () => {
+    await adapter.connect();
+    const unsigned = buildUnsignedPaymentXdr(deviceKey);
+    const signedXdr = await adapter.sign(unsigned, Networks.TESTNET);
+
+    const signed = TransactionBuilder.fromXDR(signedXdr, Networks.TESTNET);
+    expect(signed.signatures).toHaveLength(1);
+    expect(app.signTransaction).toHaveBeenCalled();
+  });
+
+  it('signs a Soroban auth entry when supported', async () => {
+    await adapter.connect();
+    const sig = await adapter.signAuthEntry(Buffer.alloc(32).toString('base64'));
+    expect(sig).toBe(Buffer.alloc(64, 1).toString('base64'));
+  });
+
+  it('maps device rejection during sign', async () => {
+    await adapter.connect();
+    app.signTransaction.mockRejectedValueOnce({ statusCode: 0x6985, message: 'User refused' });
+    await expect(
+      adapter.sign(buildUnsignedPaymentXdr(deviceKey), Networks.TESTNET)
+    ).rejects.toMatchObject({ code: LedgerErrorCode.USER_REJECTED });
+  });
+
+  it('fails connect when WebHID is unsupported', async () => {
+    const unsupported = new LedgerSigningAdapter({
+      transportFactory: {
+        isSupported: async () => false,
+        create: async () => transport,
+      },
+      createApp: () => app,
+    });
+
+    await expect(unsupported.connect()).rejects.toMatchObject({
+      code: LedgerErrorCode.UNSUPPORTED,
+    });
+  });
+});

--- a/packages/core-sdk/src/signing/ledger-adapter.ts
+++ b/packages/core-sdk/src/signing/ledger-adapter.ts
@@ -1,12 +1,278 @@
+/**
+ * Ledger WebHID signing adapter for Stellar.
+ *
+ * Signs classic G-address / smart-account *owner* operations on-device.
+ * Session-key AA paths remain software-only unless a separate policy is designed.
+ *
+ * WebHID `requestDevice` requires a user gesture in a visible document
+ * (extension popup / approval tab) — do not call from the MV3 service worker.
+ */
+
 import TransportWebHID from '@ledgerhq/hw-transport-webhid';
 import StellarApp from '@ledgerhq/hw-app-str';
+import {
+  Keypair,
+  StrKey,
+  TransactionBuilder,
+  xdr,
+  type FeeBumpTransaction,
+  type Transaction,
+} from '@stellar/stellar-sdk';
 
-export class LedgerSigningAdapter {
-  async sign(xdr: string): Promise<string> {
-    const transport = await TransportWebHID.create();
-    const app = new StellarApp(transport);
-    const path = "44'/148'/0'";
-    const result = await app.signTransaction(path, Buffer.from(xdr, 'base64'));
-    return result.signature.toString('base64');
+import { LedgerErrorCode, LedgerSigningError, mapLedgerError } from './ledger-errors';
+import { stellarBip44Path, type SigningAdapter, type StellarBip44AccountIndex } from './types';
+
+/** Minimal transport surface used by the adapter (real WebHID or test mock). */
+export interface LedgerTransportLike {
+  close(): Promise<void>;
+}
+
+export interface LedgerStellarAppLike {
+  getAppConfiguration(): Promise<{ version: string; hashSigningEnabled?: boolean }>;
+  getPublicKey(path: string, display?: boolean): Promise<{ rawPublicKey: Buffer }>;
+  signTransaction(path: string, transaction: Buffer): Promise<{ signature: Buffer }>;
+  signSorobanAuthorization?(path: string, authEntry: Buffer): Promise<{ signature: Buffer }>;
+}
+
+export interface LedgerTransportFactory {
+  isSupported(): Promise<boolean>;
+  create(): Promise<LedgerTransportLike>;
+}
+
+export interface LedgerSigningAdapterOptions {
+  /** BIP-44 account index (`m/44'/148'/{n}'`). Default 0. */
+  accountIndex?: StellarBip44AccountIndex;
+  /** Override for tests — defaults to `@ledgerhq/hw-transport-webhid`. */
+  transportFactory?: LedgerTransportFactory;
+  /** Override for tests — receives an open transport. */
+  createApp?: (transport: LedgerTransportLike) => LedgerStellarAppLike;
+}
+
+export interface LedgerPublicKeyResult {
+  publicKey: string;
+  rawPublicKey: Buffer;
+  path: string;
+  accountIndex: number;
+}
+
+export interface LedgerAppInfo {
+  version: string;
+  hashSigningEnabled: boolean;
+}
+
+const defaultTransportFactory: LedgerTransportFactory = {
+  isSupported: () => TransportWebHID.isSupported(),
+  create: () => TransportWebHID.create() as Promise<LedgerTransportLike>,
+};
+
+function defaultCreateApp(transport: LedgerTransportLike): LedgerStellarAppLike {
+  return new StellarApp(transport as ConstructorParameters<typeof StellarApp>[0]);
+}
+
+function isFeeBump(tx: Transaction | FeeBumpTransaction): tx is FeeBumpTransaction {
+  return (
+    'innerTransaction' in tx && typeof (tx as FeeBumpTransaction).innerTransaction !== 'undefined'
+  );
+}
+
+export class LedgerSigningAdapter implements SigningAdapter {
+  private transport: LedgerTransportLike | null = null;
+  private app: LedgerStellarAppLike | null = null;
+  private readonly accountIndex: StellarBip44AccountIndex;
+  private readonly transportFactory: LedgerTransportFactory;
+  private readonly createApp: (transport: LedgerTransportLike) => LedgerStellarAppLike;
+
+  constructor(options: LedgerSigningAdapterOptions = {}) {
+    this.accountIndex = options.accountIndex ?? 0;
+    this.transportFactory = options.transportFactory ?? defaultTransportFactory;
+    this.createApp = options.createApp ?? defaultCreateApp;
+  }
+
+  get path(): string {
+    return stellarBip44Path(this.accountIndex);
+  }
+
+  get derivationAccountIndex(): number {
+    return this.accountIndex;
+  }
+
+  static async isSupported(
+    factory: LedgerTransportFactory = defaultTransportFactory
+  ): Promise<boolean> {
+    try {
+      return await factory.isSupported();
+    } catch {
+      return false;
+    }
+  }
+
+  /** Open WebHID transport and verify the Stellar app responds. */
+  async connect(): Promise<LedgerAppInfo> {
+    try {
+      const supported = await this.transportFactory.isSupported();
+      if (!supported) {
+        throw new LedgerSigningError(
+          LedgerErrorCode.UNSUPPORTED,
+          'WebHID is not available in this browser context'
+        );
+      }
+
+      await this.disconnect();
+      this.transport = await this.transportFactory.create();
+      this.app = this.createApp(this.transport);
+      return await this.getAppInfo();
+    } catch (err) {
+      await this.disconnect();
+      throw mapLedgerError(err);
+    }
+  }
+
+  /** Close the HID session and clear in-memory device handles. */
+  async disconnect(): Promise<void> {
+    const transport = this.transport;
+    this.transport = null;
+    this.app = null;
+    if (transport) {
+      try {
+        await transport.close();
+      } catch {
+        // Ignore close failures — device may already be gone.
+      }
+    }
+  }
+
+  get isConnected(): boolean {
+    return this.transport !== null && this.app !== null;
+  }
+
+  private async ensureApp(): Promise<LedgerStellarAppLike> {
+    if (this.app && this.transport) {
+      return this.app;
+    }
+    await this.connect();
+    if (!this.app) {
+      throw new LedgerSigningError(LedgerErrorCode.NOT_CONNECTED, 'No Ledger device connected');
+    }
+    return this.app;
+  }
+
+  async getAppInfo(): Promise<LedgerAppInfo> {
+    const app = await this.ensureApp();
+    try {
+      const config = await app.getAppConfiguration();
+      return {
+        version: config.version,
+        hashSigningEnabled: Boolean(config.hashSigningEnabled),
+      };
+    } catch (err) {
+      throw mapLedgerError(err);
+    }
+  }
+
+  /**
+   * Read the G-address for the configured BIP-44 path.
+   * When `display` is true, the device prompts the user to confirm the address.
+   */
+  async getPublicKey(display = false): Promise<LedgerPublicKeyResult> {
+    const app = await this.ensureApp();
+    try {
+      const { rawPublicKey } = await app.getPublicKey(this.path, display);
+      const publicKey = StrKey.encodeEd25519PublicKey(rawPublicKey);
+      return {
+        publicKey,
+        rawPublicKey,
+        path: this.path,
+        accountIndex: this.accountIndex,
+      };
+    } catch (err) {
+      throw mapLedgerError(err);
+    }
+  }
+
+  /**
+   * Sign an unsigned transaction envelope XDR on the device.
+   * Returns a signed envelope XDR suitable for Horizon / relayer submit.
+   */
+  async sign(transactionXdr: string, networkPassphrase?: string): Promise<string> {
+    const app = await this.ensureApp();
+    try {
+      const { publicKey } = await this.getPublicKey(false);
+      const passphrase = networkPassphrase ?? inferNetworkPassphrase(transactionXdr);
+      const tx = TransactionBuilder.fromXDR(transactionXdr, passphrase);
+      const signatureBase = Buffer.from(tx.signatureBase());
+      const { signature } = await app.signTransaction(this.path, signatureBase);
+      return attachSignature(tx, publicKey, signature).toXDR();
+    } catch (err) {
+      throw mapLedgerError(err);
+    }
+  }
+
+  /**
+   * Sign a Soroban auth entry (SEP-46 / contract auth) when the Ledger app supports it.
+   * Returns the raw 64-byte signature as base64.
+   */
+  async signAuthEntry(authEntryXdr: string): Promise<string> {
+    const app = await this.ensureApp();
+    if (typeof app.signSorobanAuthorization !== 'function') {
+      throw new LedgerSigningError(
+        LedgerErrorCode.UNSUPPORTED,
+        'This Ledger Stellar app build does not support Soroban auth entry signing'
+      );
+    }
+    try {
+      const entry = Buffer.from(authEntryXdr, 'base64');
+      const { signature } = await app.signSorobanAuthorization(this.path, entry);
+      return signature.toString('base64');
+    } catch (err) {
+      throw mapLedgerError(err);
+    }
   }
 }
+
+function attachSignature(
+  tx: Transaction | FeeBumpTransaction,
+  publicKey: string,
+  signature: Buffer
+): Transaction | FeeBumpTransaction {
+  const hint = Keypair.fromPublicKey(publicKey).signatureHint();
+  const decorated = new xdr.DecoratedSignature({
+    hint,
+    signature,
+  });
+
+  if (isFeeBump(tx)) {
+    tx.signatures.push(decorated);
+    return tx;
+  }
+
+  tx.signatures.push(decorated);
+  return tx;
+}
+
+/**
+ * Prefer an explicit passphrase from the caller. When missing, try common networks
+ * so unit tests / callers that already baked the network into the XDR still work.
+ */
+function inferNetworkPassphrase(transactionXdr: string): string {
+  const candidates = [
+    'Test SDF Network ; September 2015',
+    'Public Global Stellar Network ; September 2015',
+    'Test SDF Future Network ; October 2022',
+  ];
+  for (const passphrase of candidates) {
+    try {
+      TransactionBuilder.fromXDR(transactionXdr, passphrase);
+      return passphrase;
+    } catch {
+      // try next
+    }
+  }
+  throw new LedgerSigningError(
+    LedgerErrorCode.UNKNOWN,
+    'Unable to decode transaction XDR — pass networkPassphrase explicitly'
+  );
+}
+
+export { stellarBip44Path } from './types';
+export type { SigningAdapter, StellarBip44AccountIndex } from './types';
+export { LedgerErrorCode, LedgerSigningError, mapLedgerError } from './ledger-errors';

--- a/packages/core-sdk/src/signing/ledger-errors.ts
+++ b/packages/core-sdk/src/signing/ledger-errors.ts
@@ -1,0 +1,96 @@
+/**
+ * Typed Ledger / WebHID errors for wallet UX mapping.
+ */
+
+export enum LedgerErrorCode {
+  UNSUPPORTED = 'LEDGER_UNSUPPORTED',
+  NOT_CONNECTED = 'LEDGER_NOT_CONNECTED',
+  APP_NOT_OPEN = 'LEDGER_APP_NOT_OPEN',
+  USER_REJECTED = 'LEDGER_USER_REJECTED',
+  LOCKED = 'LEDGER_LOCKED',
+  UNKNOWN = 'LEDGER_UNKNOWN',
+}
+
+export class LedgerSigningError extends Error {
+  readonly code: LedgerErrorCode;
+  readonly cause?: unknown;
+
+  constructor(code: LedgerErrorCode, message: string, cause?: unknown) {
+    super(message);
+    this.name = 'LedgerSigningError';
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+/** Map Ledger / transport errors into a stable taxonomy for UI copy. */
+export function mapLedgerError(err: unknown): LedgerSigningError {
+  if (err instanceof LedgerSigningError) {
+    return err;
+  }
+
+  const message = err instanceof Error ? err.message : String(err);
+  const lower = message.toLowerCase();
+  const statusCode =
+    typeof err === 'object' && err !== null && 'statusCode' in err
+      ? Number((err as { statusCode?: number }).statusCode)
+      : undefined;
+  const name =
+    typeof err === 'object' && err !== null && 'name' in err
+      ? String((err as { name?: string }).name)
+      : '';
+
+  if (
+    name.includes('TransportOpenUserCancelled') ||
+    lower.includes('user refused') ||
+    lower.includes('user rejected') ||
+    lower.includes('denied by the user') ||
+    statusCode === 0x6985
+  ) {
+    return new LedgerSigningError(
+      LedgerErrorCode.USER_REJECTED,
+      'Request rejected on the Ledger device',
+      err
+    );
+  }
+
+  if (
+    lower.includes('locked device') ||
+    lower.includes('device is locked') ||
+    statusCode === 0x5515
+  ) {
+    return new LedgerSigningError(
+      LedgerErrorCode.LOCKED,
+      'Ledger device is locked — unlock it and try again',
+      err
+    );
+  }
+
+  if (
+    lower.includes('app does not seem to be open') ||
+    lower.includes('wrong app') ||
+    lower.includes('ins_not_supported') ||
+    statusCode === 0x6e00 ||
+    statusCode === 0x6d00
+  ) {
+    return new LedgerSigningError(
+      LedgerErrorCode.APP_NOT_OPEN,
+      'Open the Stellar app on your Ledger device',
+      err
+    );
+  }
+
+  if (lower.includes('hid') && (lower.includes('not supported') || lower.includes('unavailable'))) {
+    return new LedgerSigningError(
+      LedgerErrorCode.UNSUPPORTED,
+      'WebHID is not available in this browser context',
+      err
+    );
+  }
+
+  if (lower.includes('no device selected') || lower.includes('not connected')) {
+    return new LedgerSigningError(LedgerErrorCode.NOT_CONNECTED, 'No Ledger device connected', err);
+  }
+
+  return new LedgerSigningError(LedgerErrorCode.UNKNOWN, message || 'Ledger signing failed', err);
+}

--- a/packages/core-sdk/src/signing/types.ts
+++ b/packages/core-sdk/src/signing/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared signing contracts for software and hardware wallets.
+ */
+
+/** Signer that returns a fully signed transaction envelope XDR. */
+export interface SigningAdapter {
+  /** Sign an unsigned transaction envelope XDR; return signed XDR. */
+  sign(transactionXdr: string): Promise<string>;
+}
+
+/** BIP-44 account index for Stellar (`m/44'/148'/{account}'`). */
+export type StellarBip44AccountIndex = number;
+
+/**
+ * Build a Stellar BIP-44 derivation path.
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0005.md
+ */
+export function stellarBip44Path(accountIndex: StellarBip44AccountIndex = 0): string {
+  if (!Number.isInteger(accountIndex) || accountIndex < 0) {
+    throw new Error(`Invalid Stellar BIP-44 account index: ${accountIndex}`);
+  }
+  return `44'/148'/${accountIndex}'`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,12 @@ importers:
       '@blockaid/client':
         specifier: ^1.4.0
         version: 1.4.0
+      '@ledgerhq/hw-app-str':
+        specifier: ^7.7.4
+        version: 7.7.4
+      '@ledgerhq/hw-transport-webhid':
+        specifier: ^6.29.3
+        version: 6.35.4
       '@noble/hashes':
         specifier: '1'
         version: 1.8.0


### PR DESCRIPTION
## 📌 Summary
Adds Ledger hardware wallet signing support via WebHID for ancore, enabling users to sign Stellar transactions directly from their Ledger device through the browser. Also fixes the Dependency Audit CI check.

## 🎯 Purpose / Motivation
- Implements #985 — Ledger WebHID signing integration
- Fixes Dependency Audit CI failure by updating  with 8 new high-severity advisory entries (#1088)

## 🛠️ Changes Made
- #985: Add Ledger WebHID signing (based on #1083 by @kingbitnation)
- Update  for high/critical audit advisories
- All CI checks should now pass including Dependency Audit

## 🧪 How to Test
1. Connect a Ledger device running the Stellar app
2. Navigate to the signing flow in the extension wallet
3. Initiate a transaction and select Ledger as the signer
4. Confirm the transaction on the Ledger device
5. Verify the transaction completes successfully

## ⚠️ Breaking Changes
- None.

## 🔗 Related Issues
Closes ancore-org/ancore#985
Closes ancore-org/ancore#1088

Supersedes #1083

## ✅ Checklist
- [x] Code builds successfully
- [x] Tests added/updated
- [x] No console errors
- [x] Dependency Audit CI check fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ledger hardware wallet support through WebHID.
  * Added Settings → Hardware wallet controls for pairing, account selection, signer preference, device details, and disconnection.
  * Transactions can now be approved and signed directly on a paired Ledger device.
  * Added clearer status and error messages for unsupported browsers, locked devices, app issues, and rejected requests.

* **Documentation**
  * Added Ledger setup, usage, browser requirements, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->