### PR TITLE
feat: address QR export, split-bill validation, relayer error codes, indexer migration health

### DIFF
--- a/apps/extension-wallet/README.md
+++ b/apps/extension-wallet/README.md
@@ -64,6 +64,23 @@ Zustand stores with persistence to `chrome.storage.local` / `browser.storage.loc
 The `useLockManager` hook wires `LockManager` + `InactivityDetector` to the session store.
 Configure timeout via `useSettingsStore().setAutoLockMinutes(n)` (0 = never lock).
 
+## QR Export
+
+Settings → Address QR renders a downloadable PNG QR of the active account's public
+receive address, for support tickets and desktop use outside the receive flow.
+
+**All QR downloads must go through `utils/public-address-qr.ts`, never
+`utils/export-qr.ts` directly.** A downloaded QR is a file that leaves the extension —
+a secret encoded in one is catastrophic and invisible, since the PNG looks identical
+either way. `assertPublicAddressOnly` whitelists the Stellar public formats
+(`G…` account, `C…` contract, `M…` muxed) and throws `SecretExportBlockedError` on
+anything else, so a secret shape nobody anticipated still cannot slip through. Secret
+seeds, raw hex private keys, and recovery phrases get a specific message; everything
+else gets the generic rejection.
+
+`AccountQrScreen` applies the same check at the render boundary, so a non-public value
+never reaches the QR renderer even if a caller passes one.
+
 ## Permissions
 
 - `storage` — persist wallet state

--- a/apps/extension-wallet/src/i18n/en.json
+++ b/apps/extension-wallet/src/i18n/en.json
@@ -6,13 +6,26 @@
       "name": "My Ancore Wallet",
       "address": "GBXXX...YYYY"
     },
+    "accountQr": {
+      "label": "Address QR Code",
+      "description": "Download a shareable QR of your public address",
+      "title": "Address QR",
+      "downloadPng": "Download PNG",
+      "downloading": "Preparing…",
+      "downloadFailed": "Could not generate the QR image. Try again.",
+      "copyAddress": "Copy address",
+      "unavailable": "No account address yet. Complete onboarding to get one.",
+      "safetyTitle": "Public address only",
+      "safetyBody": "This QR contains only your public receive address. Your private key and recovery phrase are never exported here."
+    },
     "groups": {
       "network": "Network",
       "display": "Display",
       "security": "Security",
       "privacy": "Privacy",
       "about": "About",
-      "notificationsDemo": "Notifications (Demo)"
+      "notificationsDemo": "Notifications (Demo)",
+      "account": "Account"
     },
     "network": {
       "label": "Network",

--- a/apps/extension-wallet/src/i18n/locales/pt-BR.json
+++ b/apps/extension-wallet/src/i18n/locales/pt-BR.json
@@ -87,7 +87,20 @@
       "display": "Exibição",
       "security": "Segurança",
       "about": "Sobre",
-      "notifications": "Notificações"
+      "notifications": "Notificações",
+      "account": "Conta"
+    },
+    "accountQr": {
+      "label": "QR do endereço",
+      "description": "Baixe um QR compartilhável do seu endereço público",
+      "title": "QR do endereço",
+      "downloadPng": "Baixar PNG",
+      "downloading": "Preparando…",
+      "downloadFailed": "Não foi possível gerar a imagem do QR. Tente novamente.",
+      "copyAddress": "Copiar endereço",
+      "unavailable": "Ainda não há endereço de conta. Conclua a integração para obter um.",
+      "safetyTitle": "Apenas endereço público",
+      "safetyBody": "Este QR contém apenas seu endereço público de recebimento. Sua chave privada e frase de recuperação nunca são exportadas aqui."
     },
     "network": {
       "title": "Rede",

--- a/apps/extension-wallet/src/screens/Settings/AccountQrScreen.tsx
+++ b/apps/extension-wallet/src/screens/Settings/AccountQrScreen.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Download, ShieldCheck, Copy, Check } from 'lucide-react';
+import { Button } from '@ancore/ui-kit';
+import { PaymentQRCode } from '../../components/PaymentQRCode';
+import { useCopyWithFeedback } from '../../hooks/useCopyWithFeedback';
+import {
+  downloadPublicAddressQrPng,
+  isPublicAddress,
+  SecretExportBlockedError,
+} from '../../utils/public-address-qr';
+import { ScreenHeader } from './NetworkSettings';
+
+interface AccountQrScreenProps {
+  /** Public receive address (G/C/M). Never a secret — see public-address-qr.ts. */
+  address: string | null;
+  onBack: () => void;
+}
+
+function truncateMiddle(value: string, head = 8, tail = 8): string {
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+/**
+ * Settings → Address QR.
+ *
+ * Renders a downloadable QR of the account's public address, for support
+ * tickets and desktop use outside the receive flow. Only the public address is
+ * ever encoded; the export helper rejects anything else.
+ */
+export function AccountQrScreen({ address, onBack }: AccountQrScreenProps) {
+  const { t } = useTranslation();
+  const { copy, copied } = useCopyWithFeedback();
+  const [downloadError, setDownloadError] = React.useState<string | null>(null);
+  const [downloading, setDownloading] = React.useState(false);
+
+  // Guard at the render boundary too: a malformed or secret-looking value
+  // never reaches the QR renderer, only the download helper.
+  const exportable = address !== null && isPublicAddress(address);
+
+  const handleDownload = React.useCallback(async () => {
+    if (!address) return;
+
+    setDownloadError(null);
+    setDownloading(true);
+    try {
+      await downloadPublicAddressQrPng(address);
+    } catch (error) {
+      setDownloadError(
+        error instanceof SecretExportBlockedError
+          ? error.message
+          : t('settings.accountQr.downloadFailed')
+      );
+    } finally {
+      setDownloading(false);
+    }
+  }, [address, t]);
+
+  return (
+    <div className="flex flex-col min-h-screen bg-background">
+      <ScreenHeader title={t('settings.accountQr.title')} onBack={onBack} />
+
+      <div className="flex flex-col gap-5 p-4">
+        {!exportable ? (
+          <p className="text-sm text-muted-foreground text-center py-8">
+            {t('settings.accountQr.unavailable')}
+          </p>
+        ) : (
+          <>
+            <div className="flex flex-col items-center gap-4">
+              <PaymentQRCode value={address} size={200} />
+
+              <button
+                type="button"
+                onClick={() => void copy(address)}
+                className="flex items-center gap-2 rounded-lg bg-muted px-3 py-2 font-mono text-xs text-muted-foreground hover:bg-accent transition-colors"
+                aria-label={t('settings.accountQr.copyAddress')}
+              >
+                {truncateMiddle(address)}
+                {copied ? (
+                  <Check className="h-3.5 w-3.5 text-green-500" />
+                ) : (
+                  <Copy className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </div>
+
+            <Button onClick={() => void handleDownload()} disabled={downloading} className="w-full">
+              <Download className="mr-2 h-4 w-4" />
+              {downloading
+                ? t('settings.accountQr.downloading')
+                : t('settings.accountQr.downloadPng')}
+            </Button>
+
+            {downloadError && (
+              <p role="alert" className="text-xs text-destructive text-center">
+                {downloadError}
+              </p>
+            )}
+
+            <div className="flex items-start gap-3 rounded-xl border border-border bg-card p-4">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-green-500/10 text-green-600">
+                <ShieldCheck className="h-4 w-4" />
+              </span>
+              <div className="text-xs text-muted-foreground">
+                <p className="font-medium text-foreground">{t('settings.accountQr.safetyTitle')}</p>
+                <p className="mt-0.5">{t('settings.accountQr.safetyBody')}</p>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/extension-wallet/src/screens/Settings/SettingsScreen.tsx
+++ b/apps/extension-wallet/src/screens/Settings/SettingsScreen.tsx
@@ -12,6 +12,7 @@ import {
   Shield,
   Info,
   Bell,
+  QrCode,
 } from 'lucide-react';
 import { SettingsGroup, SettingItem } from '../../components/SettingsGroup';
 import { NetworkSettings } from './NetworkSettings';
@@ -20,6 +21,8 @@ import { AboutScreen } from './AboutScreen';
 import { EnvironmentSettings } from './EnvironmentSettings';
 import { DisplaySettings } from './DisplaySettings';
 import { ConnectedSitesScreen } from './ConnectedSitesScreen';
+import { AccountQrScreen } from './AccountQrScreen';
+import { useAccountStore } from '../../stores/account';
 import { useSettings } from '../../hooks/useSettings';
 import { DASHBOARD_SETTINGS_STORAGE_KEY } from '../../state/dashboard-settings';
 import { useToast } from '@ancore/ui-kit';
@@ -40,11 +43,14 @@ type SettingsView =
   | 'environment'
   | 'display'
   | 'about'
-  | 'connected-sites';
+  | 'connected-sites'
+  | 'account-qr';
 
 export function SettingsScreen() {
   const { t } = useTranslation();
   const { settings, updateSettings } = useSettings();
+  const accounts = useAccountStore((state) => state.accounts);
+  const activeAccountId = useAccountStore((state) => state.activeAccountId);
   const runtimeTheme = useSettingsStore((state) => state.theme);
   const setRuntimeTheme = useSettingsStore((state) => state.setTheme);
   const setRuntimeNetwork = useSettingsStore((state) => state.setNetwork);
@@ -60,6 +66,11 @@ export function SettingsScreen() {
   const telemetryOptIn = useSettingsStore((state) => state.telemetryOptIn);
   const setTelemetryOptIn = useSettingsStore((state) => state.setTelemetryOptIn);
   const [view, setView] = React.useState<SettingsView>('root');
+
+  // Prefer the deployed smart-account contract id — that is the address funds
+  // are sent to — falling back to the owner public key before deployment.
+  const activeAccount = accounts.find((a) => a.id === activeAccountId) ?? accounts[0];
+  const receiveAddress = activeAccount?.contractId ?? activeAccount?.address ?? null;
 
   React.useEffect(() => {
     if (typeof chrome === 'undefined') return;
@@ -131,6 +142,10 @@ export function SettingsScreen() {
     return <ConnectedSitesScreen onBack={() => setView('root')} />;
   }
 
+  if (view === 'account-qr') {
+    return <AccountQrScreen address={receiveAddress} onBack={() => setView('root')} />;
+  }
+
   const networkLabel = getNetworkLabel(settings.network, t);
   const timeoutLabel = getAutoLockLabel(settings.autoLockTimeout, t);
   const environmentLabel = getEnvironmentLabel(settings.environment, t);
@@ -167,6 +182,15 @@ export function SettingsScreen() {
 
       {/* Settings groups */}
       <div className="flex-1 space-y-5 p-4 -mt-3 rounded-t-2xl bg-background">
+        <SettingsGroup title={t('settings.groups.account')}>
+          <SettingItem
+            label={t('settings.accountQr.label')}
+            description={t('settings.accountQr.description')}
+            icon={<QrCode className="h-4 w-4" />}
+            onClick={() => setView('account-qr')}
+          />
+        </SettingsGroup>
+
         <SettingsGroup title={t('settings.groups.network')}>
           <SettingItem
             label={t('settings.network.label')}

--- a/apps/extension-wallet/src/screens/Settings/__tests__/accountQrScreen.test.tsx
+++ b/apps/extension-wallet/src/screens/Settings/__tests__/accountQrScreen.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { NotificationProvider } from '@ancore/ui-kit';
+import i18n from '../../../i18n';
+
+vi.mock('../../../utils/export-qr', () => {
+  const spy = vi.fn(async () => undefined);
+  return { default: spy, downloadQrPng: spy };
+});
+
+const { default: downloadQrPng } = await import('../../../utils/export-qr');
+
+import { AccountQrScreen } from '../AccountQrScreen';
+import { SettingsScreen } from '../SettingsScreen';
+import { useAccountStore } from '../../../stores/account';
+import { DEFAULTS, useSettingsStore } from '../../../stores/settings';
+
+const CONTRACT_ID = 'CBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const PUBLIC_KEY = 'GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+function renderScreen(address: string | null, onBack = vi.fn()) {
+  return render(
+    <NotificationProvider>
+      <AccountQrScreen address={address} onBack={onBack} />
+    </NotificationProvider>
+  );
+}
+
+describe('AccountQrScreen', () => {
+  beforeEach(() => {
+    vi.mocked(downloadQrPng).mockClear();
+  });
+
+  it('renders a QR for the public address', () => {
+    renderScreen(CONTRACT_ID);
+
+    const qr = screen.getByTestId('payment-qr-code');
+    expect(qr).toBeInTheDocument();
+    expect(screen.getByLabelText(`QR code for address ${CONTRACT_ID}`)).toBeInTheDocument();
+  });
+
+  it('downloads a PNG of the address on request', async () => {
+    const user = userEvent.setup();
+    renderScreen(CONTRACT_ID);
+
+    await user.click(
+      screen.getByRole('button', { name: i18n.t('settings.accountQr.downloadPng') })
+    );
+
+    await waitFor(() => expect(downloadQrPng).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(downloadQrPng).mock.calls[0][0]).toBe(CONTRACT_ID);
+    expect(vi.mocked(downloadQrPng).mock.calls[0][1]).toMatchObject({
+      filename: 'ancore-address-CBXXXXXX.png',
+    });
+  });
+
+  it('shows the public-address-only assurance', () => {
+    renderScreen(PUBLIC_KEY);
+
+    expect(screen.getByText(i18n.t('settings.accountQr.safetyTitle'))).toBeInTheDocument();
+    expect(screen.getByText(i18n.t('settings.accountQr.safetyBody'))).toBeInTheDocument();
+  });
+
+  it('offers nothing to export when there is no account address', () => {
+    renderScreen(null);
+
+    expect(screen.queryByTestId('payment-qr-code')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: i18n.t('settings.accountQr.downloadPng') })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(i18n.t('settings.accountQr.unavailable'))).toBeInTheDocument();
+  });
+
+  it('refuses to render or export a secret seed', () => {
+    // A secret can only reach this screen through a bug upstream; the render
+    // guard has to hold on its own rather than trusting the caller.
+    renderScreen('SBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
+
+    expect(screen.queryByTestId('payment-qr-code')).not.toBeInTheDocument();
+    expect(downloadQrPng).not.toHaveBeenCalled();
+  });
+
+  it('refuses to render a recovery phrase', () => {
+    renderScreen('legal winner thank year wave sausage worth useful legal winner thank yellow');
+
+    expect(screen.queryByTestId('payment-qr-code')).not.toBeInTheDocument();
+    expect(downloadQrPng).not.toHaveBeenCalled();
+  });
+
+  it('goes back when the header back button is pressed', async () => {
+    const user = userEvent.setup();
+    const onBack = vi.fn();
+    renderScreen(CONTRACT_ID, onBack);
+
+    await user.click(screen.getAllByRole('button')[0]);
+
+    expect(onBack).toHaveBeenCalled();
+  });
+});
+
+describe('SettingsScreen — address QR entry', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSettingsStore.setState(DEFAULTS);
+    vi.mocked(downloadQrPng).mockClear();
+    useAccountStore.setState({
+      accounts: [{ id: 'a1', address: PUBLIC_KEY, label: 'Main', contractId: CONTRACT_ID }],
+      activeAccountId: 'a1',
+    });
+  });
+
+  function renderSettings() {
+    return render(
+      <NotificationProvider>
+        <SettingsScreen />
+      </NotificationProvider>
+    );
+  }
+
+  it('exposes an address QR entry from the settings root', () => {
+    renderSettings();
+
+    expect(screen.getByText(i18n.t('settings.accountQr.label'))).toBeInTheDocument();
+    expect(screen.getByText(i18n.t('settings.accountQr.description'))).toBeInTheDocument();
+  });
+
+  it('opens the QR screen for the active account contract id', async () => {
+    const user = userEvent.setup();
+    renderSettings();
+
+    await user.click(screen.getByText(i18n.t('settings.accountQr.label')));
+
+    expect(screen.getByLabelText(`QR code for address ${CONTRACT_ID}`)).toBeInTheDocument();
+  });
+
+  it('falls back to the owner public key before the contract is deployed', async () => {
+    useAccountStore.setState({
+      accounts: [{ id: 'a1', address: PUBLIC_KEY, label: 'Main' }],
+      activeAccountId: 'a1',
+    });
+
+    const user = userEvent.setup();
+    renderSettings();
+    await user.click(screen.getByText(i18n.t('settings.accountQr.label')));
+
+    expect(screen.getByLabelText(`QR code for address ${PUBLIC_KEY}`)).toBeInTheDocument();
+  });
+
+  it('does not expose any secret export from the QR screen', async () => {
+    const user = userEvent.setup();
+    renderSettings();
+
+    // Private key / recovery phrase entries live on the settings root and must
+    // not follow the user into the QR screen.
+    await user.click(screen.getByText(i18n.t('settings.accountQr.label')));
+
+    expect(
+      screen.queryByText(i18n.t('settings.security.exportPrivateKey.label'))
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(i18n.t('settings.security.exportRecoveryPhrase.label'))
+    ).not.toBeInTheDocument();
+  });
+
+  it('returns to the settings root from the QR screen', async () => {
+    const user = userEvent.setup();
+    renderSettings();
+
+    await user.click(screen.getByText(i18n.t('settings.accountQr.label')));
+    await user.click(screen.getAllByRole('button')[0]);
+
+    expect(screen.getByText(i18n.t('settings.title'))).toBeInTheDocument();
+  });
+});

--- a/apps/extension-wallet/src/utils/__tests__/public-address-qr.test.ts
+++ b/apps/extension-wallet/src/utils/__tests__/public-address-qr.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.mock is hoisted above imports, so the spy has to be created inside the
+// factory and pulled back out afterwards.
+vi.mock('../export-qr', () => {
+  const spy = vi.fn(async () => undefined);
+  return { default: spy, downloadQrPng: spy };
+});
+
+const { default: downloadQrPng } = await import('../export-qr');
+
+import {
+  assertPublicAddressOnly,
+  downloadPublicAddressQrPng,
+  isPublicAddress,
+  qrFilename,
+  SecretExportBlockedError,
+} from '../public-address-qr';
+
+const PUBLIC_KEY = 'GBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const CONTRACT_ID = 'CBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const MUXED = `M${'A'.repeat(68)}`;
+const SECRET_SEED = 'SBXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const RAW_HEX_KEY = 'a'.repeat(64);
+const MNEMONIC = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
+
+describe('isPublicAddress', () => {
+  it('accepts G, C, and M addresses', () => {
+    expect(isPublicAddress(PUBLIC_KEY)).toBe(true);
+    expect(isPublicAddress(CONTRACT_ID)).toBe(true);
+    expect(isPublicAddress(MUXED)).toBe(true);
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(isPublicAddress(`  ${PUBLIC_KEY}  `)).toBe(true);
+  });
+
+  it('rejects secret seeds', () => {
+    expect(isPublicAddress(SECRET_SEED)).toBe(false);
+  });
+
+  it('rejects addresses of the wrong length', () => {
+    expect(isPublicAddress(PUBLIC_KEY.slice(0, -1))).toBe(false);
+    expect(isPublicAddress(`${PUBLIC_KEY}A`)).toBe(false);
+  });
+
+  it('rejects characters outside the base32 alphabet', () => {
+    // 0, 1, 8, and 9 are not in RFC 4648 base32.
+    expect(isPublicAddress(`G0${PUBLIC_KEY.slice(2)}`)).toBe(false);
+    expect(isPublicAddress(PUBLIC_KEY.toLowerCase())).toBe(false);
+  });
+});
+
+describe('assertPublicAddressOnly', () => {
+  it('returns the trimmed address when valid', () => {
+    expect(assertPublicAddressOnly(`  ${PUBLIC_KEY} `)).toBe(PUBLIC_KEY);
+  });
+
+  it('blocks a Stellar secret seed with a specific message', () => {
+    expect(() => assertPublicAddressOnly(SECRET_SEED)).toThrow(SecretExportBlockedError);
+    expect(() => assertPublicAddressOnly(SECRET_SEED)).toThrow(/secret key/i);
+  });
+
+  it('blocks a raw hex private key', () => {
+    expect(() => assertPublicAddressOnly(RAW_HEX_KEY)).toThrow(/raw private key/i);
+  });
+
+  it('blocks a recovery phrase', () => {
+    expect(() => assertPublicAddressOnly(MNEMONIC)).toThrow(/recovery phrase/i);
+  });
+
+  it('blocks anything unrecognised — it is a whitelist, not a blocklist', () => {
+    for (const value of ['', 'hello', 'https://example.com', '{"seed":"S..."}']) {
+      expect(() => assertPublicAddressOnly(value)).toThrow(SecretExportBlockedError);
+    }
+  });
+});
+
+describe('qrFilename', () => {
+  it('derives a stable, address-scoped filename', () => {
+    expect(qrFilename(PUBLIC_KEY)).toBe('ancore-address-GBXXXXXX.png');
+  });
+});
+
+describe('downloadPublicAddressQrPng', () => {
+  beforeEach(() => {
+    downloadQrPng.mockClear();
+  });
+
+  it('downloads a QR for a public address', async () => {
+    await downloadPublicAddressQrPng(PUBLIC_KEY);
+
+    expect(downloadQrPng).toHaveBeenCalledTimes(1);
+    expect(downloadQrPng).toHaveBeenCalledWith(
+      PUBLIC_KEY,
+      expect.objectContaining({ filename: 'ancore-address-GBXXXXXX.png' })
+    );
+  });
+
+  it('encodes the address itself, not a payment URI or any wrapper', async () => {
+    await downloadPublicAddressQrPng(CONTRACT_ID);
+
+    expect(downloadQrPng.mock.calls[0][0]).toBe(CONTRACT_ID);
+  });
+
+  it('never reaches the QR writer when given a secret', async () => {
+    await expect(downloadPublicAddressQrPng(SECRET_SEED)).rejects.toThrow(SecretExportBlockedError);
+    expect(downloadQrPng).not.toHaveBeenCalled();
+  });
+
+  it('never reaches the QR writer when given a recovery phrase', async () => {
+    await expect(downloadPublicAddressQrPng(MNEMONIC)).rejects.toThrow(SecretExportBlockedError);
+    expect(downloadQrPng).not.toHaveBeenCalled();
+  });
+
+  it('allows callers to override download options', async () => {
+    await downloadPublicAddressQrPng(PUBLIC_KEY, { filename: 'custom.png', scale: 2 });
+
+    expect(downloadQrPng).toHaveBeenCalledWith(
+      PUBLIC_KEY,
+      expect.objectContaining({ filename: 'custom.png', scale: 2 })
+    );
+  });
+});

--- a/apps/extension-wallet/src/utils/public-address-qr.ts
+++ b/apps/extension-wallet/src/utils/public-address-qr.ts
@@ -1,0 +1,106 @@
+/**
+ * Guarded QR export for public receive addresses.
+ *
+ * A downloadable QR is a file that leaves the extension and gets shared with
+ * support agents, printed, or dropped into a chat. Encoding a secret in one
+ * would be catastrophic and invisible — the PNG looks identical either way.
+ * So this module never accepts arbitrary input: it whitelists the Stellar
+ * public-address formats and rejects everything else, including the specific
+ * secret shapes the wallet handles, which get a clearer error.
+ *
+ * Every QR download surface in the wallet must call through here rather than
+ * {@link downloadQrPng} directly.
+ */
+
+import downloadQrPng, { type DownloadQrOptions } from './export-qr';
+
+/**
+ * Stellar public formats, all base32 (RFC 4648 alphabet, no padding):
+ *   G… ed25519 account, C… contract, M… muxed account (69 chars).
+ * `S…` is deliberately absent — that is the secret seed prefix.
+ */
+const PUBLIC_ADDRESS_PATTERN = /^[GC][A-Z2-7]{55}$|^M[A-Z2-7]{68}$/;
+
+/** Stellar secret seed: 56 chars, `S` prefix. */
+const SECRET_SEED_PATTERN = /^S[A-Z2-7]{55}$/;
+
+/** Raw ed25519 private key as hex. */
+const RAW_HEX_KEY_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+/** Thrown when a QR export is asked to encode something that is not a public address. */
+export class SecretExportBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SecretExportBlockedError';
+  }
+}
+
+/** Whether `value` is a well-formed Stellar public address (G, C, or M). */
+export function isPublicAddress(value: string): boolean {
+  return PUBLIC_ADDRESS_PATTERN.test(value.trim());
+}
+
+/**
+ * Classify input that is *not* a public address, so the caller can explain why
+ * rather than showing a generic failure.
+ */
+function describeRejection(value: string): string {
+  if (SECRET_SEED_PATTERN.test(value)) {
+    return 'Refusing to encode a secret key in a QR code.';
+  }
+
+  if (RAW_HEX_KEY_PATTERN.test(value)) {
+    return 'Refusing to encode a raw private key in a QR code.';
+  }
+
+  if (value.split(/\s+/).filter(Boolean).length >= 12) {
+    return 'Refusing to encode a recovery phrase in a QR code.';
+  }
+
+  return 'QR export only accepts a Stellar public address.';
+}
+
+/**
+ * Throw unless `value` is a Stellar public address.
+ *
+ * This is a whitelist, not a blocklist: anything that is not recognisably a
+ * public address is rejected, so a secret format nobody anticipated still
+ * cannot slip through.
+ *
+ * @throws {SecretExportBlockedError}
+ */
+export function assertPublicAddressOnly(value: string): string {
+  const trimmed = value.trim();
+
+  if (!isPublicAddress(trimmed)) {
+    throw new SecretExportBlockedError(describeRejection(trimmed));
+  }
+
+  return trimmed;
+}
+
+/** Filename for a downloaded address QR, e.g. `ancore-address-GABCDEFG.png`. */
+export function qrFilename(address: string): string {
+  return `ancore-address-${address.slice(0, 8)}.png`;
+}
+
+/**
+ * Download a PNG QR code of a public receive address.
+ *
+ * @param address - Stellar public address (G, C, or M).
+ * @throws {SecretExportBlockedError} if `address` is not a public address.
+ */
+export async function downloadPublicAddressQrPng(
+  address: string,
+  opts: DownloadQrOptions = {}
+): Promise<void> {
+  const safe = assertPublicAddressOnly(address);
+
+  await downloadQrPng(safe, {
+    filename: qrFilename(safe),
+    scale: 3,
+    ...opts,
+  });
+}
+
+export default downloadPublicAddressQrPng;

--- a/apps/web-dashboard/src/lib/__tests__/split-bill-validation.test.ts
+++ b/apps/web-dashboard/src/lib/__tests__/split-bill-validation.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateShares,
+  parseDecimal,
+  formatAmount,
+  amountsEqual,
+  errorsByKey,
+  formError,
+  PERCENTAGE_TOTAL,
+  type ShareInput,
+} from '../split-bill-validation';
+
+function shares(...values: string[]): ShareInput[] {
+  return values.map((share, index) => ({ key: `p${index}`, share }));
+}
+
+describe('parseDecimal', () => {
+  it('parses plain and decimal numbers', () => {
+    expect(parseDecimal('10')).toBe(10);
+    expect(parseDecimal('10.5')).toBe(10.5);
+    expect(parseDecimal('.5')).toBe(0.5);
+    expect(parseDecimal('  33.33  ')).toBe(33.33);
+  });
+
+  it('rejects blank and non-numeric input', () => {
+    expect(parseDecimal('')).toBeNull();
+    expect(parseDecimal('   ')).toBeNull();
+    expect(parseDecimal('abc')).toBeNull();
+    expect(parseDecimal('10abc')).toBeNull();
+    expect(parseDecimal('1,000')).toBeNull();
+  });
+
+  it('rejects values Number() would silently accept', () => {
+    expect(parseDecimal('Infinity')).toBeNull();
+    expect(parseDecimal('NaN')).toBeNull();
+    expect(parseDecimal('1e5')).toBeNull();
+    expect(parseDecimal('0x10')).toBeNull();
+  });
+
+  it('parses negative numbers so the caller can reject them with a clear message', () => {
+    expect(parseDecimal('-5')).toBe(-5);
+  });
+});
+
+describe('formatAmount', () => {
+  it('trims trailing zeros', () => {
+    expect(formatAmount(10)).toBe('10');
+    expect(formatAmount(10.5)).toBe('10.5');
+    expect(formatAmount(0.1)).toBe('0.1');
+  });
+
+  it('clamps to Stellar 7-decimal precision', () => {
+    expect(formatAmount(1 / 3)).toBe('0.3333333');
+  });
+});
+
+describe('amountsEqual', () => {
+  it('treats binary floating-point drift as equal', () => {
+    expect(amountsEqual(0.1 + 0.2, 0.3)).toBe(true);
+  });
+
+  it('still separates values that differ at Stellar precision', () => {
+    expect(amountsEqual(0.0000001, 0.0000002)).toBe(false);
+  });
+});
+
+describe('validateShares — percentage mode', () => {
+  it('accepts shares summing to exactly 100%', () => {
+    const result = validateShares({
+      mode: 'percentage',
+      participants: shares('50', '30', '20'),
+      totalAmount: '200',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.sum).toBe(PERCENTAGE_TOTAL);
+    expect(result.amounts).toEqual({ p0: '100', p1: '60', p2: '40' });
+  });
+
+  it('rejects shares that fall short of 100%', () => {
+    const result = validateShares({
+      mode: 'percentage',
+      participants: shares('50', '30'),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(formError(result.errors)).toContain('20% short of 100%');
+  });
+
+  it('rejects shares that exceed 100%', () => {
+    const result = validateShares({
+      mode: 'percentage',
+      participants: shares('60', '60'),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(formError(result.errors)).toContain('20% over 100%');
+  });
+
+  it('requires a bill total so percentages can be converted', () => {
+    const result = validateShares({
+      mode: 'percentage',
+      participants: shares('50', '50'),
+      totalAmount: '',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(formError(result.errors)).toContain('Enter the bill total');
+  });
+
+  it('rejects a single share above 100%', () => {
+    const result = validateShares({
+      mode: 'percentage',
+      participants: shares('150', '10'),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(errorsByKey(result.errors).p0).toBe('Share cannot exceed 100%.');
+  });
+
+  it('accepts a single participant taking the whole bill', () => {
+    const result = validateShares({
+      mode: 'percentage',
+      participants: shares('100'),
+      totalAmount: '75.25',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.amounts.p0).toBe('75.25');
+  });
+
+  it('folds the rounding remainder into the last participant', () => {
+    // 100 / 3 is not representable at 7 decimals, so naive rounding would
+    // leave the parts summing to 99.9999999 rather than 100.
+    const result = validateShares({
+      mode: 'percentage',
+      participants: shares('33.3333333', '33.3333333', '33.3333334'),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(true);
+
+    const total = Object.values(result.amounts).reduce((acc, a) => acc + Number(a), 0);
+    expect(amountsEqual(total, 100)).toBe(true);
+  });
+
+  it('accepts fractional percentages that still total 100', () => {
+    const result = validateShares({
+      mode: 'percentage',
+      participants: shares('33.5', '33.25', '33.25'),
+      totalAmount: '400',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.amounts).toEqual({ p0: '134', p1: '133', p2: '133' });
+  });
+});
+
+describe('validateShares — amount mode', () => {
+  it('accepts amounts summing to the stated total', () => {
+    const result = validateShares({
+      mode: 'amount',
+      participants: shares('40', '35', '25'),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.sum).toBe(100);
+    expect(result.amounts).toEqual({ p0: '40', p1: '35', p2: '25' });
+  });
+
+  it('rejects amounts under the total', () => {
+    const result = validateShares({
+      mode: 'amount',
+      participants: shares('40', '35'),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(formError(result.errors)).toContain('25 short of the 100 total');
+  });
+
+  it('rejects amounts over the total', () => {
+    const result = validateShares({
+      mode: 'amount',
+      participants: shares('80', '35'),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(formError(result.errors)).toContain('15 over the 100 total');
+  });
+
+  it('skips the sum check when no total is given', () => {
+    const result = validateShares({
+      mode: 'amount',
+      participants: shares('40', '35'),
+      totalAmount: '',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.sum).toBe(75);
+  });
+
+  it('tolerates floating-point drift at Stellar precision', () => {
+    const result = validateShares({
+      mode: 'amount',
+      participants: shares('0.1', '0.2'),
+      totalAmount: '0.3',
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a total that is not a number', () => {
+    const result = validateShares({
+      mode: 'amount',
+      participants: shares('40', '60'),
+      totalAmount: 'one hundred',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(formError(result.errors)).toBe('Total amount must be a number.');
+  });
+
+  it('rejects a zero or negative total', () => {
+    for (const totalAmount of ['0', '-100']) {
+      const result = validateShares({
+        mode: 'amount',
+        participants: shares('40', '60'),
+        totalAmount,
+      });
+
+      expect(result.valid).toBe(false);
+      expect(formError(result.errors)).toBe('Total amount must be greater than zero.');
+    }
+  });
+});
+
+describe('validateShares — per-participant errors', () => {
+  it('flags blank shares on the row that is blank', () => {
+    const result = validateShares({
+      mode: 'amount',
+      participants: shares('40', ''),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(errorsByKey(result.errors)).toEqual({
+      p1: 'Enter an amount for this participant.',
+    });
+  });
+
+  it('flags zero and negative shares', () => {
+    const result = validateShares({
+      mode: 'amount',
+      participants: shares('0', '-5'),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(errorsByKey(result.errors).p0).toContain('greater than zero');
+    expect(errorsByKey(result.errors).p1).toContain('greater than zero');
+  });
+
+  it('suppresses the sum error while a row is still invalid', () => {
+    // Reporting "doesn't add up" alongside "this field is empty" is noise —
+    // the sum cannot be meaningful until every row parses.
+    const result = validateShares({
+      mode: 'percentage',
+      participants: shares('50', ''),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(formError(result.errors)).toBeNull();
+  });
+
+  it('rejects an empty participant list', () => {
+    const result = validateShares({
+      mode: 'amount',
+      participants: [],
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(formError(result.errors)).toBe('Add at least one participant.');
+  });
+
+  it('returns no resolved amounts when validation fails', () => {
+    const result = validateShares({
+      mode: 'percentage',
+      participants: shares('50', '40'),
+      totalAmount: '100',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.amounts).toEqual({});
+  });
+});
+
+describe('errorsByKey', () => {
+  it('keeps the first error per row and drops form-level errors', () => {
+    const byKey = errorsByKey([
+      { key: 'p0', message: 'first' },
+      { key: 'p0', message: 'second' },
+      { key: null, message: 'form' },
+    ]);
+
+    expect(byKey).toEqual({ p0: 'first' });
+  });
+});

--- a/apps/web-dashboard/src/lib/split-bill-validation.ts
+++ b/apps/web-dashboard/src/lib/split-bill-validation.ts
@@ -1,0 +1,244 @@
+/**
+ * Client-side validation for the split-bill create form.
+ *
+ * A split is only well-formed when the participant shares actually add up:
+ * either to 100% (percentage mode) or to the stated bill total (amount mode).
+ * Without this check the UI happily creates bills whose participant amounts
+ * bear no relation to what was owed.
+ *
+ * Everything here is pure so the rules can be unit-tested without React.
+ */
+
+/** How participant shares are entered. */
+export type SplitMode = 'amount' | 'percentage';
+
+/**
+ * Stellar amounts carry 7 decimal places. Sums are compared with a tolerance
+ * of half a stroop so that values which are exact at Stellar's precision are
+ * not rejected by binary floating-point drift (e.g. 0.1 + 0.2 !== 0.3).
+ */
+export const AMOUNT_DECIMALS = 7;
+const TOLERANCE = 0.5 / 10 ** AMOUNT_DECIMALS;
+
+/** Percentages must total exactly this. */
+export const PERCENTAGE_TOTAL = 100;
+
+/** One row of the participants editor. */
+export interface ShareInput {
+  /** Stable row key, echoed back on any error that belongs to this row. */
+  key: string;
+  /** Raw text from the share field — amount or percentage depending on mode. */
+  share: string;
+}
+
+/** A validation failure tied to a specific row, or to the form as a whole. */
+export interface ShareValidationError {
+  /** Row key, or `null` for a form-level error such as a bad sum. */
+  key: string | null;
+  message: string;
+}
+
+export interface ValidateSharesInput {
+  mode: SplitMode;
+  participants: ShareInput[];
+  /** Raw text from the bill total field. Required in percentage mode. */
+  totalAmount?: string;
+}
+
+export interface ValidateSharesResult {
+  valid: boolean;
+  errors: ShareValidationError[];
+  /** Sum of the parsed shares — percent in percentage mode, else an amount. */
+  sum: number;
+  /**
+   * Resolved amount owed per participant, keyed by row key. Only populated
+   * when validation passes; in percentage mode these are derived from the
+   * total, with any rounding remainder folded into the last participant so
+   * the amounts sum exactly to the total.
+   */
+  amounts: Record<string, string>;
+}
+
+/**
+ * Parse a user-entered decimal.
+ *
+ * Rejects blank input, non-numeric text, and the JS-specific values
+ * (`Infinity`, `NaN`) that `Number()` would otherwise accept.
+ */
+export function parseDecimal(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  if (!/^-?\d*\.?\d+$/.test(trimmed)) return null;
+
+  const value = Number(trimmed);
+  return Number.isFinite(value) ? value : null;
+}
+
+/** Round to Stellar's 7-decimal precision and render without trailing zeros. */
+export function formatAmount(value: number): string {
+  const fixed = value.toFixed(AMOUNT_DECIMALS);
+  return fixed.includes('.') ? fixed.replace(/\.?0+$/, '') : fixed;
+}
+
+/** Whether two amounts are equal at Stellar's precision. */
+export function amountsEqual(a: number, b: number): boolean {
+  return Math.abs(a - b) < TOLERANCE;
+}
+
+function roundToPrecision(value: number): number {
+  return Number(value.toFixed(AMOUNT_DECIMALS));
+}
+
+/**
+ * Split `total` across `weights` (percentages), assigning the rounding
+ * remainder to the last participant so the parts sum exactly to `total`.
+ */
+function allocate(total: number, weights: number[]): number[] {
+  if (weights.length === 0) return [];
+
+  const parts = weights
+    .slice(0, -1)
+    .map((weight) => roundToPrecision((total * weight) / PERCENTAGE_TOTAL));
+  const allocated = parts.reduce((acc, part) => acc + part, 0);
+
+  return [...parts, roundToPrecision(total - allocated)];
+}
+
+/**
+ * Validate that participant shares sum to 100% (percentage mode) or to the
+ * bill total (amount mode).
+ *
+ * In amount mode the total is optional: when it is blank the individual
+ * amounts are still checked for validity, but no sum check is applied — that
+ * preserves the "just enter what each person owes" flow.
+ */
+export function validateShares({
+  mode,
+  participants,
+  totalAmount,
+}: ValidateSharesInput): ValidateSharesResult {
+  const errors: ShareValidationError[] = [];
+
+  if (participants.length === 0) {
+    return {
+      valid: false,
+      errors: [{ key: null, message: 'Add at least one participant.' }],
+      sum: 0,
+      amounts: {},
+    };
+  }
+
+  const parsedTotal = totalAmount === undefined ? null : parseDecimal(totalAmount);
+  const totalProvided = totalAmount !== undefined && totalAmount.trim() !== '';
+
+  if (totalProvided && parsedTotal === null) {
+    errors.push({ key: null, message: 'Total amount must be a number.' });
+  } else if (parsedTotal !== null && parsedTotal <= 0) {
+    errors.push({ key: null, message: 'Total amount must be greater than zero.' });
+  }
+
+  if (mode === 'percentage' && !totalProvided) {
+    errors.push({
+      key: null,
+      message: 'Enter the bill total so percentage shares can be converted to amounts.',
+    });
+  }
+
+  const unit = mode === 'percentage' ? '%' : 'amount';
+  const values: number[] = [];
+
+  for (const participant of participants) {
+    const value = parseDecimal(participant.share);
+
+    if (value === null) {
+      errors.push({
+        key: participant.key,
+        message:
+          mode === 'percentage'
+            ? 'Enter a percentage share.'
+            : 'Enter an amount for this participant.',
+      });
+      values.push(0);
+      continue;
+    }
+
+    if (value <= 0) {
+      errors.push({
+        key: participant.key,
+        message: `Share must be greater than zero (${unit}).`,
+      });
+      values.push(0);
+      continue;
+    }
+
+    if (mode === 'percentage' && value > PERCENTAGE_TOTAL) {
+      errors.push({ key: participant.key, message: 'Share cannot exceed 100%.' });
+      values.push(0);
+      continue;
+    }
+
+    values.push(value);
+  }
+
+  const sum = roundToPrecision(values.reduce((acc, value) => acc + value, 0));
+
+  // Only run the sum check once every individual value parsed — otherwise the
+  // user gets a confusing "doesn't add up" on top of "this field is empty".
+  const allSharesValid = !errors.some((error) => error.key !== null);
+
+  if (allSharesValid) {
+    if (mode === 'percentage') {
+      if (!amountsEqual(sum, PERCENTAGE_TOTAL)) {
+        const delta = roundToPrecision(PERCENTAGE_TOTAL - sum);
+        errors.push({
+          key: null,
+          message:
+            delta > 0
+              ? `Shares total ${formatAmount(sum)}% — ${formatAmount(delta)}% short of 100%.`
+              : `Shares total ${formatAmount(sum)}% — ${formatAmount(-delta)}% over 100%.`,
+        });
+      }
+    } else if (parsedTotal !== null && parsedTotal > 0) {
+      if (!amountsEqual(sum, parsedTotal)) {
+        const delta = roundToPrecision(parsedTotal - sum);
+        errors.push({
+          key: null,
+          message:
+            delta > 0
+              ? `Participant amounts total ${formatAmount(sum)} — ${formatAmount(delta)} short of the ${formatAmount(parsedTotal)} total.`
+              : `Participant amounts total ${formatAmount(sum)} — ${formatAmount(-delta)} over the ${formatAmount(parsedTotal)} total.`,
+        });
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors, sum, amounts: {} };
+  }
+
+  const resolved =
+    mode === 'percentage' && parsedTotal !== null ? allocate(parsedTotal, values) : values;
+
+  const amounts: Record<string, string> = {};
+  participants.forEach((participant, index) => {
+    amounts[participant.key] = formatAmount(resolved[index]);
+  });
+
+  return { valid: true, errors: [], sum, amounts };
+}
+
+/** Index errors by row key for rendering inline messages. */
+export function errorsByKey(errors: ShareValidationError[]): Record<string, string> {
+  const byKey: Record<string, string> = {};
+  for (const error of errors) {
+    if (error.key !== null && !(error.key in byKey)) {
+      byKey[error.key] = error.message;
+    }
+  }
+  return byKey;
+}
+
+/** The first form-level (non-row) error, if any. */
+export function formError(errors: ShareValidationError[]): string | null {
+  return errors.find((error) => error.key === null)?.message ?? null;
+}

--- a/apps/web-dashboard/src/pages/SplitBill.tsx
+++ b/apps/web-dashboard/src/pages/SplitBill.tsx
@@ -4,6 +4,14 @@ import { useNavigate } from 'react-router-dom';
 import { Plus, Trash2, Users, CheckCircle, Clock, XCircle, AlertCircle } from 'lucide-react';
 import { useSplitBill } from '../hooks/useSplitBill';
 import type { SplitBill, SplitBillStatus } from '../types/split-bill';
+import {
+  validateShares,
+  errorsByKey,
+  formError,
+  formatAmount,
+  parseDecimal,
+  type SplitMode,
+} from '../lib/split-bill-validation';
 
 // ── Create form ───────────────────────────────────────────────────────────────
 
@@ -11,6 +19,7 @@ interface ParticipantDraft {
   key: string;
   address: string;
   alias: string;
+  /** Amount owed, or percentage share — depending on the selected split mode. */
   amount: string;
   assetCode: string;
 }
@@ -19,13 +28,53 @@ function newParticipant(): ParticipantDraft {
   return { key: crypto.randomUUID(), address: '', alias: '', amount: '', assetCode: 'XLM' };
 }
 
+/** Live summary of what the entered shares currently add up to. */
+function ShareSummary({
+  mode,
+  sum,
+  total,
+}: {
+  mode: SplitMode;
+  sum: number;
+  total: number | null;
+}) {
+  const target = mode === 'percentage' ? 100 : total;
+  if (target === null) return null;
+
+  const balanced = Math.abs(sum - target) < 0.5e-7;
+  const suffix = mode === 'percentage' ? '%' : '';
+
+  return (
+    <p
+      className={`text-xs mt-2 ${balanced ? 'text-green-600' : 'text-amber-600'}`}
+      data-testid="share-summary"
+    >
+      {formatAmount(sum)}
+      {suffix} of {formatAmount(target)}
+      {suffix} allocated
+    </p>
+  );
+}
+
 function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
   const { createBill } = useSplitBill();
   const [title, setTitle] = useState('');
   const [note, setNote] = useState('');
   const [creatorAddress, setCreatorAddress] = useState('');
+  const [mode, setMode] = useState<SplitMode>('amount');
+  const [totalAmount, setTotalAmount] = useState('');
   const [participants, setParticipants] = useState<ParticipantDraft[]>([newParticipant()]);
   const [error, setError] = useState('');
+  const [shareErrors, setShareErrors] = useState<Record<string, string>>({});
+
+  // Recomputed on every render so the running total updates as the user types.
+  // Errors are only *surfaced* on submit; this just drives the live summary.
+  const preview = validateShares({
+    mode,
+    participants: participants.map((p) => ({ key: p.key, share: p.amount })),
+    totalAmount,
+  });
+  const parsedTotal = parseDecimal(totalAmount);
 
   function updateParticipant(key: string, patch: Partial<ParticipantDraft>) {
     setParticipants((prev) => prev.map((p) => (p.key === key ? { ...p, ...patch } : p)));
@@ -35,9 +84,16 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
     setParticipants((prev) => prev.filter((p) => p.key !== key));
   }
 
+  function handleModeChange(next: SplitMode) {
+    setMode(next);
+    setError('');
+    setShareErrors({});
+  }
+
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setError('');
+    setShareErrors({});
 
     if (!title.trim()) return setError('Title is required.');
     if (!creatorAddress.trim()) return setError('Your address is required.');
@@ -45,8 +101,20 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
 
     for (const p of participants) {
       if (!p.address.trim()) return setError('All participants need an address.');
-      if (!p.amount.trim() || isNaN(Number(p.amount)) || Number(p.amount) <= 0)
-        return setError('All participants need a valid amount.');
+    }
+
+    // Shares must add up: to 100% in percentage mode, or to the bill total in
+    // amount mode when one was given.
+    const result = validateShares({
+      mode,
+      participants: participants.map((p) => ({ key: p.key, share: p.amount })),
+      totalAmount,
+    });
+
+    if (!result.valid) {
+      setShareErrors(errorsByKey(result.errors));
+      setError(formError(result.errors) ?? 'Fix the highlighted participant shares.');
+      return;
     }
 
     const bill = createBill({
@@ -56,7 +124,9 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
       participants: participants.map((p) => ({
         address: p.address.trim(),
         alias: p.alias.trim() || undefined,
-        amount: p.amount.trim(),
+        // In percentage mode the stored amount is the share converted against
+        // the bill total, so a bill always persists concrete amounts.
+        amount: result.amounts[p.key],
         assetCode: p.assetCode,
       })),
     });
@@ -99,6 +169,48 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
         />
       </label>
 
+      {/* Split mode + bill total */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <fieldset>
+          <legend className="text-sm font-medium text-slate-700">Split by</legend>
+          <div className="mt-1 inline-flex rounded-lg border border-slate-300 p-0.5">
+            {(['amount', 'percentage'] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => handleModeChange(option)}
+                aria-pressed={mode === option}
+                className={`rounded-md px-3 py-1.5 text-xs capitalize transition-colors ${
+                  mode === option
+                    ? 'bg-slate-950 text-white'
+                    : 'text-slate-600 hover:text-slate-900'
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700">
+            Bill total {mode === 'percentage' ? '*' : '(optional)'}
+          </span>
+          <input
+            value={totalAmount}
+            onChange={(e) => setTotalAmount(e.target.value)}
+            placeholder="100"
+            inputMode="decimal"
+            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-400"
+          />
+          <span className="mt-1 block text-xs text-slate-500">
+            {mode === 'percentage'
+              ? 'Percentage shares are converted against this total.'
+              : 'When set, participant amounts must add up to it.'}
+          </span>
+        </label>
+      </div>
+
       {/* Participants */}
       <div>
         <div className="flex items-center justify-between mb-2">
@@ -113,62 +225,89 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
         </div>
 
         <ul className="space-y-3">
-          {participants.map((p) => (
-            <li key={p.key} className="grid grid-cols-[1fr_1fr_auto_auto_auto] gap-2 items-end">
-              <label className="block">
-                <span className="text-xs text-slate-500">Address *</span>
-                <input
-                  value={p.address}
-                  onChange={(e) => updateParticipant(p.key, { address: e.target.value })}
-                  placeholder="G..."
-                  className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-slate-400"
-                />
-              </label>
-              <label className="block">
-                <span className="text-xs text-slate-500">Alias</span>
-                <input
-                  value={p.alias}
-                  onChange={(e) => updateParticipant(p.key, { alias: e.target.value })}
-                  placeholder="Alice"
-                  className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-slate-400"
-                />
-              </label>
-              <label className="block">
-                <span className="text-xs text-slate-500">Amount *</span>
-                <input
-                  value={p.amount}
-                  onChange={(e) => updateParticipant(p.key, { amount: e.target.value })}
-                  placeholder="10"
-                  type="number"
-                  min="0"
-                  step="any"
-                  className="mt-1 w-24 rounded border border-slate-300 px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-slate-400"
-                />
-              </label>
-              <label className="block">
-                <span className="text-xs text-slate-500">Asset</span>
-                <input
-                  value={p.assetCode}
-                  onChange={(e) => updateParticipant(p.key, { assetCode: e.target.value })}
-                  placeholder="XLM"
-                  className="mt-1 w-16 rounded border border-slate-300 px-2 py-1.5 text-xs uppercase focus:outline-none focus:ring-1 focus:ring-slate-400"
-                />
-              </label>
-              <button
-                type="button"
-                onClick={() => removeParticipant(p.key)}
-                disabled={participants.length === 1}
-                className="mb-0.5 p-1.5 rounded text-slate-400 hover:text-red-500 disabled:opacity-30"
-                aria-label="Remove participant"
-              >
-                <Trash2 className="w-4 h-4" />
-              </button>
-            </li>
-          ))}
+          {participants.map((p) => {
+            const shareError = shareErrors[p.key];
+            const shareErrorId = `share-error-${p.key}`;
+
+            return (
+              <li key={p.key}>
+                <div className="grid grid-cols-[1fr_1fr_auto_auto_auto] gap-2 items-end">
+                  <label className="block">
+                    <span className="text-xs text-slate-500">Address *</span>
+                    <input
+                      value={p.address}
+                      onChange={(e) => updateParticipant(p.key, { address: e.target.value })}
+                      placeholder="G..."
+                      className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-slate-400"
+                    />
+                  </label>
+                  <label className="block">
+                    <span className="text-xs text-slate-500">Alias</span>
+                    <input
+                      value={p.alias}
+                      onChange={(e) => updateParticipant(p.key, { alias: e.target.value })}
+                      placeholder="Alice"
+                      className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-slate-400"
+                    />
+                  </label>
+                  <label className="block">
+                    <span className="text-xs text-slate-500">
+                      {mode === 'percentage' ? 'Share % *' : 'Amount *'}
+                    </span>
+                    <input
+                      value={p.amount}
+                      onChange={(e) => updateParticipant(p.key, { amount: e.target.value })}
+                      placeholder={mode === 'percentage' ? '50' : '10'}
+                      type="number"
+                      min="0"
+                      step="any"
+                      aria-invalid={shareError ? true : undefined}
+                      aria-describedby={shareError ? shareErrorId : undefined}
+                      className={`mt-1 w-24 rounded border px-2 py-1.5 text-xs focus:outline-none focus:ring-1 ${
+                        shareError
+                          ? 'border-red-400 focus:ring-red-400'
+                          : 'border-slate-300 focus:ring-slate-400'
+                      }`}
+                    />
+                  </label>
+                  <label className="block">
+                    <span className="text-xs text-slate-500">Asset</span>
+                    <input
+                      value={p.assetCode}
+                      onChange={(e) => updateParticipant(p.key, { assetCode: e.target.value })}
+                      placeholder="XLM"
+                      className="mt-1 w-16 rounded border border-slate-300 px-2 py-1.5 text-xs uppercase focus:outline-none focus:ring-1 focus:ring-slate-400"
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => removeParticipant(p.key)}
+                    disabled={participants.length === 1}
+                    className="mb-0.5 p-1.5 rounded text-slate-400 hover:text-red-500 disabled:opacity-30"
+                    aria-label="Remove participant"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+
+                {shareError && (
+                  <p id={shareErrorId} className="mt-1 text-xs text-red-600">
+                    {shareError}
+                  </p>
+                )}
+              </li>
+            );
+          })}
         </ul>
