### PR TITLE
fix(services): resolve assigned issues #1066, #1068, #1069, #1070

### DIFF
--- a/services/ai-agent/README.md
+++ b/services/ai-agent/README.md
@@ -49,14 +49,89 @@ No authentication required.
 }
 ```
 
+### `POST /agent/draft-intent`
+
+Drafts financial action intents from natural language prompts. Rate-limited to 60 requests/minute and maximum prompt length of 2000 characters.
+
+**Request Body:**
+
+```json
+{
+  "prompt": "Send 10 XLM payment to Alice",
+  "accountId": "GA2C5RFPE6GCKMY3E5CCXBVOV2BLTCED63WBZ3XCABN35Y72EO6S2N3S"
+}
+```
+
+**Example `curl` Command:**
+
+```bash
+curl -X POST http://localhost:3001/agent/draft-intent \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Create an invoice for 10 XLM",
+    "accountId": "GA2C5RFPE6GCKMY3E5CCXBVOV2BLTCED63WBZ3XCABN35Y72EO6S2N3S"
+  }'
+```
+
+**Response `200` (Success):**
+
+```json
+{
+  "status": "draft",
+  "requiresConfirmation": true,
+  "summary": "Drafted invoice intent",
+  "intent": {
+    "type": "invoice",
+    "amount": "10",
+    "asset": "XLM",
+    "recipient": "GA2C5RFPE6GCKMY3E5CCXBVOV2BLTCED63WBZ3XCABN35Y72EO6S2N3S",
+    "dueDate": "2026-07-27T16:00:00.000Z"
+  },
+  "risk": {
+    "score": "low",
+    "flags": []
+  }
+}
+```
+
+**Response `413` (Payload Too Large):**
+
+```json
+{
+  "error": "Prompt exceeds maximum length limit of 2000 characters"
+}
+```
+
+**Response `429` (Rate Limited):**
+
+```json
+{
+  "error": "Too many draft-intent requests. Rate limit exceeded.",
+  "retryAfterSeconds": 45
+}
+```
+
 ### `POST /v1/intents/validate`
 
-Validates agent-extracted intents.
+Validates agent-extracted intents against strict Zod schemas without executing transactions.
 
 **Supported Intents:**
 
 1. **Payment Intent (`payment`):** Transfer funds. Requires `amount`, `asset` (`XLM` or `USDC`), and `destination`.
 2. **Invoice Intent (`invoice`):** Request invoice creation. Requires `amount`, `asset` (`XLM` or `USDC`), `recipient` (supports Unicode multilingual), and `dueDate` (valid parseable date).
+
+**Example `curl` Command:**
+
+```bash
+curl -X POST http://localhost:3001/v1/intents/validate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "type": "payment",
+    "amount": "250.00",
+    "asset": "USDC",
+    "destination": "GA2C5RFPE6GCKMY3E5CCXBVOV2BLTCED63WBZ3XCABN35Y72EO6S2N3S"
+  }'
+```
 
 **Response `200` (Valid):**
 
@@ -64,22 +139,26 @@ Validates agent-extracted intents.
 {
   "valid": true,
   "intent": {
-    "type": "invoice",
-    "amount": "150.00",
+    "type": "payment",
+    "amount": "250.00",
     "asset": "USDC",
-    "recipient": "Alice",
-    "dueDate": "2026-12-31T23:59:59Z"
+    "destination": "GA2C5RFPE6GCKMY3E5CCXBVOV2BLTCED63WBZ3XCABN35Y72EO6S2N3S"
+  },
+  "requiresConfirmation": true,
+  "risk": {
+    "score": "medium",
+    "flags": ["high_value_transaction"]
   }
 }
 ```
 
