### PR TITLE
Feat/issues 1044 1045 1049 1050

### DIFF
--- a/apps/web-dashboard/src/components/TransactionList.tsx
+++ b/apps/web-dashboard/src/components/TransactionList.tsx
@@ -8,7 +8,7 @@ import {
   Button,
   EmptyState,
 } from '@ancore/ui-kit';
-import { Download, Clock, ChevronUp, ChevronDown } from 'lucide-react';
+import { Download, Clock, ChevronUp, ChevronDown, Inbox, SearchX } from 'lucide-react';
 import type { Transaction } from '../types/dashboard';
 import { useTableDensity } from '../contexts/TableDensityContext';
 import { formatTxDate } from '../lib/formatDate';
@@ -17,6 +17,11 @@ interface TransactionListProps {
   transactions: Transaction[];
   pageSize?: number;
   optimisticTransaction?: Transaction | null;
+  /**
+   * Optional call to action rendered in the empty state, e.g. a link to the
+   * send flow. Kept as a prop so this component stays router-independent.
+   */
+  emptyAction?: React.ReactNode;
 }
 
 type SortField = 'date' | 'amount' | 'status';
@@ -26,6 +31,7 @@ export const TransactionList: React.FC<TransactionListProps> = ({
   transactions,
   pageSize = 5,
   optimisticTransaction = null,
+  emptyAction,
 }) => {
   const { density } = useTableDensity();
   const [page, setPage] = useState(0);
@@ -176,8 +182,21 @@ export const TransactionList: React.FC<TransactionListProps> = ({
             </div>
           </div>
         )}
-        {visible.length === 0 ? (
-          <EmptyState title="No transactions found." />
+        {allTransactions.length === 0 ? (
+          // The indexer returned an empty page — say so, rather than leaving a
+          // blank card that reads as a broken widget.
+          <EmptyState
+            icon={<Inbox className="h-5 w-5" />}
+            title="No transactions yet"
+            description="Payments sent from or received by this account will appear here once the indexer picks them up."
+            action={emptyAction}
+          />
+        ) : visible.length === 0 ? (
+          <EmptyState
+            icon={<SearchX className="h-5 w-5" />}
+            title="Nothing on this page"
+            description="Go back a page to see this account's transactions."
+          />
         ) : (
           visible.map((tx: Transaction, index: number) => {
             const isOptimistic = tx.id === optimisticTransaction?.id;

--- a/apps/web-dashboard/src/components/__tests__/TransactionList.test.tsx
+++ b/apps/web-dashboard/src/components/__tests__/TransactionList.test.tsx
@@ -53,9 +53,38 @@ describe('TransactionList', () => {
     expect(screen.getByText(/50\s*XLM/)).toBeInTheDocument();
   });
 
-  it('shows empty state when no transactions', () => {
+  it('shows a friendly empty state when the indexer returns no transactions', () => {
     renderWithProvider(<TransactionList transactions={[]} />);
-    expect(screen.getByText('No transactions found.')).toBeInTheDocument();
+
+    expect(screen.getByText('No transactions yet')).toBeInTheDocument();
+    expect(
+      screen.getByText(/will appear here once the indexer picks them up/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the supplied empty-state action', () => {
+    renderWithProvider(
+      <TransactionList transactions={[]} emptyAction={<button>Send your first payment</button>} />
+    );
+
+    expect(screen.getByRole('button', { name: 'Send your first payment' })).toBeInTheDocument();
+  });
+
+  it('omits the empty-state action when none is supplied', () => {
+    renderWithProvider(<TransactionList transactions={[]} />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Send your first payment' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the empty state hidden while an optimistic transaction is in flight', () => {
+    renderWithProvider(
+      <TransactionList transactions={[]} optimisticTransaction={mockOptimisticTransaction} />
+    );
+
+    expect(screen.queryByText('No transactions yet')).not.toBeInTheDocument();
+    expect(screen.getByText(/pending \(optimistic\)/)).toBeInTheDocument();
   });
 
   it('displays optimistic transaction at top', () => {

--- a/apps/web-dashboard/src/features/invoices/CreateInvoice.tsx
+++ b/apps/web-dashboard/src/features/invoices/CreateInvoice.tsx
@@ -8,6 +8,7 @@ import { Input } from '@ancore/ui-kit';
 import { Label } from '@ancore/ui-kit';
 import { createInvoiceSchema } from '@ancore/types';
 import type { CreateInvoiceInput } from '@ancore/types';
+import { stellarAddressError } from '../../lib/address-validation';
 
 interface CreateInvoiceProps {
   onSubmit: (data: CreateInvoiceInput) => Promise<void>;
@@ -26,6 +27,13 @@ export function CreateInvoice({ onSubmit, onCancel }: CreateInvoiceProps) {
     await onSubmit(data);
   };
 
+  // `createInvoiceSchema` only runs on submit, so surface the same format check
+  // inline while the user types. Invoices settle to a classic account, so C…
+  // contract addresses are not accepted here.
+  const recipientAddress = form.watch('recipientAddress') ?? '';
+  const recipientAddressError =
+    stellarAddressError(recipientAddress, { kinds: ['account'] }) ?? undefined;
+
   return (
     <Card>
       <CardHeader>
@@ -38,6 +46,7 @@ export function CreateInvoice({ onSubmit, onCancel }: CreateInvoiceProps) {
               name="recipientAddress"
               label="Recipient Address"
               placeholder="G..."
+              error={recipientAddressError}
               required
             />
 

--- a/apps/web-dashboard/src/hooks/useSendTransaction.ts
+++ b/apps/web-dashboard/src/hooks/useSendTransaction.ts
@@ -6,6 +6,7 @@ import {
   type ResolvedHandle,
 } from '@ancore/types';
 import type { Transaction, TransactionStatus, SignMethod } from '../types/dashboard';
+import { stellarAddressError } from '../lib/address-validation';
 import { resolveHandle as defaultResolveHandle } from '../services/handle-resolver';
 import type { SendStrategy, SendResult } from '../services/send-service';
 import { pollTransactionConfirmation, type TransactionPollStatus } from '../services/tx-polling';
@@ -64,7 +65,14 @@ const HANDLE_NOT_FOUND_MESSAGE = 'Handle not found';
 // Validation
 // ---------------------------------------------------------------------------
 
-function validateRecipientInput(recipient: string): string | undefined {
+/**
+ * Validate what the user typed into the recipient field.
+ *
+ * Handles (`@alice`) are checked for shape only — resolution happens later.
+ * Everything else must be a Stellar address; the check is shared with the
+ * other dashboard forms so the wording and accepted formats stay identical.
+ */
+export function validateRecipientInput(recipient: string): string | undefined {
   const trimmed = recipient.trim();
 
   if (!trimmed) {
@@ -75,7 +83,7 @@ function validateRecipientInput(recipient: string): string | undefined {
     return isUsernameHandle(trimmed) ? undefined : 'Enter a valid @username handle';
   }
 
-  return /^G[A-Z0-9]{55}$/.test(trimmed) ? undefined : 'Invalid Stellar address';
+  return stellarAddressError(trimmed) ?? undefined;
 }
 
 export async function resolveSendRecipient(

--- a/apps/web-dashboard/src/lib/__tests__/address-validation.test.ts
+++ b/apps/web-dashboard/src/lib/__tests__/address-validation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { isValidStellarAddress, stellarAddressError } from '../address-validation';
+
+const G_ADDRESS = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+const C_ADDRESS = 'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE';
+
+describe('isValidStellarAddress', () => {
+  it('accepts a classic G account address', () => {
+    expect(isValidStellarAddress(G_ADDRESS)).toBe(true);
+  });
+
+  it('accepts a C contract address', () => {
+    expect(isValidStellarAddress(C_ADDRESS)).toBe(true);
+  });
+
+  it('ignores surrounding whitespace so pasted addresses validate', () => {
+    expect(isValidStellarAddress(`  ${G_ADDRESS}\n`)).toBe(true);
+  });
+
+  it('rejects blank input', () => {
+    expect(isValidStellarAddress('')).toBe(false);
+    expect(isValidStellarAddress('   ')).toBe(false);
+  });
+
+  it('rejects an address that is too short', () => {
+    expect(isValidStellarAddress(G_ADDRESS.slice(0, -1))).toBe(false);
+  });
+
+  it('rejects an address that is too long', () => {
+    expect(isValidStellarAddress(`${G_ADDRESS}A`)).toBe(false);
+  });
+
+  it('rejects an unsupported StrKey prefix', () => {
+    // S… is a secret seed — never a valid recipient.
+    expect(isValidStellarAddress(`S${G_ADDRESS.slice(1)}`)).toBe(false);
+  });
+
+  it('rejects lowercase input', () => {
+    expect(isValidStellarAddress(G_ADDRESS.toLowerCase())).toBe(false);
+  });
+
+  it('rejects characters outside the base32 alphabet', () => {
+    for (const char of ['0', '1', '8', '9']) {
+      expect(isValidStellarAddress(`${G_ADDRESS.slice(0, -1)}${char}`)).toBe(false);
+    }
+  });
+
+  it('honours a restricted kind list', () => {
+    expect(isValidStellarAddress(C_ADDRESS, ['account'])).toBe(false);
+    expect(isValidStellarAddress(G_ADDRESS, ['account'])).toBe(true);
+    expect(isValidStellarAddress(G_ADDRESS, ['contract'])).toBe(false);
+    expect(isValidStellarAddress(C_ADDRESS, ['contract'])).toBe(true);
+  });
+});
+
+describe('stellarAddressError', () => {
+  it('returns null for a valid address', () => {
+    expect(stellarAddressError(G_ADDRESS)).toBeNull();
+    expect(stellarAddressError(C_ADDRESS)).toBeNull();
+  });
+
+  it('treats a blank value as valid when no requiredMessage is given', () => {
+    expect(stellarAddressError('')).toBeNull();
+  });
+
+  it('returns the requiredMessage for a blank value when the field is required', () => {
+    expect(stellarAddressError('  ', { requiredMessage: 'Recipient address is required' })).toBe(
+      'Recipient address is required'
+    );
+  });
+
+  it('names both accepted formats by default', () => {
+    expect(stellarAddressError('not-an-address')).toBe('Enter a valid Stellar address (G… or C…)');
+  });
+
+  it('names only the accepted format when kinds are restricted', () => {
+    expect(stellarAddressError(C_ADDRESS, { kinds: ['account'] })).toBe(
+      'Enter a valid Stellar address (G…)'
+    );
+  });
+
+  it('always mentions "address" so send errors route to the recipient field', () => {
+    expect(stellarAddressError('nope')).toContain('address');
+  });
+});

--- a/apps/web-dashboard/src/lib/address-validation.ts
+++ b/apps/web-dashboard/src/lib/address-validation.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared Stellar address validation for dashboard forms.
+ *
+ * Send, Create Invoice and Split Bill each used to accept free text (or carried
+ * their own copy of the same regex), so a typo only surfaced once the network
+ * rejected the transaction. This module is the single place those forms check
+ * an address against, and the single place the wording of the error lives.
+ *
+ * Stellar StrKeys are 56 characters: a one-character type prefix followed by 55
+ * base32 characters (`A`–`Z`, `2`–`7`). Two prefixes matter here:
+ *
+ * | Prefix | Kind       | Used for                                     |
+ * | ------ | ---------- | -------------------------------------------- |
+ * | `G`    | `account`  | classic Ed25519 account                      |
+ * | `C`    | `contract` | Soroban contract id — an Ancore smart account |
+ *
+ * This is a *format* check: it deliberately does not verify the trailing CRC16
+ * checksum, so it is cheap enough to run on every keystroke and it stays
+ * consistent with the address checks already used elsewhere in the dashboard.
+ * A checksum-valid address is still rejected by the network if the account does
+ * not exist — treat a pass here as "worth submitting", not "will succeed".
+ */
+
+/** The kinds of Stellar address a form can accept. */
+export type StellarAddressKind = 'account' | 'contract';
+
+const PREFIXES: Record<StellarAddressKind, string> = {
+  account: 'G',
+  contract: 'C',
+};
+
+const DEFAULT_KINDS: readonly StellarAddressKind[] = ['account', 'contract'];
+
+/** Total StrKey length: 1 prefix character + 55 base32 characters. */
+const STRKEY_LENGTH = 56;
+
+/** The 55 characters after the prefix, in RFC 4648 base32 (no 0, 1, 8 or 9). */
+const STRKEY_BODY = /^[A-Z2-7]{55}$/;
+
+/**
+ * Whether `value` is a well-formed Stellar address of one of `kinds`.
+ *
+ * Leading/trailing whitespace is ignored so pasted addresses validate.
+ *
+ * @param value - Raw field input.
+ * @param kinds - Accepted address kinds. Defaults to both `G…` and `C…`.
+ */
+export function isValidStellarAddress(
+  value: string,
+  kinds: readonly StellarAddressKind[] = DEFAULT_KINDS
+): boolean {
+  if (typeof value !== 'string') return false;
+
+  const trimmed = value.trim();
+  if (trimmed.length !== STRKEY_LENGTH) return false;
+  if (!kinds.some((kind) => trimmed.startsWith(PREFIXES[kind]))) return false;
+
+  return STRKEY_BODY.test(trimmed.slice(1));
+}
+
+export interface StellarAddressErrorOptions {
+  /** Accepted address kinds. Defaults to both `G…` and `C…`. */
+  kinds?: readonly StellarAddressKind[];
+  /**
+   * Message to return when the field is blank. Omit to treat blank as valid,
+   * which is what an optional address field wants.
+   */
+  requiredMessage?: string;
+}
+
+/** Human-readable description of the accepted formats, e.g. "G… or C…". */
+function describeKinds(kinds: readonly StellarAddressKind[]): string {
+  const parts = kinds.map((kind) => `${PREFIXES[kind]}…`);
+  return parts.length === 1 ? parts[0] : `${parts.slice(0, -1).join(', ')} or ${parts.at(-1)}`;
+}
+
+/**
+ * Inline error message for an address field, or `null` when the value is
+ * acceptable.
+ *
+ * Every message contains the word "address" — `useSendTransaction` routes
+ * thrown errors to the recipient field on that substring.
+ *
+ * @example
+ * ```ts
+ * const error = stellarAddressError(recipient, { requiredMessage: 'Recipient address is required' });
+ * ```
+ */
+export function stellarAddressError(
+  value: string,
+  options: StellarAddressErrorOptions = {}
+): string | null {
+  const { kinds = DEFAULT_KINDS, requiredMessage } = options;
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+
+  if (trimmed === '') {
+    return requiredMessage ?? null;
+  }
+
+  if (isValidStellarAddress(trimmed, kinds)) {
+    return null;
+  }
+
+  return `Enter a valid Stellar address (${describeKinds(kinds)})`;
+}

--- a/apps/web-dashboard/src/pages/Dashboard.tsx
+++ b/apps/web-dashboard/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { AccountSummary } from '../components/AccountSummary';
 import { TransactionList } from '../components/TransactionList';
 import { AccountOverviewGrid } from '../widgets/AccountOverviewGrid';
@@ -86,7 +87,17 @@ export const Dashboard: React.FC = () => {
       )}
       <AccountOverviewGrid publicKey={account.address} />
       <AccountSummary account={account} />
-      <TransactionList transactions={transactions} />
+      <TransactionList
+        transactions={transactions}
+        emptyAction={
+          <Link
+            to="/send"
+            className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            Send your first payment
+          </Link>
+        }
+      />
       {hasMore && (
         <div className="flex justify-center">
           <button

--- a/apps/web-dashboard/src/pages/Send.tsx
+++ b/apps/web-dashboard/src/pages/Send.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Send, Loader2, CheckCircle2, ExternalLink, Wallet, Shield } from 'lucide-react';
-import { useSendTransaction } from '../hooks/useSendTransaction';
+import { useSendTransaction, validateRecipientInput } from '../hooks/useSendTransaction';
 import { useSendFeeEstimate } from '../hooks/useSendFeeEstimate';
 import { useWalletConnection } from '../hooks/useWalletConnection';
 import type { SendStrategy } from '../services/send-service';
@@ -69,6 +69,14 @@ export const SendPage: React.FC = () => {
     disabled: DEMO_MODE || !recipient || !amount,
   });
 
+  // Live format feedback while typing. An empty field is not an error yet —
+  // that only surfaces on submit, via the hook.
+  const liveRecipientError = useMemo(
+    () => (recipient.trim() ? (validateRecipientInput(recipient) ?? null) : null),
+    [recipient]
+  );
+  const recipientError = send.recipientError ?? liveRecipientError;
+
   const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setFormError(null);
@@ -106,17 +114,17 @@ export const SendPage: React.FC = () => {
         <label className="block space-y-2">
           <span className="text-sm font-medium">Recipient</span>
           <input
-            aria-describedby={send.recipientError ? 'recipient-error' : undefined}
-            aria-invalid={!!send.recipientError}
+            aria-describedby={recipientError ? 'recipient-error' : undefined}
+            aria-invalid={!!recipientError}
             className="w-full rounded-lg border px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             onChange={(event) => setRecipient(event.target.value)}
             placeholder="@alice or G..."
             value={recipient}
           />
         </label>
-        {send.recipientError && (
+        {recipientError && (
           <p className="text-sm font-medium text-destructive" id="recipient-error" role="alert">
-            {send.recipientError}
+            {recipientError}
           </p>
         )}
 
@@ -173,7 +181,7 @@ export const SendPage: React.FC = () => {
           </div>
         )}
 
-        {send.error && !send.recipientError && (
+        {send.error && !recipientError && (
           <p className="text-sm font-medium text-destructive" role="alert">
             {send.error.message}
           </p>
@@ -181,7 +189,7 @@ export const SendPage: React.FC = () => {
 
         <button
           className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-          disabled={send.loading}
+          disabled={send.loading || !!liveRecipientError}
           type="submit"
         >
           {send.loading ? (

--- a/apps/web-dashboard/src/pages/SplitBill.tsx
+++ b/apps/web-dashboard/src/pages/SplitBill.tsx
@@ -12,6 +12,7 @@ import {
   parseDecimal,
   type SplitMode,
 } from '../lib/split-bill-validation';
+import { stellarAddressError } from '../lib/address-validation';
 
 // ── Create form ───────────────────────────────────────────────────────────────
 
@@ -66,6 +67,8 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
   const [participants, setParticipants] = useState<ParticipantDraft[]>([newParticipant()]);
   const [error, setError] = useState('');
   const [shareErrors, setShareErrors] = useState<Record<string, string>>({});
+  const [addressErrors, setAddressErrors] = useState<Record<string, string>>({});
+  const [creatorAddressError, setCreatorAddressError] = useState('');
 
   // Recomputed on every render so the running total updates as the user types.
   // Errors are only *surfaced* on submit; this just drives the live summary.
@@ -94,13 +97,36 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
     e.preventDefault();
     setError('');
     setShareErrors({});
+    setAddressErrors({});
+    setCreatorAddressError('');
 
     if (!title.trim()) return setError('Title is required.');
     if (!creatorAddress.trim()) return setError('Your address is required.');
+
+    const creatorError = stellarAddressError(creatorAddress);
+    if (creatorError) {
+      setCreatorAddressError(creatorError);
+      return setError(creatorError);
+    }
+
     if (participants.length === 0) return setError('Add at least one participant.');
 
     for (const p of participants) {
       if (!p.address.trim()) return setError('All participants need an address.');
+    }
+
+    // Every participant is paid on-chain, so a malformed address is caught here
+    // rather than at settlement time. All rows are checked so the user fixes
+    // them in one pass instead of one per submit.
+    const badAddresses: Record<string, string> = {};
+    for (const p of participants) {
+      const addressError = stellarAddressError(p.address);
+      if (addressError) badAddresses[p.key] = addressError;
+    }
+
+    if (Object.keys(badAddresses).length > 0) {
+      setAddressErrors(badAddresses);
+      return setError('Fix the highlighted participant addresses.');
     }
 
     // Shares must add up: to 100% in percentage mode, or to the bill total in
@@ -154,8 +180,19 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
             value={creatorAddress}
             onChange={(e) => setCreatorAddress(e.target.value)}
             placeholder="G..."
-            className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-slate-400"
+            aria-invalid={creatorAddressError ? true : undefined}
+            aria-describedby={creatorAddressError ? 'creator-address-error' : undefined}
+            className={`mt-1 w-full rounded-lg border px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 ${
+              creatorAddressError
+                ? 'border-red-400 focus:ring-red-400'
+                : 'border-slate-300 focus:ring-slate-400'
+            }`}
           />
+          {creatorAddressError && (
+            <span id="creator-address-error" className="mt-1 block text-xs text-red-600">
+              {creatorAddressError}
+            </span>
+          )}
         </label>
       </div>
 
@@ -228,6 +265,8 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
           {participants.map((p) => {
             const shareError = shareErrors[p.key];
             const shareErrorId = `share-error-${p.key}`;
+            const addressError = addressErrors[p.key];
+            const addressErrorId = `address-error-${p.key}`;
 
             return (
               <li key={p.key}>
@@ -238,7 +277,13 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
                       value={p.address}
                       onChange={(e) => updateParticipant(p.key, { address: e.target.value })}
                       placeholder="G..."
-                      className="mt-1 w-full rounded border border-slate-300 px-2 py-1.5 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-slate-400"
+                      aria-invalid={addressError ? true : undefined}
+                      aria-describedby={addressError ? addressErrorId : undefined}
+                      className={`mt-1 w-full rounded border px-2 py-1.5 text-xs font-mono focus:outline-none focus:ring-1 ${
+                        addressError
+                          ? 'border-red-400 focus:ring-red-400'
+                          : 'border-slate-300 focus:ring-slate-400'
+                      }`}
                     />
                   </label>
                   <label className="block">
@@ -289,6 +334,12 @@ function CreateBillForm({ onCreated }: { onCreated: (id: string) => void }) {
                     <Trash2 className="w-4 h-4" />
                   </button>
                 </div>
+
+                {addressError && (
+                  <p id={addressErrorId} className="mt-1 text-xs text-red-600">
+                    {addressError}
+                  </p>
+                )}
 
                 {shareError && (
                   <p id={shareErrorId} className="mt-1 text-xs text-red-600">

--- a/apps/web-dashboard/src/pages/__tests__/SplitBill.test.tsx
+++ b/apps/web-dashboard/src/pages/__tests__/SplitBill.test.tsx
@@ -241,6 +241,50 @@ describe('SplitBill create form — share validation', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('All participants need an address.');
   });
 
+  it('rejects a malformed participant address with an inline error', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+
+    await user.type(within(participantList()).getByPlaceholderText('G...'), 'not-an-address');
+    await user.type(shareFields()[0], '40');
+    await submit(user);
+
+    expect(mockCreateBill).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Fix the highlighted participant addresses.'
+    );
+    expect(within(participantList()).getByPlaceholderText('G...')).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    );
+  });
+
+  it('rejects a malformed creator address before checking participants', async () => {
+    const user = userEvent.setup();
+    render(<SplitBillPage />);
+    await user.click(screen.getByRole('button', { name: /new bill/i }));
+    await user.type(screen.getByLabelText(/title/i), 'Dinner');
+    await user.type(screen.getByLabelText(/your address/i), 'GNOTVALID');
+    await submit(user);
+
+    expect(mockCreateBill).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/your address/i)).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('accepts a C… smart-account address for a participant', async () => {
+    const user = userEvent.setup();
+    await openForm(user);
+
+    await user.type(
+      within(participantList()).getByPlaceholderText('G...'),
+      'CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE'
+    );
+    await user.type(shareFields()[0], '40');
+    await submit(user);
+
+    expect(mockCreateBill).toHaveBeenCalled();
+  });
+
   it('labels the share column by mode', async () => {
     const user = userEvent.setup();
     await openForm(user);

--- a/apps/web-dashboard/src/services/contactsStorage.ts
+++ b/apps/web-dashboard/src/services/contactsStorage.ts
@@ -6,6 +6,7 @@
  * mocking React state.
  */
 
+import { isValidStellarAddress as isValidAddress } from '../lib/address-validation';
 import type { Contact, ContactPayload } from '../types/contacts';
 
 export const CONTACTS_STORAGE_KEY = 'ancore-dashboard-contacts';
@@ -21,9 +22,14 @@ export class DuplicateAliasError extends Error {
 
 // ── Validation helpers ────────────────────────────────────────────────────────
 
-/** Stellar public key: G + 55 uppercase alphanumeric chars */
+/**
+ * Stellar public key: `G` + 55 base32 chars.
+ *
+ * Contacts address classic accounts only, so this narrows the shared helper in
+ * `lib/address-validation` to the `account` kind.
+ */
 export function isValidStellarAddress(address: string): boolean {
-  return /^G[A-Z0-9]{55}$/.test(address);
+  return isValidAddress(address, ['account']);
 }
 
 /** Alias: 1–32 chars, letters/numbers/spaces/hyphens/underscores */

--- a/docs/development/local-services.md
+++ b/docs/development/local-services.md
@@ -112,13 +112,18 @@ DATABASE_URL=postgres://postgres:ancore@localhost:5432/ancore_indexer \
 
 **Endpoints**:
 - `GET /relay/status` - Service status
-- `POST /relay/submit` - Submit transaction
+- `POST /relay/execute` - Execute a signed relay transaction
+- `POST /relay/validate` - Pre-flight validation without executing
 
 **Environment Variables**:
 - `PORT` - Service port (default: 3000, mapped to 3001 on host)
 - `NODE_ENV` - Environment (development, production)
-- `STELLAR_NETWORK` - Stellar network (testnet, mainnet)
-- `STELLAR_HORIZON_URL` - Horizon API URL
+- `STELLAR_NETWORK` - Stellar network (testnet, mainnet, futurenet, local)
+- `RELAYER_AUTH_SECRET` - Bearer token secret; **unset falls back to a stub that accepts any token**
+- `RELAYER_USE_MOCK_SUBMISSION` - Dev-only: skip Stellar submission entirely
+
+Full table (limits, timers, RPC configuration) and the mock-mode warning:
+[services/relayer/README.md → Environment Variables](../../services/relayer/README.md#environment-variables).
 
 ## Configuration
 

--- a/packages/wallet-api/README.md
+++ b/packages/wallet-api/README.md
@@ -95,24 +95,146 @@ if (await isConnected()) {
 
 ## Errors
 
-| Error                     | When                                                                  |
-| ------------------------- | --------------------------------------------------------------------- |
-| `WalletNotInstalledError` | Extension content script is not present on the page                   |
-| `WalletApiError`          | Background rejected the request or bridge timed out (default **30s**) |
+Every rejection from this package is a `WalletApiError` (or its `WalletNotInstalledError`
+subclass). There is no numeric error code — **the `message` string is the discriminator**, so the
+tables below list the exact strings the extension produces today.
+
+### Error classes
+
+| Class                     | `instanceof WalletApiError` | Thrown today?                                                                                                                                                                                   |
+| ------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WalletApiError`          | yes                         | Yes — every failure path below                                                                                                                                                                  |
+| `WalletNotInstalledError` | yes (it extends it)         | **Not yet.** Exported for `instanceof` narrowing; with no content script on the page the request currently fails as a timeout instead. See [detecting the extension](#detecting-the-extension). |
+
+Because `WalletNotInstalledError extends WalletApiError`, always check the **subclass first** in an
+`if / else if` chain.
+
+### Connect and read errors
+
+Raised by `connect()`, `requestAccess()`, `getAddress()`, `getNetwork()`, `isConnected()` and
+`getSmartAccount()`.
+
+| `error.message`                                 | Origin                    | What happened                                                                    | dApp should                                      |
+| ----------------------------------------------- | ------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `wallet-api requires a browser window`          | wallet-api bridge         | Called where `window` is undefined (SSR, Node, a worker)                         | Only call the SDK from client-side code          |
+| `Request timed out after 30000ms`               | wallet-api bridge         | No response within **30s** — usually no extension installed, or a stalled worker | Prompt to install the wallet, then offer a retry |
+| `Origin not allowed. Call requestAccess first.` | background handler        | Page origin is not on the allowlist for the active account                       | Call `connect()` / `requestAccess()`, then retry |
+| `Wallet not set up. Complete onboarding first.` | background handler        | Extension installed but onboarding never finished                                | Ask the user to finish wallet setup              |
+| `Invalid origin`                                | background service worker | Request arrived with a missing or non-string origin                              | Treat as a bug; do not retry                     |
+| `Origin mismatch`                               | background service worker | Sender origin does not match the claimed origin                                  | Treat as a bug; do not retry                     |
+| `Unknown method: <method>`                      | content script            | Method not recognised by this extension build                                    | Check the installed extension version            |
+| `Unknown external API method: <method>`         | background registry       | Method reached the background but has no handler                                 | Check the installed extension version            |
+| `Unexpected response from background`           | content script            | Background replied with a malformed envelope                                     | Retry once, then surface a generic failure       |
+| `Unknown wallet error`                          | wallet-api bridge         | Background reported failure with no message                                      | Surface a generic failure                        |
+
+### Signing errors
+
+Raised by `signTransaction()`, `signAuthEntry()`, `signMessage()` and `requestSessionKey()`. These
+open an approval screen, so they can also fail on the user's decision.
+
+| `error.message`                                                 | Origin             | What happened                                                     | dApp should                                                        |
+| --------------------------------------------------------------- | ------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `Origin not allowed. Call requestAccess first.`                 | background handler | Not allowlisted — checked **before** the approval UI opens        | Call `connect()` first                                             |
+| `User rejected the sign request`                                | approval UI        | User pressed **Reject**                                           | Cancel silently — this is a normal outcome, not an error to report |
+| `Approval request timed out.`                                   | background handler | No decision within **5 minutes** (e.g. the popup was closed)      | Offer a retry                                                      |
+| `Request timed out after 30000ms`                               | wallet-api bridge  | The bridge's own 30s budget elapsed first                         | See [timeouts](#two-timeouts-not-one)                              |
+| `Session key policy must include a future expiresAt timestamp.` | background handler | `requestSessionKey()` policy had a missing or past `expiresAt`    | Fix the policy — this is a caller bug                              |
+| `Session key policy must include permissions.`                  | background handler | `requestSessionKey()` policy had no numeric `permissions` bitmask | Fix the policy — this is a caller bug                              |
+
+### Two timeouts, not one
+
+The signing path has **two independent clocks**, and the shorter one wins:
+
+- the bridge rejects after **30s** (`Request timed out after 30000ms`);
+- the background gives the user **5 minutes** to approve (`Approval request timed out.`).
+
+A user who takes longer than 30 seconds to read an approval screen therefore sees the dApp give up
+while the extension is still waiting. Do not treat a bridge timeout as "the user declined" — if the
+approval is later accepted the transaction is still signed. Re-check state with `isConnected()` /
+`getAddress()` before retrying.
+
+### Handling errors
 
 ```typescript
-import { WalletApiError, WalletNotInstalledError } from '@ancore/wallet-api';
+import {
+  connect,
+  signTransaction,
+  WalletApiError,
+  WalletNotInstalledError,
+} from '@ancore/wallet-api';
 
-try {
-  await connect();
-} catch (err) {
+/** Map a wallet-api rejection to something worth showing a user. */
+function describe(err: unknown): { message: string; retryable: boolean } {
+  // Subclass first — WalletNotInstalledError is also a WalletApiError.
   if (err instanceof WalletNotInstalledError) {
-    // prompt user to install Ancore Wallet
-  } else if (err instanceof WalletApiError) {
-    // user rejected, timeout, or handler error
+    return { message: 'Install the Ancore Wallet extension to continue.', retryable: false };
+  }
+
+  if (!(err instanceof WalletApiError)) {
+    return { message: 'Something went wrong.', retryable: true };
+  }
+
+  if (err.message.startsWith('Origin not allowed')) {
+    return { message: 'Connect your wallet to this site first.', retryable: true };
+  }
+
+  if (err.message.startsWith('Wallet not set up')) {
+    return { message: 'Finish setting up your Ancore Wallet, then try again.', retryable: false };
+  }
+
+  if (err.message.includes('timed out')) {
+    return { message: 'The wallet did not respond in time.', retryable: true };
+  }
+
+  return { message: err.message, retryable: true };
+}
+
+async function signWithWallet(xdr: string) {
+  try {
+    await connect();
+    const { signedXdr } = await signTransaction({
+      xdr,
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    });
+    return signedXdr;
+  } catch (err) {
+    // A rejected approval is a user choice, not a failure — bail out quietly.
+    if (err instanceof WalletApiError && err.message === 'User rejected the sign request') {
+      return null;
+    }
+
+    const { message, retryable } = describe(err);
+    showToast(message, { action: retryable ? 'Retry' : undefined });
+    throw err;
   }
 }
 ```
+
+### Detecting the extension
+
+`WalletNotInstalledError` is not thrown yet, so a page with no extension pays the full 30-second
+bridge timeout. Until the presence check lands, race the call against a short deadline of your own:
+
+```typescript
+import { isConnected, WalletApiError } from '@ancore/wallet-api';
+
+/** Resolves false when no extension answers within `ms`. */
+async function walletPresent(ms = 1000): Promise<boolean> {
+  const timeout = new Promise<false>((resolve) => setTimeout(() => resolve(false), ms));
+
+  try {
+    return await Promise.race([isConnected().then(() => true), timeout]);
+  } catch (err) {
+    if (err instanceof WalletApiError) return false;
+    throw err;
+  }
+}
+```
+
+> **Follow-up:** the hardened error surface — real `WalletNotInstalledError` throwing, a stable
+> machine-readable `code` on each error, and a playground to exercise every path — is tracked in
+> [issue #1009](https://github.com/ancore-org/ancore/issues/1009). Match on `message` only until
+> that lands, and keep the comparisons in one place so the migration to `code` is a single edit.
 
 ## Protocol
 

--- a/services/relayer/README.md
+++ b/services/relayer/README.md
@@ -4,6 +4,52 @@ Transaction relay service for the Ancore account abstraction layer. Accepts sign
 
 ---
 
+## Quickstart
+
+Two ways to get a relayer answering on localhost. Full stack setup — Postgres, indexer, health
+checks, teardown, troubleshooting — lives in
+**[docs/development/local-services.md](../../docs/development/local-services.md)**.
+
+### Option A — Docker Compose (relayer + indexer + Postgres)
+
+Use this when you need the whole stack, e.g. to see relayed transactions appear in the indexer.
+
+```bash
+# From the repository root
+docker compose -f docker-compose.dev.yml up
+
+# Verify (compose maps the relayer to host port 3001)
+curl http://localhost:3001/relay/status
+```
+
+Teardown: `docker compose -f docker-compose.dev.yml down` (add `-v` to drop the Postgres volume).
+See [Local Services Setup → Quick Start](../../docs/development/local-services.md#quick-start).
+
+### Option B — pnpm only (relayer alone)
+
+Fastest loop when you are working on the relayer itself.
+
+```bash
+# From the repository root
+pnpm install
+pnpm --filter @ancore/relayer build
+
+# Dev-only: skip real Stellar submission, no RPC node needed. See "Mock mode" below.
+RELAYER_USE_MOCK_SUBMISSION=true pnpm --filter @ancore/relayer start
+
+# Verify (defaults to host port 3000)
+curl http://localhost:3000/relay/status
+```
+
+> **Port note:** the service listens on `PORT` (default `3000`) in both cases. Compose remaps it to
+> **3001** on the host so it does not collide with the indexer, which also uses `3000`. Point apps at
+> `http://localhost:3001` when using Compose and `http://localhost:3000` when running it directly.
+
+Wiring the wallets and dashboard to a local relayer:
+[Local Services Setup → Integration with Applications](../../docs/development/local-services.md#integration-with-applications).
+
+---
+
 ## Deployment Requirements
 
 | Requirement     | Value                            |
@@ -14,12 +60,63 @@ Transaction relay service for the Ancore account abstraction layer. Accepts sign
 
 ### Environment Variables
 
-| Variable              | Required | Description                                                          |
-| --------------------- | -------- | -------------------------------------------------------------------- |
-| `PORT`                | No       | HTTP listen port (default: `3000`)                                   |
-| `RELAYER_AUTH_SECRET` | No       | Bearer token secret required for protected `/relay` routes (JWT/API) |
+Every variable is optional — the service boots with the defaults below. Defaults are tuned for local
+development, so read the **Prod** column before deploying.
 
-> **MVP note:** Authentication and signature verification use stub implementations. Replace `stubAuthService` and `stubSignatureService` in `src/server.ts` before production deployment.
+**Server and auth**
+
+| Variable              | Default | Prod         | Description                                                                                                                                       |
+| --------------------- | ------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                | `3000`  | as needed    | HTTP listen port                                                                                                                                  |
+| `RELAYER_AUTH_SECRET` | _unset_ | **required** | Bearer token secret for protected `/relay` routes. **When unset the service falls back to a stub auth service that accepts any non-empty token.** |
+| `ALLOWED_ORIGINS`     | `*`     | **set it**   | Comma-separated CORS allowlist, e.g. `http://localhost:5173,https://app.example.com`                                                              |
+
+**Stellar network**
+
+| Variable                     | Default                               | Description                                                                                   |
+| ---------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `STELLAR_NETWORK`            | `testnet`                             | One of `testnet`, `mainnet`, `futurenet`, `local`. Unrecognised values fall back to `testnet` |
+| `STELLAR_NETWORK_PASSPHRASE` | derived from `STELLAR_NETWORK`        | Overrides the passphrase used by the transaction submitter                                    |
+| `RPC_URL`                    | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint used for on-chain session-key lookups                                    |
+| `NETWORK_PASSPHRASE`         | `Test SDF Network ; September 2015`   | Passphrase used for those session-key lookups                                                 |
+
+**Limits and timers**
+
+| Variable                              | Default            | Description                                                               |
+| ------------------------------------- | ------------------ | ------------------------------------------------------------------------- |
+| `RELAY_RATE_LIMIT_RPM`                | `30`               | Per-**account** requests/minute on `/relay/execute` (429 + `Retry-After`) |
+| `RELAY_RATE_LIMIT_MAX`                | `50`               | Per-**caller/IP** requests per 15-minute window on `/relay/*`             |
+| `STATUS_RATE_LIMIT_MAX`               | `200`              | Per-IP requests per 15-minute window on `/relay/status`                   |
+| `RELAY_MAX_PAYLOAD_BYTES`             | `524288` (512 KiB) | Request bodies above this are rejected before JSON parsing                |
+| `SCHEDULER_POLL_INTERVAL_MS`          | `1000`             | Scheduled-transfer engine poll interval                                   |
+| `SIGNATURE_SERVICE_HEALTH_TIMEOUT_MS` | `5000`             | Timeout for the signature-service health probe                            |
+
+**Dev-only flags**
+
+| Variable                      | Default | Description                                                    |
+| ----------------------------- | ------- | -------------------------------------------------------------- |
+| `RELAYER_USE_MOCK_SUBMISSION` | _unset_ | Set to the exact string `true` to enable mock mode — see below |
+
+#### Mock mode — never enable outside local development
+
+`RELAYER_USE_MOCK_SUBMISSION=true` makes `/relay/execute` **skip Stellar entirely**. Signature,
+nonce, and rate-limit checks still run, but instead of building and submitting a transaction the
+service returns a randomly generated `transactionId` with `gasUsed: 0` — an id that corresponds to
+nothing on any network. `/relay/status` also reports RPC as healthy (`"Mock submission mode"`)
+without contacting a node, so a broken RPC configuration looks fine.
+
+That combination is exactly what you want for a fast local loop and exactly what you must not ship:
+callers receive `success: true` for payments that never happened, and the health endpoint will not
+tell you. Enable it only via a per-shell variable (as in [Option B](#option-b--pnpm-only-relayer-alone)),
+never in a committed `.env` or deployment manifest. Mock-flag hardening — refusing to start with
+mock mode on when `NODE_ENV=production`, and surfacing the flag in the status payload — is tracked in
+[issue #968](https://github.com/ancore-org/ancore/issues/968).
+
+The same warning applies to leaving `RELAYER_AUTH_SECRET` unset: the fallback stub auth service
+accepts **any** non-empty Bearer token.
+
+> **MVP note:** signature verification is real (`Ed25519SignatureService`), but nonce replay tracking
+> and gas enforcement are not production-complete — see [Security Model](#security-model).
 
 ---
 
@@ -316,6 +413,10 @@ pnpm --filter @ancore/relayer test
 # Start (development)
 pnpm --filter @ancore/relayer start
 ```
+
+For the full local stack (Postgres + indexer + relayer), env file setup, log tailing, and teardown,
+see [Local Services Setup](../../docs/development/local-services.md) — summarised in
+[Quickstart](#quickstart) above.
 
 ---
 


### PR DESCRIPTION
## Description

Resolves four assigned issues across docs and the web dashboard.

**#1044 — `packages/wallet-api` error reference.** Integrators previously had to read the extension
source to learn what `connect()` / `signTransaction()` can throw. The README now carries an error
class table, the exact `error.message` strings for both the connect/read and signing paths (with the
component that produced each), and a `try/catch` example. Two behaviours worth calling out because
they are easy to get wrong and are now documented explicitly:

- `WalletNotInstalledError` is exported but **never thrown** today — a page without the extension
  currently fails as a 30-second bridge timeout. Documented as-is (no code change), with a
  `Promise.race` workaround for detection.
- There are **two independent timeouts**: 30s in the bridge and 5 minutes for the approval UI. A
  bridge timeout is therefore not the same as a user rejection, and the transaction may still get
  signed.

**#1045 — `services/relayer` quickstart cross-link.** The relayer README had no path to
`docs/development/local-services.md`. Adds a Quickstart with copy-paste Docker Compose and
pnpm-only flows, both cross-linked, plus a note on the 3000-vs-3001 port remap Compose applies.
The environment variable table went from 2 rows to the full set read out of the source (grouped by
server/auth, Stellar network, limits and timers, dev-only flags), and mock-flag warnings were added
per #968.

**#1049 — shared address validation.** New `apps/web-dashboard/src/lib/address-validation.ts`
exporting `isValidStellarAddress` and `stellarAddressError`, covering `G…` (account) and `C…`
(contract) StrKeys. Wired into Send, Create Invoice and Split Bill with inline errors, and
`contactsStorage` now delegates to it instead of holding a second copy of the regex.

**#1050 — transaction list empty state.** An indexer page of `[]` rendered a bare
`"No transactions found."` line under a card header, which reads as a broken widget. Replaced with
an icon + explanatory copy, a distinct message for an out-of-range page, and an optional
`emptyAction` slot that `Dashboard` fills with a link to the send flow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test addition/improvement

## Security Impact

- [ ] This change involves cryptographic operations
- [ ] This change affects account validation logic
- [ ] This change modifies smart contracts
- [ ] This change handles user private keys
- [ ] This change affects authorization/authentication
- [x] No security impact

No security-tier code was touched — the diff is limited to `apps/web-dashboard/**`, two READMEs, and
one file under `docs/`. Two notes for reviewers:

- **The address check is deliberately format-only** — prefix, length, and the base32 alphabet. It
  does not verify the CRC16 checksum, so a transposed character inside a StrKey still passes. That
  keeps it cheap enough to run on every keystroke and matches the checks already used elsewhere in
  the dashboard (a checksum check would also have rejected the existing test fixtures across the
  repo, which are shape-valid but not checksum-valid). It is a UX guard, not a security control —
  the network remains the authority.
- The relayer README now documents that an unset `RELAYER_AUTH_SECRET` falls back to a stub auth
  service accepting any non-empty token, and that `RELAYER_USE_MOCK_SUBMISSION=true` returns
  `success: true` for transactions that never reach Stellar while reporting RPC healthy. Both are
  pre-existing behaviours; this PR only documents them and links #968 for the hardening work.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] E2E tests added/updated (if applicable)

Added:

- `apps/web-dashboard/src/lib/__tests__/address-validation.test.ts` — 16 cases covering G and C
  formats, whitespace tolerance, length and prefix rejection, the base32 alphabet (`0`, `1`, `8`,
  `9` rejected), restricted kind lists, and the error-message wording.
- `SplitBill.test.tsx` — malformed participant address surfaces an inline error and blocks submit;
  malformed creator address is caught before participants; a `C…` smart-account address is accepted.
- `TransactionList.test.tsx` — empty-state copy, the optional action rendering and its absence, and
  that an in-flight optimistic transaction suppresses the empty state.

Full local run of what CI runs, all exit 0:

```
corepack pnpm format:check   # All matched files use Prettier code style
corepack pnpm lint           # 24/24 tasks, 0 errors (pre-existing warnings only)
corepack pnpm build          # 14/14 tasks
corepack pnpm test           # 28/28 tasks
```

`apps/web-dashboard` alone: **36 test files, 315 tests passing** (up from 36/36 and 204 before —
new suites are counted once workspace packages are built).

No Rust files were touched, so the `contracts/` and `services/indexer/` Cargo gates are unaffected
and were not run. No workflow YAML changed, so `actionlint` was not needed.

### Manual Testing Steps

1. `corepack pnpm dev:dashboard`
2. **Send** — type `GABC` into Recipient: inline error appears while typing and the submit button
   disables. Paste a valid `G…` or `C…` address: the error clears and submit re-enables. Type
   `@alice`: handled by the existing handle path, not the address check.
3. **Split Bill → New bill** — submit with a malformed participant address: the row is outlined,
   carries `aria-invalid="true"`, and shows the inline message; all bad rows are flagged in one pass
   rather than one per submit.
4. **Dashboard** with an indexer returning `[]` — the transaction card shows the icon, explanatory
   copy, and the "Send your first payment" link instead of a blank card.

## Breaking Changes

- [ ] This PR introduces breaking changes

`TransactionList`'s new `emptyAction` prop is optional; every existing call site is unchanged.
`validateRecipientInput` is now exported from `useSendTransaction` so `Send.tsx` can reuse it — an
addition, not a signature change.

The one user-visible copy change: the send flow's `"Invalid Stellar address"` is now
`"Enter a valid Stellar address (G… or C…)"`, and `C…` addresses are accepted where previously only
`G…` was. The new message still contains the substring `address`, which is what
`useSendTransaction` matches on to route an error to the recipient field.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] Any flaky-test quarantine entry includes a linked follow-up issue, owner, expiry, and stable failure signature

## Related Issues

Closes #1044
Closes #1045
Closes #1049
Closes #1050
Related to #968
Related to #1009

## Additional Context

Two small accuracy fixes were made in files these issues point at, because leaving them would
mislead anyone following the new cross-links:

- `docs/development/local-services.md` listed `POST /relay/submit`, which does not exist — the real
  endpoints are `/relay/execute` and `/relay/validate`. It also listed `STELLAR_HORIZON_URL`, which
  appears nowhere in the relayer source.
- The relayer README's MVP note claimed signature verification was a stub. It is real now
  (`Ed25519SignatureService`); nonce replay tracking and gas enforcement are the parts that remain
  incomplete, and the note now says so.

Observed but **not** changed, as out of scope for these issues:

- The relayer README's threat-summary table still says rate limiting and gas limits are "not yet
  implemented" while the section directly above documents the working per-account limiter.
- `services/relayer` `tests/unit/nonceStore.test.ts › evicts expired nonces based on TTL` failed once
  under full-suite parallel load and passed on isolated re-run and on a repeat full-suite run. It is
  timing-sensitive (60 ms TTL with a 60 ms sleep) and unrelated to this branch, which touches no
  relayer source.

## Reviewer Notes

The judgement call worth a second opinion is in the **Security Impact** section: format-only address
validation, no checksum. If you would rather have `StrKey.isValidEd25519PublicKey` /
`StrKey.isValidContract` from `@stellar/stellar-sdk`, that is a one-line swap inside
`address-validation.ts` — but it will fail existing test fixtures across the repo (`GAAAA…A`,
`GRECIPIENT1`, and similar), so it needs a fixture sweep in the same PR. Happy to do that if
preferred.

Also worth a look: `CreateInvoice` is narrowed to `G…` only, because `createInvoiceSchema` in
`@ancore/types` is `G…`-only. If invoices should be payable to smart accounts, the schema needs to
change first — that is a `packages/types` change affecting other consumers, so I left it alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer transaction-list empty states, including a “Send your first payment” action.
  - Added live Stellar address validation while sending payments, creating invoices, and splitting bills.
  - Added inline validation errors and accessibility feedback for invalid recipient and participant addresses.
  - Added support for validating both account and contract addresses.

- **Documentation**
  - Improved local relayer setup, configuration, mock-mode guidance, and wallet API error-handling documentation.

- **Bug Fixes**
  - Prevented invalid addresses from being submitted and preserved optimistic transactions during empty-state display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->