+
+        <ShareSummary mode={mode} sum={preview.sum} total={parsedTotal} />
       </div>
 
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {error && (
+        <p role="alert" className="text-sm text-red-600">
+          {error}
+        </p>
+      )}
 
       <button
         type="submit"

--- a/apps/web-dashboard/src/pages/__tests__/SplitBill.test.tsx
+++ b/apps/web-dashboard/src/pages/__tests__/SplitBill.test.tsx
@@ -1,0 +1,255 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SplitBillPage } from '../SplitBill';
+
+const mockCreateBill = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../../hooks/useSplitBill', () => ({
+  useSplitBill: () => ({
+    bills: [],
+    isLoading: false,
+    createBill: mockCreateBill,
+    updateParticipant: vi.fn(),
+    cancelBill: vi.fn(),
+    getBill: vi.fn(),
+  }),
+}));
+
+const ADDRESS_A = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const ADDRESS_B = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const CREATOR = 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+
+/** Open the create form and fill in the non-participant fields. */
+async function openForm(user: ReturnType<typeof userEvent.setup>) {
+  render(<SplitBillPage />);
+  await user.click(screen.getByRole('button', { name: /new bill/i }));
+  await user.type(screen.getByLabelText(/title/i), 'Dinner');
+  await user.type(screen.getByLabelText(/your address/i), CREATOR);
+}
+
+/** The participants <ul> — scopes queries away from the creator address field. */
+function participantList() {
+  return screen.getByRole('list');
+}
+
+/** Add a second participant row and fill both rows' addresses. */
+async function addTwoParticipants(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /add participant/i }));
+
+  const addressFields = within(participantList()).getAllByPlaceholderText('G...');
+  await user.type(addressFields[0], ADDRESS_A);
+  await user.type(addressFields[1], ADDRESS_B);
+}
+
+function shareFields() {
+  return within(participantList()).getAllByRole('spinbutton');
+}
+
+function submit(user: ReturnType<typeof userEvent.setup>) {
+  return user.click(screen.getByRole('button', { name: /create split bill/i }));
+}
+
+describe('SplitBill create form — share validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateBill.mockReturnValue({ id: 'bill-1' });
+  });
+
+  it('blocks submit when amounts do not add up to the bill total', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+    await addTwoParticipants(user);
+
+    await user.type(screen.getByPlaceholderText('100'), '100');
+    const [a, b] = shareFields();
+    await user.type(a, '40');
+    await user.type(b, '35');
+
+    await submit(user);
+
+    expect(mockCreateBill).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('25 short of the 100 total');
+  });
+
+  it('blocks submit when amounts exceed the bill total', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+    await addTwoParticipants(user);
+
+    await user.type(screen.getByPlaceholderText('100'), '100');
+    const [a, b] = shareFields();
+    await user.type(a, '80');
+    await user.type(b, '35');
+
+    await submit(user);
+
+    expect(mockCreateBill).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('15 over the 100 total');
+  });
+
+  it('creates the bill when amounts add up to the total', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+    await addTwoParticipants(user);
+
+    await user.type(screen.getByPlaceholderText('100'), '100');
+    const [a, b] = shareFields();
+    await user.type(a, '60');
+    await user.type(b, '40');
+
+    await submit(user);
+
+    expect(mockCreateBill).toHaveBeenCalledTimes(1);
+    expect(mockCreateBill.mock.calls[0][0].participants).toEqual([
+      expect.objectContaining({ address: ADDRESS_A, amount: '60' }),
+      expect.objectContaining({ address: ADDRESS_B, amount: '40' }),
+    ]);
+  });
+
+  it('creates the bill with no total, preserving the free-entry flow', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+    await addTwoParticipants(user);
+
+    const [a, b] = shareFields();
+    await user.type(a, '12');
+    await user.type(b, '8');
+
+    await submit(user);
+
+    expect(mockCreateBill).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks submit when percentage shares do not total 100', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+    await user.click(screen.getByRole('button', { name: /percentage/i }));
+    await addTwoParticipants(user);
+
+    await user.type(screen.getByPlaceholderText('100'), '200');
+    const [a, b] = shareFields();
+    await user.type(a, '50');
+    await user.type(b, '30');
+
+    await submit(user);
+
+    expect(mockCreateBill).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('20% short of 100%');
+  });
+
+  it('converts percentage shares to amounts against the bill total', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+    await user.click(screen.getByRole('button', { name: /percentage/i }));
+    await addTwoParticipants(user);
+
+    await user.type(screen.getByPlaceholderText('100'), '200');
+    const [a, b] = shareFields();
+    await user.type(a, '75');
+    await user.type(b, '25');
+
+    await submit(user);
+
+    expect(mockCreateBill.mock.calls[0][0].participants).toEqual([
+      expect.objectContaining({ amount: '150' }),
+      expect.objectContaining({ amount: '50' }),
+    ]);
+  });
+
+  it('requires a bill total in percentage mode', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+    await user.click(screen.getByRole('button', { name: /percentage/i }));
+    await addTwoParticipants(user);
+
+    const [a, b] = shareFields();
+    await user.type(a, '50');
+    await user.type(b, '50');
+
+    await submit(user);
+
+    expect(mockCreateBill).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter the bill total');
+  });
+
+  it('shows an inline error on the offending participant row', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+    await addTwoParticipants(user);
+
+    await user.type(screen.getByPlaceholderText('100'), '100');
+    await user.type(shareFields()[0], '100');
+    // Second participant's amount is left blank.
+
+    await submit(user);
+
+    const blankField = shareFields()[1];
+    expect(blankField).toHaveAttribute('aria-invalid', 'true');
+
+    const describedBy = blankField.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)).toHaveTextContent(
+      'Enter an amount for this participant.'
+    );
+  });
+
+  it('tracks the running total as shares are entered', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+    await addTwoParticipants(user);
+
+    await user.type(screen.getByPlaceholderText('100'), '100');
+    await user.type(shareFields()[0], '40');
+
+    expect(screen.getByTestId('share-summary')).toHaveTextContent('40 of 100 allocated');
+
+    await user.type(shareFields()[1], '60');
+
+    expect(screen.getByTestId('share-summary')).toHaveTextContent('100 of 100 allocated');
+  });
+
+  it('clears stale errors when the split mode changes', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+    await addTwoParticipants(user);
+
+    await user.type(screen.getByPlaceholderText('100'), '100');
+    await user.type(shareFields()[0], '40');
+    await submit(user);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /percentage/i }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('still enforces the pre-existing address requirement', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+
+    await user.type(shareFields()[0], '40');
+    await submit(user);
+
+    expect(mockCreateBill).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('All participants need an address.');
+  });
+
+  it('labels the share column by mode', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+
+    const participantList = screen.getByRole('list');
+    expect(within(participantList).getByText(/amount \*/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /percentage/i }));
+
+    expect(within(screen.getByRole('list')).getByText(/share % \*/i)).toBeInTheDocument();
+  });
+});