-**Response `400` (Invalid):**
+**Response `400` (Invalid Schema):**
 
 ```json
 {
   "errors": {
     "fieldErrors": {
-      "dueDate": ["Required"]
+      "destination": ["Required"]
     }
   }
 }

--- a/services/ai-agent/openapi.yaml
+++ b/services/ai-agent/openapi.yaml
@@ -1,0 +1,100 @@
+openapi: 3.0.3
+info:
+  title: "@ancore/ai-agent Service API"
+  version: 0.1.0
+  description: API specification for AI Agent intent drafting, validation, and health monitoring.
+
+paths:
+  /health:
+    get:
+      summary: Health check endpoint
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  uptime:
+                    type: integer
+                    example: 120
+                  timestamp:
+                    type: string
+                    format: date-time
+                  service:
+                    type: string
+                    example: ai-agent
+                  version:
+                    type: string
+                    example: 0.1.0
+
+  /agent/draft-intent:
+    post:
+      summary: Draft intent from natural language prompt
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - prompt
+                - accountId
+              properties:
+                prompt:
+                  type: string
+                  maxLength: 2000
+                  example: Send 10 XLM payment to Alice
+                accountId:
+                  type: string
+                  maxLength: 128
+                  example: GA2C5RFPE6GCKMY3E5CCXBVOV2BLTCED63WBZ3XCABN35Y72EO6S2N3S
+      responses:
+        '200':
+          description: Intent successfully drafted
+        '400':
+          description: Invalid request parameters
+        '413':
+          description: Prompt exceeds maximum length limit
+        '429':
+          description: Rate limit exceeded
+
+  /v1/intents/validate:
+    post:
+      summary: Validate intent payload against Zod schema
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - type
+                - amount
+                - asset
+              properties:
+                type:
+                  type: string
+                  enum: [payment, invoice]
+                amount:
+                  type: string
+                  example: "100.00"
+                asset:
+                  type: string
+                  enum: [XLM, USDC]
+                destination:
+                  type: string
+                recipient:
+                  type: string
+                dueDate:
+                  type: string
+                  format: date-time
+      responses:
+        '200':
+          description: Intent is valid
+        '400':
+          description: Invalid intent schema

--- a/services/ai-agent/src/middleware/rate-limiter.ts
+++ b/services/ai-agent/src/middleware/rate-limiter.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction } from 'express';
+
+interface RateLimitStore {
+  count: number;
+  resetTime: number;
+}
+
+const windowMs = 60 * 1000; // 1 minute window
+const maxRequests = 60; // 60 requests per minute
+const hits = new Map<string, RateLimitStore>();
+
+// Clean up expired entries every 5 minutes to prevent memory leaks
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, record] of hits.entries()) {
+    if (now > record.resetTime) {
+      hits.delete(key);
+    }
+  }
+}, 5 * 60 * 1000).unref();
+
+export function draftIntentRateLimiter(req: Request, res: Response, next: NextFunction): void | Response {
+  const accountId = req.body?.accountId;
+  const key = accountId ? `account:${accountId}` : `ip:${req.ip || 'unknown'}`;
+  const now = Date.now();
+
+  let record = hits.get(key);
+  if (!record || now > record.resetTime) {
+    record = { count: 1, resetTime: now + windowMs };
+    hits.set(key, record);
+    return next();
+  }
+
+  record.count += 1;
+  if (record.count > maxRequests) {
+    return res.status(429).json({
+      error: 'Too many draft-intent requests. Rate limit exceeded.',
+      retryAfterSeconds: Math.ceil((record.resetTime - now) / 1000),
+    });
+  }
+
+  next();
+}

--- a/services/ai-agent/src/server.ts
+++ b/services/ai-agent/src/server.ts
@@ -1,7 +1,11 @@
 import express, { Express, Request, Response } from 'express';
 import { intentSchema, HIGH_VALUE_PAYMENT_THRESHOLD, type Intent } from './schemas/intent';
 import { requestLogger } from './middleware/request-logger';
+import { draftIntentRateLimiter } from './middleware/rate-limiter';
 import { scoreRisk } from './risk';
+
+const MAX_PROMPT_LENGTH = 2000;
+const MAX_ACCOUNT_ID_LENGTH = 128;
 
 const startTime = Date.now();
 
@@ -45,12 +49,25 @@ export function createApp(): Express {
   });
 
   // ── Draft Intent endpoint ──────────────────────────────────────────────────
-  app.post('/agent/draft-intent', (req: Request, res: Response) => {
+  app.post('/agent/draft-intent', draftIntentRateLimiter, (req: Request, res: Response) => {
     const { prompt, accountId } = req.body;
-    if (!prompt || !accountId) {
-      return res.status(400).json({ error: 'Invalid request' });
+    if (!prompt || !accountId || typeof prompt !== 'string' || typeof accountId !== 'string') {
+      return res.status(400).json({ error: 'Invalid request: prompt and accountId required' });
     }
-    const isInvoice = typeof prompt === 'string' && prompt.toLowerCase().includes('invoice');
+
+    if (prompt.length > MAX_PROMPT_LENGTH) {
+      return res.status(413).json({
+        error: `Prompt exceeds maximum length limit of ${MAX_PROMPT_LENGTH} characters`,
+      });
+    }
+
+    if (accountId.length > MAX_ACCOUNT_ID_LENGTH) {
+      return res.status(400).json({
+        error: `accountId exceeds maximum length limit of ${MAX_ACCOUNT_ID_LENGTH} characters`,
+      });
+    }
+
+    const isInvoice = prompt.toLowerCase().includes('invoice');
     const draftIntent: Intent = isInvoice
       ? {
           type: 'invoice',

--- a/services/indexer/src/repositories/account_activity.rs
+++ b/services/indexer/src/repositories/account_activity.rs
@@ -147,15 +147,32 @@ fn encode_cursor(created_at: DateTime<Utc>, id: Uuid) -> String {
 
 /// Decode cursor to extract created_at and id
 fn decode_cursor(cursor: &str) -> Result<DecodedCursor> {
+    if cursor.trim().is_empty() {
+        return Err(ApiError::InvalidCursor("Cursor cannot be empty".to_string()));
+    }
+
     let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(cursor)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(cursor))
+        .or_else(|_| base64::engine::general_purpose::STANDARD_NO_PAD.decode(cursor))
+        .or_else(|_| base64::engine::general_purpose::STANDARD.decode(cursor))
         .map_err(|_| ApiError::InvalidCursor("Invalid base64 encoding".to_string()))?;
 
     let json_str = std::str::from_utf8(&decoded)
-        .map_err(|_| ApiError::InvalidCursor("Invalid UTF-8".to_string()))?;
+        .map_err(|_| ApiError::InvalidCursor("Invalid UTF-8 sequence in cursor".to_string()))?;
 
     let cursor_obj: DecodedCursor = serde_json::from_str(json_str)
-        .map_err(|_| ApiError::InvalidCursor("Invalid JSON structure".to_string()))?;
+        .map_err(|_| ApiError::InvalidCursor("Invalid JSON structure in cursor".to_string()))?;
+
+    // Validate UUID format
+    if Uuid::parse_str(&cursor_obj.i).is_err() {
+        return Err(ApiError::InvalidCursor("Invalid UUID in cursor".to_string()));
+    }
+
+    // Validate timestamp format
+    if DateTime::parse_from_rfc3339(&cursor_obj.t).is_err() {
+        return Err(ApiError::InvalidCursor("Invalid timestamp format in cursor".to_string()));
+    }
 
     Ok(cursor_obj)
 }

--- a/services/relayer/src/middleware/requestId.ts
+++ b/services/relayer/src/middleware/requestId.ts
@@ -31,8 +31,9 @@ export function createRequestIdMiddleware(): RequestHandler {
       id = randomUUID();
     }
 
-    // Expose on request and response header
+    // Expose on request and response headers (both lower-case and canonical)
     Object.assign(req, { requestId: id });
+    res.setHeader('x-request-id', id);
     res.setHeader('X-Request-Id', id);
 
     next();

--- a/services/relayer/src/server.ts
+++ b/services/relayer/src/server.ts
@@ -110,7 +110,8 @@ export function createApp(
     cors({
       origin: corsOrigins,
       methods: ['GET', 'POST', 'PATCH', 'OPTIONS'],
-      allowedHeaders: ['Authorization', 'Content-Type'],
+      allowedHeaders: ['Authorization', 'Content-Type', 'X-Request-Id', 'x-request-id'],
+      exposedHeaders: ['X-Request-Id', 'x-request-id'],
       credentials: true,
     })
   );


### PR DESCRIPTION
Closes #1066
Closes #1068
Closes #1069
Closes #1070

## Summary of Solved Issues

This pull request resolves the 4 assigned open issues across the Ancore services stack:

### 1. Relayer Request ID Propagation (Closes #1066)
- **Issue:** [RELAYER] Request ID middleware: echo x-request-id on all responses
- **Solution:** Updated `createRequestIdMiddleware` in `services/relayer/src/middleware/requestId.ts` to set both `x-request-id` and `X-Request-Id` headers on every response. Configured CORS in `server.ts` to include both headers under `allowedHeaders` and `exposedHeaders`.

### 2. Indexer Invalid Cursor Validation (Closes #1068)
- **Issue:** [INDEXER] Reject invalid cursor tokens with 400 and stable error body
- **Solution:** Hardened `decode_cursor` in `services/indexer/src/repositories/account_activity.rs` to support base64 variants and strictly validate UUID string format and RFC3339 timestamp string format. All malformed cursor tokens map cleanly to `ApiError::InvalidCursor`, returning HTTP 400 with `{ "code": "INVALID_CURSOR", "message": "..." }`.

### 3. AI Agent Route Rate Limiting & Input Length Limits (Closes #1069)
- **Issue:** [AI-AGENT] Input length limits and rate limit on draft-intent route
- **Solution:** Implemented in-memory rate limiting middleware (`draftIntentRateLimiter`) in `services/ai-agent/src/middleware/rate-limiter.ts` (60 req/min per account/IP, returning 429). Enforced maximum input length bounds (max 2000 chars for prompt returning 413, max 128 chars for accountId returning 400) on `POST /agent/draft-intent` in `services/ai-agent/src/server.ts`.

### 4. AI Agent OpenAPI & README Documentation (Closes #1070)
- **Issue:** [AI-AGENT] OpenAPI or README examples for draft-intent and validate routes
- **Solution:** Added OpenAPI specification file in `services/ai-agent/openapi.yaml` and expanded `services/ai-agent/README.md` with request/response schemas, sample JSON payloads, and `curl` command examples for both `POST /agent/draft-intent` and `POST /v1/intents/validate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documented API endpoints for health checks, intent drafting, and intent validation.
  * Added support for generating draft intents with validation, confirmation requirements, risk details, and rate-limit handling.

* **Bug Fixes**
  * Improved cursor validation for alternate Base64 formats, UUIDs, timestamps, and malformed input.
  * Request IDs are now consistently exposed in response headers.

* **Improvements**
  * Added stricter prompt and account identifier limits.
  * Enabled clients to read request ID headers across supported browser requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->