--- a/services/indexer/README.md
+++ b/services/indexer/README.md
@@ -215,8 +215,43 @@ Sample response:
   "latest_indexed_ledger": 50123456,
   "chain_head": 50123456,
   "lag_blocks": 0,
-  "lag_seconds": 0
+  "lag_seconds": 0,
+  "schema_version": 5,
+  "expected_schema_version": 5,
+  "migration_status": "up_to_date",
+  "latest_migration": "create_schema_migrations_table",
+  "migration_applied_at": "2024-01-15T09:00:00Z",
+  "applied_migrations": 5
 }
+```
+
+### Health and migration status
+
+`/health` reports the live database schema alongside ledger lag so a deploy can
+verify the indexer is not serving mid-migrate.
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Highest version in the `schema_migrations` ledger. `null` when the ledger is missing or empty. |
+| `expected_schema_version` | Version this binary was compiled against (`EXPECTED_SCHEMA_VERSION`). |
+| `migration_status` | `up_to_date`, `pending`, `ahead`, or `unknown`. |
+| `latest_migration` | Name of the highest applied migration. |
+| `migration_applied_at` | When that migration ran. |
+| `applied_migrations` | Number of rows in the ledger. |
+
+`migration_status` values:
+
+- **`up_to_date`** — applied version matches the binary. Safe to serve.
+- **`pending`** — database is behind; migrations have not finished. Deploy is mid-migrate.
+- **`ahead`** — a newer indexer already migrated the database; this instance is stale and should be rolled forward.
+- **`unknown`** — the `schema_migrations` table is missing or empty. Either migrations have never run, or the database predates migration `005`.
+
+Anything other than `up_to_date` sets the top-level `status` to `degraded`, even
+when ledger lag is zero — gate rollouts on `status`, and read `migration_status`
+to tell a migration problem from a lag problem:
+
+```bash
+curl -sf localhost:3000/health | jq -e '.migration_status == "up_to_date"'
 ```
 
 ### Prometheus metrics
@@ -351,10 +386,18 @@ PROMETHEUS_PORT=9090 # Optional, defaults to 9090
 ### Running Migrations
 
 ```bash
-# Apply migrations
-psql $DATABASE_URL -f migrations/001_create_account_activity_table.sql
-psql $DATABASE_URL -f migrations/002_create_ingest_checkpoints_table.sql
+# Apply every migration in filename order
+for f in migrations/*.sql; do psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"; done
 ```
+
+Applied migrations are recorded in the `schema_migrations` ledger created by
+`005_create_schema_migrations_table.sql`. **Every new migration file must end
+with an `INSERT INTO schema_migrations (version, name) VALUES (…) ON CONFLICT
+(version) DO NOTHING;`** for its own version, and
+`EXPECTED_SCHEMA_VERSION` in `src/repositories/migrations.rs` must be bumped in
+the same commit. `GET /health` compares the two so a deploy can tell whether the
+indexer is serving a schema it was not built for — see
+[Health and migration status](#health-and-migration-status).
 
 ### Linting Migrations
 

--- a/services/indexer/migrations/005_create_schema_migrations_table.sql
+++ b/services/indexer/migrations/005_create_schema_migrations_table.sql
@@ -1,0 +1,23 @@
+-- Migration ledger.
+--
+-- Records which migrations have been applied so /health can report the live
+-- schema version and whether the database is mid-migrate. Every migration file
+-- from here on MUST end with its own INSERT into this table (see the backfill
+-- below for the expected shape) — the ledger is what deploy verification reads.
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Backfill the migrations that shipped before the ledger existed. Databases
+-- created from scratch and databases upgraded in place both end up with the
+-- same rows.
+INSERT INTO schema_migrations (version, name)
+VALUES
+    (1, 'create_account_activity_table'),
+    (2, 'create_ingest_checkpoints_table'),
+    (3, 'add_asset_code_issuer_to_account_activity'),
+    (4, 'create_contract_events_table'),
+    (5, 'create_schema_migrations_table')
+ON CONFLICT (version) DO NOTHING;

--- a/services/indexer/scripts/check-migrations.sh
+++ b/services/indexer/scripts/check-migrations.sh
@@ -50,6 +50,7 @@ if [[ "${SKIP_DOWN:-0}" != "1" ]]; then
   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
     DROP TABLE IF EXISTS account_activity CASCADE;
     DROP TABLE IF EXISTS ingest_checkpoints CASCADE;
+    DROP TABLE IF EXISTS schema_migrations CASCADE;
   "
   echo "==> Re-applying migrations after teardown"
   for file in "$MIGRATIONS_DIR"/*.sql; do

--- a/services/indexer/src/api/health.rs
+++ b/services/indexer/src/api/health.rs
@@ -5,18 +5,23 @@ use sqlx::{PgPool, Row};
 
 use crate::error::Result;
 use crate::metrics::record_lag;
+use crate::repositories::migrations::{
+    fetch_migration_state, MigrationStatus, EXPECTED_SCHEMA_VERSION,
+};
 
 /// Health response body.
 ///
 /// Reports the latest ledger the indexer has processed, the current chain
 /// head (latest ledger on the network), the block-level lag between them,
-/// and an estimated lag in seconds derived from the Stellar ledger close time
-/// of roughly 5 seconds per ledger.
+/// an estimated lag in seconds derived from the Stellar ledger close time
+/// of roughly 5 seconds per ledger, and the live database schema version so
+/// deploys can verify the indexer is not serving mid-migrate.
 #[derive(Debug, Serialize)]
 pub struct HealthResponse {
     /// ISO-8601 timestamp of when this response was generated.
     pub timestamp: String,
-    /// Status: "ok" when lag is within acceptable range, "degraded" otherwise.
+    /// Status: "ok" when lag is within range and migrations are up to date,
+    /// "degraded" otherwise.
     pub status: String,
     /// Latest ledger sequence number persisted by the indexer.
     pub latest_indexed_ledger: i64,
@@ -29,6 +34,19 @@ pub struct HealthResponse {
     /// Estimated seconds the indexer is behind the chain head.
     /// Calculated as lag_blocks × STELLAR_LEDGER_CLOSE_SECONDS.
     pub lag_seconds: i64,
+    /// Highest migration version applied to the connected database.
+    /// `null` when the `schema_migrations` ledger is missing or empty.
+    pub schema_version: Option<i32>,
+    /// Schema version this build of the indexer was compiled against.
+    pub expected_schema_version: i32,
+    /// One of `up_to_date`, `pending`, `ahead`, `unknown`.
+    pub migration_status: MigrationStatus,
+    /// Name of the highest applied migration, e.g. `create_contract_events_table`.
+    pub latest_migration: Option<String>,
+    /// ISO-8601 timestamp of when the highest migration was applied.
+    pub migration_applied_at: Option<String>,
+    /// Number of migrations recorded in the ledger.
+    pub applied_migrations: i64,
 }
 
 /// Approximate Stellar ledger close time used for lag estimation.
@@ -37,16 +55,30 @@ const STELLAR_LEDGER_CLOSE_SECONDS: i64 = 5;
 /// Lag threshold above which the service is considered "degraded".
 const DEGRADED_LAG_BLOCKS: i64 = 100;
 
+/// Decide the overall health string from lag and migration state.
+///
+/// A database that is behind, ahead, or has no ledger at all means the
+/// indexer may be reading a schema it was not built for, so it reports
+/// `degraded` regardless of how small the ledger lag is.
+fn overall_status(lag_blocks: i64, migration_status: MigrationStatus) -> &'static str {
+    if lag_blocks >= DEGRADED_LAG_BLOCKS || !migration_status.is_healthy() {
+        "degraded"
+    } else {
+        "ok"
+    }
+}
+
 /// GET /health
 ///
-/// Returns indexer lag metrics derived from the activity_records table.
+/// Returns indexer lag metrics derived from the account_activity table plus
+/// the live database schema version read from the `schema_migrations` ledger.
 /// In production, `chain_head` should be fetched from a live Horizon or
 /// Stellar RPC endpoint; here we use the MAX(ledger_seq) in the DB as a
 /// stand-in so the endpoint is fully self-contained.
 pub async fn health_handler(State(db): State<PgPool>) -> Result<Json<HealthResponse>> {
     // Latest ledger the indexer has indexed (most-recent record persisted).
     let indexed_row =
-        sqlx::query("SELECT COALESCE(MAX(ledger_seq), 0) AS latest FROM activity_records")
+        sqlx::query("SELECT COALESCE(MAX(ledger_seq), 0) AS latest FROM account_activity")
             .fetch_one(&db)
             .await?;
 
@@ -57,7 +89,7 @@ pub async fn health_handler(State(db): State<PgPool>) -> Result<Json<HealthRespo
     // (same value, so lag is always 0 unless the indexer has genuinely fallen
     // behind a separately-maintained chain-head counter).
     let chain_head_row =
-        sqlx::query("SELECT COALESCE(MAX(ledger_seq), 0) AS head FROM activity_records")
+        sqlx::query("SELECT COALESCE(MAX(ledger_seq), 0) AS head FROM account_activity")
             .fetch_one(&db)
             .await?;
 
@@ -66,11 +98,10 @@ pub async fn health_handler(State(db): State<PgPool>) -> Result<Json<HealthRespo
     let lag_blocks = (chain_head - latest_indexed_ledger).max(0);
     let lag_seconds = lag_blocks * STELLAR_LEDGER_CLOSE_SECONDS;
 
-    let status = if lag_blocks >= DEGRADED_LAG_BLOCKS {
-        "degraded".to_string()
-    } else {
-        "ok".to_string()
-    };
+    let migrations = fetch_migration_state(&db).await?;
+    let migration_status = migrations.status();
+
+    let status = overall_status(lag_blocks, migration_status).to_string();
 
     // Update Prometheus metrics
     record_lag(lag_blocks, lag_seconds);
@@ -82,5 +113,48 @@ pub async fn health_handler(State(db): State<PgPool>) -> Result<Json<HealthRespo
         chain_head,
         lag_blocks,
         lag_seconds,
+        schema_version: migrations.schema_version,
+        expected_schema_version: EXPECTED_SCHEMA_VERSION,
+        migration_status,
+        latest_migration: migrations.latest_migration,
+        migration_applied_at: migrations.applied_at.map(|ts| ts.to_rfc3339()),
+        applied_migrations: migrations.applied_count,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn healthy_when_lag_low_and_migrations_up_to_date() {
+        assert_eq!(overall_status(0, MigrationStatus::UpToDate), "ok");
+        assert_eq!(
+            overall_status(DEGRADED_LAG_BLOCKS - 1, MigrationStatus::UpToDate),
+            "ok"
+        );
+    }
+
+    #[test]
+    fn degraded_when_lag_exceeds_threshold() {
+        assert_eq!(
+            overall_status(DEGRADED_LAG_BLOCKS, MigrationStatus::UpToDate),
+            "degraded"
+        );
+    }
+
+    #[test]
+    fn degraded_while_migrations_are_pending_even_with_no_lag() {
+        assert_eq!(overall_status(0, MigrationStatus::Pending), "degraded");
+    }
+
+    #[test]
+    fn degraded_when_database_is_ahead_of_this_build() {
+        assert_eq!(overall_status(0, MigrationStatus::Ahead), "degraded");
+    }
+
+    #[test]
+    fn degraded_when_migration_ledger_is_missing() {
+        assert_eq!(overall_status(0, MigrationStatus::Unknown), "degraded");
+    }
 }

--- a/services/indexer/src/repositories/migrations.rs
+++ b/services/indexer/src/repositories/migrations.rs
@@ -1,0 +1,179 @@
+//! Read access to the `schema_migrations` ledger.
+//!
+//! The ledger is written by the SQL files in `migrations/` (see
+//! `005_create_schema_migrations_table.sql`). It exists so operators can ask a
+//! running indexer which schema version it is actually serving, rather than
+//! inferring it from the deployed image tag.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sqlx::{PgPool, Row};
+
+/// Schema version this build of the indexer expects the database to be at.
+///
+/// Bump this in the same commit that adds a migration file — it is the
+/// reference point `/health` compares the live ledger against.
+pub const EXPECTED_SCHEMA_VERSION: i32 = 5;
+
+/// Where the database stands relative to [`EXPECTED_SCHEMA_VERSION`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MigrationStatus {
+    /// Applied version matches what this build expects. Safe to serve.
+    UpToDate,
+    /// Database is behind — migrations have not finished running yet.
+    Pending,
+    /// Database is ahead — a newer indexer has migrated it, this one is stale.
+    Ahead,
+    /// The ledger table is missing. Either migrations have never run, or the
+    /// database predates `005_create_schema_migrations_table.sql`.
+    Unknown,
+}
+
+impl MigrationStatus {
+    /// Classify an applied version against [`EXPECTED_SCHEMA_VERSION`].
+    pub fn classify(applied: Option<i32>) -> Self {
+        match applied {
+            None => MigrationStatus::Unknown,
+            Some(v) if v == EXPECTED_SCHEMA_VERSION => MigrationStatus::UpToDate,
+            Some(v) if v < EXPECTED_SCHEMA_VERSION => MigrationStatus::Pending,
+            Some(_) => MigrationStatus::Ahead,
+        }
+    }
+
+    /// Whether this state should be treated as healthy for deploy gating.
+    pub fn is_healthy(self) -> bool {
+        matches!(self, MigrationStatus::UpToDate)
+    }
+}
+
+/// Snapshot of the migration ledger at a point in time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationState {
+    /// Highest applied migration version, or `None` when the ledger is missing.
+    pub schema_version: Option<i32>,
+    /// Name of the highest applied migration.
+    pub latest_migration: Option<String>,
+    /// When the highest applied migration ran.
+    pub applied_at: Option<DateTime<Utc>>,
+    /// Total number of rows in the ledger.
+    pub applied_count: i64,
+}
+
+impl MigrationState {
+    /// State reported when the ledger table does not exist.
+    pub fn unknown() -> Self {
+        Self {
+            schema_version: None,
+            latest_migration: None,
+            applied_at: None,
+            applied_count: 0,
+        }
+    }
+
+    /// Classification of this state against [`EXPECTED_SCHEMA_VERSION`].
+    pub fn status(&self) -> MigrationStatus {
+        MigrationStatus::classify(self.schema_version)
+    }
+}
+
+/// Read the migration ledger.
+///
+/// A missing `schema_migrations` table is not an error — it is reported as
+/// [`MigrationState::unknown`], which `/health` surfaces as
+/// [`MigrationStatus::Unknown`]. Every other database error propagates, so a
+/// genuinely broken connection still fails the health check loudly.
+pub async fn fetch_migration_state(db: &PgPool) -> Result<MigrationState, sqlx::Error> {
+    let ledger_exists: bool =
+        sqlx::query_scalar("SELECT to_regclass('schema_migrations') IS NOT NULL")
+            .fetch_one(db)
+            .await?;
+
+    if !ledger_exists {
+        return Ok(MigrationState::unknown());
+    }
+
+    let row = sqlx::query(
+        "SELECT \
+            (SELECT COUNT(*) FROM schema_migrations) AS applied_count, \
+            version, name, applied_at \
+         FROM schema_migrations ORDER BY version DESC LIMIT 1",
+    )
+    .fetch_optional(db)
+    .await?;
+
+    // The table exists but is empty — treat it the same as a missing ledger,
+    // since neither tells us which schema is live.
+    let Some(row) = row else {
+        return Ok(MigrationState::unknown());
+    };
+
+    Ok(MigrationState {
+        schema_version: Some(row.try_get("version")?),
+        latest_migration: Some(row.try_get("name")?),
+        applied_at: Some(row.try_get("applied_at")?),
+        applied_count: row.try_get("applied_count")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_matching_version_as_up_to_date() {
+        assert_eq!(
+            MigrationStatus::classify(Some(EXPECTED_SCHEMA_VERSION)),
+            MigrationStatus::UpToDate
+        );
+    }
+
+    #[test]
+    fn classifies_lower_version_as_pending() {
+        assert_eq!(
+            MigrationStatus::classify(Some(EXPECTED_SCHEMA_VERSION - 1)),
+            MigrationStatus::Pending
+        );
+    }
+
+    #[test]
+    fn classifies_higher_version_as_ahead() {
+        assert_eq!(
+            MigrationStatus::classify(Some(EXPECTED_SCHEMA_VERSION + 1)),
+            MigrationStatus::Ahead
+        );
+    }
+
+    #[test]
+    fn classifies_missing_ledger_as_unknown() {
+        assert_eq!(MigrationStatus::classify(None), MigrationStatus::Unknown);
+    }
+
+    #[test]
+    fn only_up_to_date_is_healthy() {
+        assert!(MigrationStatus::UpToDate.is_healthy());
+        assert!(!MigrationStatus::Pending.is_healthy());
+        assert!(!MigrationStatus::Ahead.is_healthy());
+        assert!(!MigrationStatus::Unknown.is_healthy());
+    }
+
+    #[test]
+    fn unknown_state_reports_no_version() {
+        let state = MigrationState::unknown();
+        assert_eq!(state.schema_version, None);
+        assert_eq!(state.applied_count, 0);
+        assert_eq!(state.status(), MigrationStatus::Unknown);
+    }
+
+    #[test]
+    fn serializes_status_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&MigrationStatus::UpToDate).unwrap(),
+            "\"up_to_date\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MigrationStatus::Unknown).unwrap(),
+            "\"unknown\""
+        );
+    }
+}

--- a/services/indexer/src/repositories/mod.rs
+++ b/services/indexer/src/repositories/mod.rs
@@ -1,2 +1,3 @@
 pub mod account_activity;
 pub mod contract_events;
+pub mod migrations;

--- a/services/indexer/tests/health_migration_test.rs
+++ b/services/indexer/tests/health_migration_test.rs
@@ -1,0 +1,141 @@
+//! Integration tests for the migration fields on GET /health.
+//!
+//! These require a live Postgres and are `#[ignore]`d like the other DB-backed
+//! suites in this crate. Run them with:
+//!
+//! ```bash
+//! TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/ancore_test \
+//!   cargo test --test health_migration_test -- --ignored
+//! ```
+//!
+//! The classification logic itself is covered by unit tests in
+//! `src/repositories/migrations.rs` and `src/api/health.rs`, which run without
+//! a database.
+
+use axum::{
+    body::{Body, Bytes},
+    http::{Request, StatusCode},
+    Router,
+};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use sqlx::PgPool;
+use tower::ServiceExt;
+
+use ancore_indexer::api::health;
+use ancore_indexer::repositories::migrations::{
+    fetch_migration_state, MigrationStatus, EXPECTED_SCHEMA_VERSION,
+};
+
+async fn response_body_bytes(response: axum::response::Response) -> Bytes {
+    response.into_body().collect().await.unwrap().to_bytes()
+}
+
+async fn setup() -> (Router, PgPool) {
+    dotenvy::dotenv().ok();
+
+    let database_url = std::env::var("TEST_DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://postgres:postgres@localhost:5432/ancore_test".to_string()
+    });
+
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to test database");
+
+    let app = Router::new()
+        .route("/health", axum::routing::get(health::health_handler))
+        .with_state(pool.clone());
+
+    (app, pool)
+}
+
+async fn get_health(app: &Router) -> Value {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    serde_json::from_slice(&response_body_bytes(response).await).unwrap()
+}
+
+#[tokio::test]
+#[ignore]
+async fn health_reports_schema_version_from_migration_ledger() {
+    let (app, _pool) = setup().await;
+    let body = get_health(&app).await;
+
+    assert_eq!(
+        body["expected_schema_version"].as_i64(),
+        Some(EXPECTED_SCHEMA_VERSION as i64)
+    );
+    assert_eq!(
+        body["schema_version"].as_i64(),
+        Some(EXPECTED_SCHEMA_VERSION as i64),
+        "test database should be migrated to the version this build expects"
+    );
+    assert_eq!(body["migration_status"], "up_to_date");
+    assert_eq!(body["status"], "ok");
+}
+
+#[tokio::test]
+#[ignore]
+async fn health_reports_the_latest_applied_migration() {
+    let (app, _pool) = setup().await;
+    let body = get_health(&app).await;
+
+    assert!(
+        body["latest_migration"].is_string(),
+        "expected a migration name, got {}",
+        body["latest_migration"]
+    );
+    assert!(
+        body["migration_applied_at"].is_string(),
+        "expected an applied_at timestamp, got {}",
+        body["migration_applied_at"]
+    );
+    assert!(
+        body["applied_migrations"].as_i64().unwrap_or(0) >= EXPECTED_SCHEMA_VERSION as i64,
+        "ledger should record every migration up to the expected version"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn health_keeps_reporting_ledger_lag_fields() {
+    let (app, _pool) = setup().await;
+    let body = get_health(&app).await;
+
+    // The migration fields are additive — the pre-existing lag contract must
+    // still hold for anything already scraping /health.
+    for field in [
+        "timestamp",
+        "status",
+        "latest_indexed_ledger",
+        "chain_head",
+        "lag_blocks",
+        "lag_seconds",
+    ] {
+        assert!(!body[field].is_null(), "missing /health field: {field}");
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn migration_state_matches_the_expected_version() {
+    let (_app, pool) = setup().await;
+
+    let state = fetch_migration_state(&pool)
+        .await
+        .expect("reading the migration ledger should succeed");
+
+    assert_eq!(state.schema_version, Some(EXPECTED_SCHEMA_VERSION));
+    assert_eq!(state.status(), MigrationStatus::UpToDate);
+    assert!(state.applied_count >= EXPECTED_SCHEMA_VERSION as i64);
+}

--- a/services/relayer/openapi.yaml
+++ b/services/relayer/openapi.yaml
@@ -358,6 +358,43 @@ components:
           minimum: 0
           description: Replay-protection nonce (non-negative integer)
           example: 1
+        transferPolicy:
+          $ref: '#/components/schemas/TransferPolicyContext'
+
+    TransferPolicyContext:
+      type: object
+      description: >-
+        Optional transfer-policy context. When present the relayer evaluates the
+        transfer against the policy and rejects blocked transfers with
+        `POLICY_DENIED`.
+      required:
+        - policy
+        - amount
+        - todayTotal
+      properties:
+        policy:
+          type: object
+          required:
+            - dailyLimit
+            - stepUpThreshold
+          properties:
+            dailyLimit:
+              type: number
+              minimum: 0
+              example: 1000
+            stepUpThreshold:
+              type: number
+              minimum: 0
+              description: Must be less than or equal to dailyLimit
+              example: 250
+        amount:
+          type: number
+          description: Amount of this transfer, in XLM
+          example: 50
+        todayTotal:
+          type: number
+          description: Total already transferred today, in XLM
+          example: 100
 
     RelayValidateRequest:
       type: object
@@ -502,13 +539,31 @@ components:
             - NONCE_REPLAY
             - GAS_LIMIT_EXCEEDED
             - SIMULATION_FAILED
+            - POLICY_DENIED
+            - RPC_DOWN
             - UNAUTHORIZED
             - INTERNAL_ERROR
-          description: Machine-readable error code
+            - TRANSFER_LIMIT_EXCEEDED
+          description: >-
+            Stable machine-readable error code. Clients MUST switch on this
+            field and MUST NOT parse `message`, which is free text and may
+            change between releases.
+
+            Codes:
+              * `INVALID_SIGNATURE` — signature verification failed, or the session key is malformed/unknown on chain.
+              * `SESSION_KEY_EXPIRED` — the session key exists but is past its expiry.
+              * `NONCE_REPLAY` — nonce is negative or already consumed by this session key.
+              * `GAS_LIMIT_EXCEEDED` — Soroban resource budget (fee, CPU, memory) exhausted.
+              * `SIMULATION_FAILED` — simulation or host-function invocation failed.
+              * `POLICY_DENIED` — a transfer policy rejected the request.
+              * `RPC_DOWN` — the upstream Horizon / Soroban RPC endpoint is unreachable.
+              * `UNAUTHORIZED` — caller is not authenticated or lacks permission.
+              * `INTERNAL_ERROR` — unclassified server-side failure. Treat unrecognised codes as this.
+              * `TRANSFER_LIMIT_EXCEEDED` — **deprecated**, superseded by `POLICY_DENIED`; no longer emitted.
           example: "INVALID_SIGNATURE"
         message:
           type: string
-          description: Human-readable error message
+          description: Human-readable error detail. Not part of the API contract.
           example: "Signature verification failed"
 
     ValidationErrorResponse:

--- a/services/relayer/src/server.ts
+++ b/services/relayer/src/server.ts
@@ -2,6 +2,7 @@ import express, { Express, Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
 import { z } from 'zod';
+import { TransferPolicySchema } from '@ancore/types';
 import { RelayService } from './services/relayService';
 import { createStellarSubmitterFromEnv } from './services/stellarSubmitter';
 import { createAuthMiddleware } from './middleware/auth';
@@ -54,6 +55,15 @@ const relayRequestSchema = z.object({
     .length(128)
     .regex(/^[0-9a-fA-F]+$/),
   nonce: z.number().int().nonnegative(),
+  // Optional; zod strips unknown keys, so this must be declared for the
+  // service-level policy check (POLICY_DENIED) to be reachable over HTTP.
+  transferPolicy: z
+    .object({
+      policy: TransferPolicySchema,
+      amount: z.number(),
+      todayTotal: z.number(),
+    })
+    .optional(),
 });
 
 // ── Stub implementations (replace with real services) ─────────────────────────

--- a/services/relayer/src/services/mapSimulationError.ts
+++ b/services/relayer/src/services/mapSimulationError.ts
@@ -1,4 +1,5 @@
 import type { RelayError } from '../types';
+import { RelayErrorCodes } from '../types';
 
 /**
  * Map Soroban simulation failures to typed relay errors.
@@ -21,7 +22,7 @@ export function mapSimulationError(error: unknown): RelayError | null {
     haystack.includes('budget exceeded') ||
     haystack.includes('out of gas')
   ) {
-    return { code: 'GAS_LIMIT_EXCEEDED', message };
+    return { code: RelayErrorCodes.GAS_LIMIT_EXCEEDED, message };
   }
 
   if (
@@ -31,7 +32,7 @@ export function mapSimulationError(error: unknown): RelayError | null {
     haystack.includes('invokehostfunction') ||
     haystack.includes('insufficient balance')
   ) {
-    return { code: 'SIMULATION_FAILED', message };
+    return { code: RelayErrorCodes.SIMULATION_FAILED, message };
   }
 
   return null;

--- a/services/relayer/src/services/mapSubmissionError.ts
+++ b/services/relayer/src/services/mapSubmissionError.ts
@@ -1,13 +1,17 @@
 import { NetworkError, SimulationFailedError, TransactionError } from '@ancore/stellar';
 import type { RelayError } from '../types';
+import { RelayErrorCodes } from '../types';
 
 /**
  * Map Stellar network / submission errors to typed relay error responses.
+ *
+ * Every branch resolves to a {@link RelayErrorCodes} member so callers can
+ * switch on `error.code` rather than parsing `error.message`.
  */
 export function mapSubmissionError(error: unknown): RelayError {
   if (error instanceof SimulationFailedError) {
     return {
-      code: 'SIMULATION_FAILED',
+      code: RelayErrorCodes.SIMULATION_FAILED,
       message: error.message,
     };
   }
@@ -22,7 +26,7 @@ export function mapSubmissionError(error: unknown): RelayError {
       code === 'tx_insufficient_fee'
     ) {
       return {
-        code: 'GAS_LIMIT_EXCEEDED',
+        code: RelayErrorCodes.GAS_LIMIT_EXCEEDED,
         message: error.message,
       };
     }
@@ -34,24 +38,27 @@ export function mapSubmissionError(error: unknown): RelayError {
       code.includes('invalid')
     ) {
       return {
-        code: 'SIMULATION_FAILED',
+        code: RelayErrorCodes.SIMULATION_FAILED,
         message: error.message,
       };
     }
 
     return {
-      code: 'INTERNAL_ERROR',
+      code: RelayErrorCodes.INTERNAL_ERROR,
       message: error.message,
     };
   }
 
+  // The upstream Horizon / Soroban RPC endpoint could not be reached. This is
+  // retryable from the client's perspective, which is why it is distinct from
+  // INTERNAL_ERROR.
   if (error instanceof NetworkError) {
     return {
-      code: 'INTERNAL_ERROR',
+      code: RelayErrorCodes.RPC_DOWN,
       message: error.message,
     };
   }
 
   const message = error instanceof Error ? error.message : 'Transaction submission failed';
-  return { code: 'INTERNAL_ERROR', message };
+  return { code: RelayErrorCodes.INTERNAL_ERROR, message };
 }

--- a/services/relayer/src/services/relayService.ts
+++ b/services/relayer/src/services/relayService.ts
@@ -18,6 +18,7 @@ import type {
   DependencyStatus,
   RelayError,
 } from '../types';
+import { RelayErrorCodes } from '../types';
 import { mapSimulationError } from './mapSimulationError';
 import { mapSubmissionError } from './mapSubmissionError';
 
@@ -66,12 +67,18 @@ export class RelayService implements RelayServiceContract {
       try {
         const keyError = this.validateSessionKey(request.sessionKey);
         if (keyError) {
-          const error: RelayError = { code: 'INVALID_SIGNATURE', message: keyError };
+          const error: RelayError = {
+            code: RelayErrorCodes.INVALID_SIGNATURE,
+            message: keyError,
+          };
           return { valid: false, error };
         }
 
         if (request.nonce < 0) {
-          const error: RelayError = { code: 'NONCE_REPLAY', message: 'Nonce must be non-negative' };
+          const error: RelayError = {
+            code: RelayErrorCodes.NONCE_REPLAY,
+            message: 'Nonce must be non-negative',
+          };
           return { valid: false, error };
         }
 
@@ -80,7 +87,7 @@ export class RelayService implements RelayServiceContract {
             await this.nonceStore.assertFresh(request.sessionKey, request.nonce);
           } catch (err) {
             const message = err instanceof Error ? err.message : 'Nonce already used';
-            const error: RelayError = { code: 'NONCE_REPLAY', message };
+            const error: RelayError = { code: RelayErrorCodes.NONCE_REPLAY, message };
             return { valid: false, error };
           }
         }
@@ -99,7 +106,10 @@ export class RelayService implements RelayServiceContract {
           if (!onChainKey) {
             return {
               valid: false,
-              error: { code: 'INVALID_SIGNATURE', message: 'Session key not found on chain' },
+              error: {
+                code: RelayErrorCodes.INVALID_SIGNATURE,
+                message: 'Session key not found on chain',
+              },
             };
           }
         } catch (e: unknown) {
@@ -112,7 +122,10 @@ export class RelayService implements RelayServiceContract {
         if (!ok) {
           return {
             valid: false,
-            error: { code: 'INVALID_SIGNATURE', message: 'Signature verification failed' },
+            error: {
+              code: RelayErrorCodes.INVALID_SIGNATURE,
+              message: 'Signature verification failed',
+            },
           };
         }
 
@@ -122,7 +135,7 @@ export class RelayService implements RelayServiceContract {
           if (policyResult.action === 'block') {
             return {
               valid: false,
-              error: { code: 'TRANSFER_LIMIT_EXCEEDED', message: policyResult.message },
+              error: { code: RelayErrorCodes.POLICY_DENIED, message: policyResult.message },
             };
           }
         }
@@ -152,7 +165,7 @@ export class RelayService implements RelayServiceContract {
       return {
         success: false,
         error: {
-          code: 'INTERNAL_ERROR',
+          code: RelayErrorCodes.INTERNAL_ERROR,
           message: 'Transaction submitter is not configured',
         },
         gasUsed: 0,
@@ -164,7 +177,7 @@ export class RelayService implements RelayServiceContract {
       return {
         success: false,
         error: {
-          code: 'INTERNAL_ERROR',
+          code: RelayErrorCodes.INTERNAL_ERROR,
           message: `Missing required parameter: ${SIGNED_TX_PARAMETER}`,
         },
         gasUsed: 0,

--- a/services/relayer/src/types/errorCodes.ts
+++ b/services/relayer/src/types/errorCodes.ts
@@ -1,0 +1,50 @@
+/**
+ * Stable, machine-readable error codes returned by the Relayer API.
+ *
+ * Every non-2xx relay response carries `error.code` drawn from this enum. The
+ * codes are part of the public API contract: clients switch on `error.code`
+ * and must never parse `error.message`, which is free text and may change
+ * between releases without notice.
+ *
+ * Adding a code is a backwards-compatible change; renaming or removing one is
+ * not. Clients should treat an unrecognised code as `INTERNAL_ERROR`.
+ */
+export const RelayErrorCodes = {
+  /** Request signature failed Ed25519 verification, or the session key is malformed/unknown. */
+  INVALID_SIGNATURE: 'INVALID_SIGNATURE',
+  /** The session key exists on chain but is past its expiry. */
+  SESSION_KEY_EXPIRED: 'SESSION_KEY_EXPIRED',
+  /** The nonce is negative, or has already been consumed by this session key. */
+  NONCE_REPLAY: 'NONCE_REPLAY',
+  /** Soroban resource budget (fee, CPU, or memory) exhausted. */
+  GAS_LIMIT_EXCEEDED: 'GAS_LIMIT_EXCEEDED',
+  /** Transaction simulation or host-function invocation failed. */
+  SIMULATION_FAILED: 'SIMULATION_FAILED',
+  /** A transfer policy (daily limit, step-up threshold, allowlist) rejected the request. */
+  POLICY_DENIED: 'POLICY_DENIED',
+  /** The upstream Soroban RPC / Horizon endpoint is unreachable or unhealthy. */
+  RPC_DOWN: 'RPC_DOWN',
+  /** The caller is not authenticated or lacks permission for this operation. */
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  /** Unclassified server-side failure. */
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+  /**
+   * @deprecated Emitted by relayer <= 0.1.0 for transfer-limit denials.
+   * Superseded by {@link RelayErrorCodes.POLICY_DENIED}; retained so existing
+   * clients keep type-checking. The service no longer produces this code.
+   */
+  TRANSFER_LIMIT_EXCEEDED: 'TRANSFER_LIMIT_EXCEEDED',
+} as const;
+
+/** Union of every code the relayer may return in `error.code`. */
+export type RelayErrorCode = (typeof RelayErrorCodes)[keyof typeof RelayErrorCodes];
+
+/** Every code as a frozen array — useful for schema generation and contract tests. */
+export const RELAY_ERROR_CODES: readonly RelayErrorCode[] = Object.freeze(
+  Object.values(RelayErrorCodes)
+);
+
+/** Narrow an unknown value to a {@link RelayErrorCode}. */
+export function isRelayErrorCode(value: unknown): value is RelayErrorCode {
+  return typeof value === 'string' && (RELAY_ERROR_CODES as readonly string[]).includes(value);
+}

--- a/services/relayer/src/types/responses.ts
+++ b/services/relayer/src/types/responses.ts
@@ -2,18 +2,15 @@
  * Typed response interfaces for the Relayer Service.
  */
 
-export type RelayErrorCode =
-  | 'INVALID_SIGNATURE'
-  | 'SESSION_KEY_EXPIRED'
-  | 'NONCE_REPLAY'
-  | 'GAS_LIMIT_EXCEEDED'
-  | 'SIMULATION_FAILED'
-  | 'TRANSFER_LIMIT_EXCEEDED'
-  | 'UNAUTHORIZED'
-  | 'INTERNAL_ERROR';
+import type { RelayErrorCode } from './errorCodes';
+
+export { RelayErrorCodes, RELAY_ERROR_CODES, isRelayErrorCode } from './errorCodes';
+export type { RelayErrorCode } from './errorCodes';
 
 export interface RelayError {
+  /** Stable machine-readable code — switch on this, never on `message`. */
   code: RelayErrorCode;
+  /** Human-readable detail. Free text; not part of the API contract. */
   message: string;
 }
 

--- a/services/relayer/src/validation/transferPolicy.ts
+++ b/services/relayer/src/validation/transferPolicy.ts
@@ -1,5 +1,6 @@
 import { validateTransferPolicy, type TransferPolicy } from '@ancore/types';
 import type { RelayError } from '../types';
+import { RelayErrorCodes } from '../types';
 
 export interface TransferValidationContext {
   amount: number;
@@ -26,7 +27,7 @@ export function validateTransferPolicyConstraints(
     return {
       valid: false,
       error: {
-        code: 'TRANSFER_LIMIT_EXCEEDED',
+        code: RelayErrorCodes.POLICY_DENIED,
         message: result.message,
       },
     };

--- a/services/relayer/tests/contract/error-codes.test.ts
+++ b/services/relayer/tests/contract/error-codes.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Contract tests for the relay error-code enum.
+ *
+ * `error.code` is the stable, machine-readable part of every relay failure
+ * response — clients switch on it instead of parsing `error.message`. These
+ * tests pin three things at once:
+ *
+ *   1. The enum, the exported union type, and `openapi.yaml` agree on the
+ *      exact set of codes.
+ *   2. The HTTP API only ever emits codes from that set.
+ *   3. The specific failure scenarios documented in the spec map to the
+ *      specific codes clients are told to expect.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import request from 'supertest';
+import { createApp } from '../../src/server';
+import { MemoryNonceStore } from '../../src/store/nonceStore';
+import { IdempotencyStore } from '../../src/store/idempotency';
+import {
+  RelayErrorCodes,
+  RELAY_ERROR_CODES,
+  isRelayErrorCode,
+  type RelayErrorCode,
+} from '../../src/types';
+import type { AuthServiceContract, SignatureServiceContract } from '../../src/types';
+
+const VALID_KEY = 'a'.repeat(64);
+const VALID_SIG = 'b'.repeat(128);
+
+const validBody = {
+  sessionKey: VALID_KEY,
+  operation: 'relay_execute' as const,
+  parameters: {},
+  signature: VALID_SIG,
+  nonce: 1,
+};
+
+function makeApp(
+  sigValid = true,
+  opts: { nonceStore?: MemoryNonceStore; idempotencyStore?: IdempotencyStore } = {}
+) {
+  const authService: AuthServiceContract = {
+    verifyToken: jest.fn().mockResolvedValue({ callerId: 'test-caller' }),
+  };
+  const signatureService: SignatureServiceContract = {
+    verify: jest.fn().mockReturnValue(sigValid),
+  };
+  return createApp(
+    authService,
+    signatureService,
+    opts.idempotencyStore ?? new IdempotencyStore(),
+    undefined,
+    { useMockSubmission: true, startScheduler: false },
+    opts.nonceStore ?? new MemoryNonceStore()
+  );
+}
+
+function post(app: ReturnType<typeof makeApp>, path: string, body: object) {
+  return request(app).post(path).set('Authorization', 'Bearer token').send(body);
+}
+
+/** Extract the `RelayError.code` enum values declared in openapi.yaml. */
+function specErrorCodes(): string[] {
+  const spec = readFileSync(join(__dirname, '../../openapi.yaml'), 'utf8');
+  const schema = spec.slice(spec.indexOf('    RelayError:'));
+  const enumBlock = schema.slice(schema.indexOf('enum:'), schema.indexOf('description:'));
+
+  return enumBlock
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '))
+    .map((line) => line.slice(2).trim());
+}
+
+describe('Relay error code contract', () => {
+  describe('enum definition', () => {
+    it('exposes every documented code as a runtime value', () => {
+      expect(RELAY_ERROR_CODES).toEqual(
+        expect.arrayContaining([
+          'INVALID_SIGNATURE',
+          'SESSION_KEY_EXPIRED',
+          'NONCE_REPLAY',
+          'GAS_LIMIT_EXCEEDED',
+          'SIMULATION_FAILED',
+          'POLICY_DENIED',
+          'RPC_DOWN',
+          'UNAUTHORIZED',
+          'INTERNAL_ERROR',
+        ])
+      );
+    });
+
+    it('keys and values match, so the enum is safe to serialize directly', () => {
+      for (const [key, value] of Object.entries(RelayErrorCodes)) {
+        expect(value).toBe(key);
+      }
+    });
+
+    it('contains no duplicate codes', () => {
+      expect(new Set(RELAY_ERROR_CODES).size).toBe(RELAY_ERROR_CODES.length);
+    });
+
+    it('matches the enum published in openapi.yaml exactly', () => {
+      expect([...specErrorCodes()].sort()).toEqual([...RELAY_ERROR_CODES].sort());
+    });
+
+    it('narrows unknown values with isRelayErrorCode', () => {
+      expect(isRelayErrorCode('POLICY_DENIED')).toBe(true);
+      expect(isRelayErrorCode('NOT_A_CODE')).toBe(false);
+      expect(isRelayErrorCode(undefined)).toBe(false);
+      expect(isRelayErrorCode(42)).toBe(false);
+    });
+  });
+
+  describe('API responses', () => {
+    it('POST /relay/execute returns INVALID_SIGNATURE for a bad signature', async () => {
+      const res = await post(makeApp(false), '/relay/execute', validBody);
+
+      expect(res.status).toBe(422);
+      expect(res.body.error.code).toBe(RelayErrorCodes.INVALID_SIGNATURE);
+    });
+
+    it('POST /relay/validate returns INVALID_SIGNATURE for a bad signature', async () => {
+      const res = await post(makeApp(false), '/relay/validate', validBody);
+
+      expect(res.status).toBe(422);
+      expect(res.body.valid).toBe(false);
+      expect(res.body.error.code).toBe(RelayErrorCodes.INVALID_SIGNATURE);
+    });
+
+    it('POST /relay/execute returns NONCE_REPLAY when a nonce is reused', async () => {
+      const app = makeApp(true, { nonceStore: new MemoryNonceStore() });
+
+      const first = await post(app, '/relay/execute', validBody);
+      expect(first.status).toBe(200);
+
+      const replay = await post(app, '/relay/execute', validBody);
+      expect(replay.status).toBe(422);
+      expect(replay.body.error.code).toBe(RelayErrorCodes.NONCE_REPLAY);
+    });
+
+    it('POST /relay/execute returns POLICY_DENIED when a transfer policy blocks', async () => {
+      const res = await post(makeApp(), '/relay/execute', {
+        ...validBody,
+        nonce: 2,
+        transferPolicy: {
+          amount: 5000,
+          todayTotal: 0,
+          policy: { dailyLimit: 100, stepUpThreshold: 50 },
+        },
+      });
+
+      expect(res.status).toBe(422);
+      expect(res.body.error.code).toBe(RelayErrorCodes.POLICY_DENIED);
+    });
+
+    it('never emits a code outside the enum', async () => {
+      const replayApp = makeApp(true, { nonceStore: new MemoryNonceStore() });
+      await post(replayApp, '/relay/execute', validBody);
+
+      const responses = await Promise.all([
+        post(makeApp(false), '/relay/execute', validBody),
+        post(makeApp(false), '/relay/validate', validBody),
+        post(replayApp, '/relay/execute', validBody),
+        post(makeApp(), '/relay/execute', {
+          ...validBody,
+          nonce: 3,
+          transferPolicy: {
+            amount: 900,
+            todayTotal: 200,
+            policy: { dailyLimit: 1000, stepUpThreshold: 250 },
+          },
+        }),
+      ]);
+
+      for (const res of responses) {
+        const code: unknown = res.body.error?.code;
+        expect(isRelayErrorCode(code)).toBe(true);
+        expect(RELAY_ERROR_CODES).toContain(code as RelayErrorCode);
+      }
+    });
+
+    it('pairs every error code with a non-empty human-readable message', async () => {
+      const res = await post(makeApp(false), '/relay/execute', validBody);
+
+      expect(typeof res.body.error.message).toBe('string');
+      expect(res.body.error.message.length).toBeGreaterThan(0);
+      // The message must not be the code itself — clients that log both would
+      // otherwise get no extra detail.
+      expect(res.body.error.message).not.toBe(res.body.error.code);
+    });
+  });
+});

--- a/services/relayer/tests/integration/relay.test.ts
+++ b/services/relayer/tests/integration/relay.test.ts
@@ -128,7 +128,7 @@ describe('POST /relay/execute', () => {
 
     expect(res.status).toBe(422);
     expect(res.body.success).toBe(false);
-    expect(res.body.error.code).toBe('INTERNAL_ERROR');
+    expect(res.body.error.code).toBe('RPC_DOWN');
     expect(res.body.error.message).toBe('Horizon unavailable');
   });
 

--- a/services/relayer/tests/unit/mapSubmissionError.test.ts
+++ b/services/relayer/tests/unit/mapSubmissionError.test.ts
@@ -26,10 +26,10 @@ describe('mapSubmissionError', () => {
     });
   });
 
-  it('maps network errors to INTERNAL_ERROR', () => {
+  it('maps network errors to RPC_DOWN', () => {
     const error = new NetworkError('Horizon unreachable');
     expect(mapSubmissionError(error)).toEqual({
-      code: 'INTERNAL_ERROR',
+      code: 'RPC_DOWN',
       message: 'Horizon unreachable',
     });
   });

--- a/services/relayer/tests/unit/relayService.test.ts
+++ b/services/relayer/tests/unit/relayService.test.ts
@@ -164,7 +164,7 @@ describe('RelayService', () => {
       );
 
       expect(result.success).toBe(false);
-      expect(result.error?.code).toBe('INTERNAL_ERROR');
+      expect(result.error?.code).toBe('RPC_DOWN');
       expect(result.error?.message).toBe('Horizon down');
     });
 


### PR DESCRIPTION
## Description

Four independent, self-contained improvements, one commit each:

| Commit | Issue | Area |
| --- | --- | --- |
| `feat(relayer): add structured error code enum for relay failures` | #1064 | Infrastructure / SDK |
| `feat(indexer): report schema version and migration status from /health` | #1067 | Infrastructure |
| `feat(dashboard): validate split-bill shares sum to 100% or the bill total` | #1063 | Web Dashboard |
| `feat(extension): export public address QR from Settings, never a secret` | #1055 | Extension Wallet |

---

### #1064 — Relayer structured error codes

`error.code` existed only as a TypeScript union: no runtime value, and no codes for the two most common operational failures, so clients fell back to parsing free-text `error.message`.

- `types/errorCodes.ts` exports `RelayErrorCodes` as a runtime enum, plus `RELAY_ERROR_CODES` and an `isRelayErrorCode` type guard.
- New codes: **`POLICY_DENIED`** (transfer-policy rejections) and **`RPC_DOWN`** (upstream Horizon/Soroban RPC unreachable).
- Wired through `relayService`, `transferPolicy` validation, and both error mappers — every emitted code now comes from the enum.
- `transferPolicy` is now declared in the relay request schema. It was previously stripped by zod as an unknown key, which made the service-level policy check unreachable over HTTP.
- `openapi.yaml` documents the full enum with per-code semantics.

**Behaviour changes** (both intentional, both are the point of the issue):
- `NetworkError` on submission now maps to `RPC_DOWN` instead of `INTERNAL_ERROR`.
- Transfer-policy denials now return `POLICY_DENIED` instead of `TRANSFER_LIMIT_EXCEEDED`. The old code stays in the enum, marked deprecated and no longer emitted, so existing clients keep type-checking.

Three pre-existing test assertions were updated to match. New contract tests assert the enum, the exported union, and `openapi.yaml` agree exactly, and that the live API never emits a code outside the enum.

### #1067 — Indexer schema version on `/health`

Operators could not tell a running indexer's live schema version, so a deploy could not distinguish "healthy" from "serving mid-migrate".

- Migration `005` creates a `schema_migrations` ledger, backfilled with the four migrations that predate it.
- `repositories/migrations.rs` adds `EXPECTED_SCHEMA_VERSION` and a `MigrationStatus` classifier — `up_to_date` / `pending` / `ahead` / `unknown`. A missing ledger table reports `unknown` rather than erroring; every other DB error still propagates.
- `/health` gains `schema_version`, `expected_schema_version`, `migration_status`, `latest_migration`, `migration_applied_at`, `applied_migrations`. Existing lag fields are unchanged and still asserted.
- Anything other than `up_to_date` sets top-level `status: degraded`, so rollouts can gate on `/health` alone.
- The down/up smoke now drops `schema_migrations` so it rebuilds from scratch.

> **⚠️ Also fixes a pre-existing bug, flagged for reviewer attention.** The lag queries read `activity_records`, a table that does not exist anywhere in the repo — the schema defines `account_activity`. `/health` returned **500 against any correctly-migrated database**. The new integration tests surfaced this immediately, and the endpoint cannot serve deploy verification without the fix. It is a two-token change in `health.rs`; happy to split it into its own PR if you'd prefer.

**Contract note for future migrations:** each new migration file must insert its own row into `schema_migrations`, and `EXPECTED_SCHEMA_VERSION` must be bumped in the same commit. Documented in the indexer README.

### #1063 — Split-bill share validation

The create form accepted any set of participant amounts, so a bill could be created whose shares bore no relation to what was owed.

- `lib/split-bill-validation.ts` — a pure `validateShares` checking that percentage shares total 100% and amount shares total the stated bill total. Comparisons use a half-stroop tolerance at Stellar's 7-decimal precision, so `0.1 + 0.2 === 0.3` holds.
- New split-mode toggle (amount / percentage) and an optional bill-total field. Percentage shares convert against the total on submit, with the rounding remainder folded into the last participant so the parts sum exactly.
- Per-row errors inline via `aria-invalid` / `aria-describedby`, sum errors via `role="alert"`, and a running "N of M allocated" summary.
- Leaving the total blank in amount mode still skips the sum check, preserving the existing free-entry flow.

### #1055 — Settings address QR export

Receive already renders a QR, but there was no downloadable one for support tickets or desktop use.

- Settings → Address QR (`AccountQrScreen`) renders the active account's public address with a PNG download, copy control, and an explicit "public address only" assurance.
- **`utils/public-address-qr.ts` is now the only sanctioned QR download path.** `assertPublicAddressOnly` **whitelists** the Stellar public formats (`G` account, `C` contract, `M` muxed) and throws `SecretExportBlockedError` on everything else — so a secret shape nobody anticipated still cannot slip through. Secret seeds, raw hex private keys, and recovery phrases get a specific message.
- The same check runs at the render boundary, so a non-public value never reaches the QR renderer even if a caller passes one.
- Address resolves to the deployed contract id, falling back to the owner public key pre-deployment.
- `en` and `pt-BR` strings added.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test addition/improvement

## Security Impact

- [ ] This change involves cryptographic operations
- [ ] This change affects account validation logic
- [ ] This change modifies smart contracts
- [x] This change handles user private keys
- [ ] This change affects authorization/authentication

**#1055 is the security-relevant change.** A downloadable QR is a file that leaves the extension and gets shared into chats, support tickets, and printouts — a secret encoded in one is catastrophic *and invisible*, since the PNG looks identical either way. The guard is therefore a whitelist of public-address formats rather than a blocklist of known secret shapes, applied at both the download helper and the render boundary. Tests assert directly that a secret seed and a recovery phrase never reach the QR writer.

No other change touches key material. #1064 alters only error classification, never what is signed or submitted.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] E2E tests added/updated

### Test Coverage

New tests, all passing:

| Area | Tests |
| --- | --- |
| Relayer error-code contract | 11 |
| Indexer migration classification (no DB) | 12 |
| Indexer `/health` migration fields (DB-backed, `#[ignore]`d) | 4 |
| Split-bill validation rules | 29 |
| Split-bill form behaviour | 12 |
| Public-address QR guard | 16 |
| Address QR screen + settings entry | 12 |

The indexer DB tests are `#[ignore]`d to match the existing integration suites, since the `indexer` CI job runs `cargo test` without Postgres. The classification logic they cover is additionally unit-tested without a database, so the `pending` / `ahead` / `unknown` paths are enforced in CI regardless.

### Manual Testing Steps

The indexer work was verified against a real Postgres 16, not just mocks:

1. `bash services/indexer/scripts/check-migrations.sh` against a scratch DB — all five migrations apply, down/up smoke passes.
2. Ran the four `#[ignore]`d integration tests — all pass, `migration_status: "up_to_date"`, `status: "ok"`.
3. Dropped `schema_migrations` → endpoint returns **200** with `schema_version: null` (classified `unknown`), confirming a missing ledger degrades rather than erroring.
4. Recreated the ledger at version 4 → endpoint reports `schema_version: 4`, classified `pending`.
5. Restored to version 5 → back to `up_to_date`, all four tests green. Scratch DB dropped.

Step 2 is what surfaced the `activity_records` bug — before the fix, every endpoint test returned 500.

### CI parity

Ran the exact commands from [AGENTS.md § Before you push](../blob/main/AGENTS.md#before-you-push--run-what-ci-runs):

```
corepack pnpm format:check   ✅ all files match Prettier
corepack pnpm lint           ✅ 0 errors (warnings all pre-existing)
corepack pnpm build          ✅ 14/14 tasks
corepack pnpm test           ✅ 28/28 tasks
corepack pnpm indexer:lint-migrations   ✅ 5 files
pnpm --filter @ancore/extension-wallet lint:translations   ✅

cd services/indexer
cargo fmt --check            ✅
cargo clippy -- -D warnings  ✅ 0 errors
cargo test                   ✅ 81 unit + 4 integration + 1 doc
```

`contracts/` is untouched by this branch.

One note on flakiness: `tests/integration/relay.test.ts › POST /relay/validate › 401 when Authorization header is missing` failed **once** with a 404 during a full-repo run, then passed on every subsequent isolated and full-suite run. It is unrelated to these changes — that request is rejected by auth middleware before reaching any code this branch touches, and a missing-auth request cannot produce a 404 from a schema change. Raising it here rather than quarantining it, since a single occurrence isn't a stable failure signature.

## Breaking Changes

- [ ] This PR introduces breaking changes

The two relayer error-code remappings change response *values*, not response shape or status codes. `TRANSFER_LIMIT_EXCEEDED` remains a valid enum member so existing client code keeps compiling. Flagging them explicitly since clients switching on the old values will need to update.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] Any flaky-test quarantine entry includes a linked follow-up issue, owner, expiry, and stable failure signature — n/a, no quarantine entries added

## Related Issues

Closes #1055
Closes #1063
Closes #1064
Closes #1067

## Reviewer Notes

Three things worth a close look:

1. **The `activity_records` → `account_activity` fix in `health.rs`** is outside the literal scope of #1067. I included it because `/health` 500s without it, which makes the migration-status work unusable for its stated purpose. Easy to split out if you'd rather keep the PR strictly scoped.
2. **`POLICY_DENIED` replacing `TRANSFER_LIMIT_EXCEEDED`** — #1064 names `POLICY_DENIED` explicitly, so I made it the emitted code and deprecated the old one rather than keeping both live. Say the word if you'd prefer `TRANSFER_LIMIT_EXCEEDED` retained as the emitted value for the limit case specifically.
3. **Adding `transferPolicy` to the relay request schema** widens the accepted request body. It was necessary to make the policy path reachable at all, but it is a public API surface change worth confirming.

Each commit is independently revertable if any one of the four needs to go back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added downloadable account address QR codes with copy support and safeguards that prevent secret information from being exported.
  * Added split-bill support for percentage-based allocation, with live totals and clearer validation feedback.
  * Added transfer-policy details to relay requests and standardized machine-readable relay error codes.

* **Bug Fixes**
  * Network submission failures are now reported as RPC outages.
  * Indexer health reporting now includes database migration status and accurately reflects service readiness.

* **Documentation**
  * Expanded guidance for QR exports, migrations, health checks, and relay API contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->