### PR TITLE
Indexer OpenAPI, mobile force-update gate, roadmap status pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,9 @@ jobs:
       - name: Check documented repository structure
         run: pnpm docs:check-structure
 
+      - name: Lint OpenAPI specs
+        run: pnpm docs:lint-openapi
+
   contracts:
     name: Contracts — Build & Test
     runs-on: ubuntu-latest

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,6 @@
+extends: spectral:oas
+rules:
+  info-contact: warn
+  operation-tag-defined: error
+  operation-operationId: error
+  oas3-unused-component: error

--- a/apps/mobile-wallet/src/app/App.tsx
+++ b/apps/mobile-wallet/src/app/App.tsx
@@ -1,5 +1,8 @@
 import { ReadOnlyAccountView } from '../accounts';
+import { useAppGate } from '../config/hooks/useAppGate';
 import { MobileWalletShell } from '../navigation';
+import { ForceUpdateScreen } from '../screens/gate/ForceUpdateScreen';
+import { MaintenanceScreen } from '../screens/gate/MaintenanceScreen';
 import { bootstrapMobileWallet } from './bootstrap';
 
 interface Props {
@@ -8,6 +11,29 @@ interface Props {
 
 export const MobileWalletApp = ({ env }: Props) => {
   const bootstrap = bootstrapMobileWallet(env);
+  const gate = useAppGate({
+    configUrl: bootstrap.environment.remoteConfigUrl,
+    appVersion: bootstrap.environment.appVersion,
+    bypass: bootstrap.environment.remoteConfigBypass,
+  });
+
+  if (gate.isLoading) {
+    return <p aria-live="polite">Loading…</p>;
+  }
+
+  if (gate.result.status === 'maintenance') {
+    return <MaintenanceScreen message={gate.result.message} />;
+  }
+
+  if (gate.result.status === 'force-update') {
+    return (
+      <ForceUpdateScreen
+        minimumAppVersion={gate.result.minimumAppVersion}
+        currentVersion={bootstrap.environment.appVersion}
+        updateUrl={gate.result.updateUrl}
+      />
+    );
+  }
 
   return (
     <MobileWalletShell appName={bootstrap.environment.appName} activeRoute="account">

--- a/apps/mobile-wallet/src/config/__tests__/remote-config.test.ts
+++ b/apps/mobile-wallet/src/config/__tests__/remote-config.test.ts
@@ -1,0 +1,246 @@
+import {
+  RemoteConfigError,
+  checkAppGate,
+  compareSemver,
+  evaluateAppGate,
+  fetchRemoteAppConfig,
+  isVersionBelowMinimum,
+  parseRemoteAppConfig,
+  parseSemver,
+  type FetchLike,
+  type RemoteAppConfig,
+} from '../remote-config';
+
+const baseConfig: RemoteAppConfig = {
+  minimumAppVersion: '1.2.0',
+  maintenanceMode: false,
+};
+
+const fetchReturning = (payload: unknown, ok = true, status = 200): FetchLike => {
+  return jest.fn().mockResolvedValue({
+    ok,
+    status,
+    json: () => Promise.resolve(payload),
+  });
+};
+
+describe('parseSemver', () => {
+  it('parses MAJOR.MINOR.PATCH into numeric parts', () => {
+    expect(parseSemver('1.2.3')).toEqual([1, 2, 3]);
+    expect(parseSemver('0.0.1')).toEqual([0, 0, 1]);
+    expect(parseSemver('10.20.30')).toEqual([10, 20, 30]);
+  });
+
+  it('accepts a leading "v" and ignores prerelease/build suffixes', () => {
+    expect(parseSemver('v2.1.0')).toEqual([2, 1, 0]);
+    expect(parseSemver('1.2.3-beta.1')).toEqual([1, 2, 3]);
+    expect(parseSemver('1.2.3+build.42')).toEqual([1, 2, 3]);
+  });
+
+  it('throws RemoteConfigError on malformed versions', () => {
+    expect(() => parseSemver('1.2')).toThrow(RemoteConfigError);
+    expect(() => parseSemver('not-a-version')).toThrow(RemoteConfigError);
+    expect(() => parseSemver('')).toThrow(RemoteConfigError);
+    expect(() => parseSemver('1.2.x')).toThrow(RemoteConfigError);
+  });
+});
+
+describe('compareSemver', () => {
+  it('compares major versions first', () => {
+    expect(compareSemver('2.0.0', '1.9.9')).toBe(1);
+    expect(compareSemver('1.9.9', '2.0.0')).toBe(-1);
+  });
+
+  it('compares minor versions when majors are equal', () => {
+    expect(compareSemver('1.3.0', '1.2.9')).toBe(1);
+    expect(compareSemver('1.2.9', '1.3.0')).toBe(-1);
+  });
+
+  it('compares patch versions when major and minor are equal', () => {
+    expect(compareSemver('1.2.3', '1.2.2')).toBe(1);
+    expect(compareSemver('1.2.2', '1.2.3')).toBe(-1);
+  });
+
+  it('returns 0 for equal versions', () => {
+    expect(compareSemver('1.2.3', '1.2.3')).toBe(0);
+    expect(compareSemver('v1.2.3', '1.2.3')).toBe(0);
+  });
+
+  it('compares numerically, not lexicographically', () => {
+    expect(compareSemver('1.10.0', '1.9.0')).toBe(1);
+    expect(compareSemver('0.2.10', '0.2.9')).toBe(1);
+  });
+});
+
+describe('isVersionBelowMinimum', () => {
+  it('is true only when the current version is strictly below the minimum', () => {
+    expect(isVersionBelowMinimum('1.1.9', '1.2.0')).toBe(true);
+    expect(isVersionBelowMinimum('1.2.0', '1.2.0')).toBe(false);
+    expect(isVersionBelowMinimum('1.2.1', '1.2.0')).toBe(false);
+  });
+});
+
+describe('parseRemoteAppConfig', () => {
+  it('parses a valid payload', () => {
+    expect(
+      parseRemoteAppConfig({
+        minimumAppVersion: '1.2.0',
+        maintenanceMode: true,
+        maintenanceMessage: 'Back soon',
+        updateUrl: 'https://example.com/update',
+      })
+    ).toEqual({
+      minimumAppVersion: '1.2.0',
+      maintenanceMode: true,
+      maintenanceMessage: 'Back soon',
+      updateUrl: 'https://example.com/update',
+    });
+  });
+
+  it('rejects non-object payloads', () => {
+    expect(() => parseRemoteAppConfig(null)).toThrow(RemoteConfigError);
+    expect(() => parseRemoteAppConfig([])).toThrow(RemoteConfigError);
+    expect(() => parseRemoteAppConfig('1.2.0')).toThrow(RemoteConfigError);
+  });
+
+  it('rejects missing or invalid required fields', () => {
+    expect(() => parseRemoteAppConfig({ maintenanceMode: false })).toThrow(RemoteConfigError);
+    expect(() =>
+      parseRemoteAppConfig({ minimumAppVersion: 'nope', maintenanceMode: false })
+    ).toThrow(RemoteConfigError);
+    expect(() =>
+      parseRemoteAppConfig({ minimumAppVersion: '1.2.0', maintenanceMode: 'yes' })
+    ).toThrow(RemoteConfigError);
+  });
+
+  it('drops empty optional strings', () => {
+    const config = parseRemoteAppConfig({
+      minimumAppVersion: '1.2.0',
+      maintenanceMode: false,
+      maintenanceMessage: '   ',
+    });
+
+    expect(config.maintenanceMessage).toBeUndefined();
+  });
+});
+
+describe('fetchRemoteAppConfig', () => {
+  it('fetches and parses the hosted config', async () => {
+    const fetchFn = fetchReturning({ minimumAppVersion: '1.2.0', maintenanceMode: false });
+
+    await expect(
+      fetchRemoteAppConfig('https://config.example.com/app.json', fetchFn)
+    ).resolves.toEqual(baseConfig);
+    expect(fetchFn).toHaveBeenCalledWith('https://config.example.com/app.json');
+  });
+
+  it('throws on non-2xx responses', async () => {
+    const fetchFn = fetchReturning({}, false, 503);
+
+    await expect(
+      fetchRemoteAppConfig('https://config.example.com/app.json', fetchFn)
+    ).rejects.toThrow(RemoteConfigError);
+  });
+});
+
+describe('evaluateAppGate', () => {
+  it('allows up-to-date clients through', () => {
+    expect(evaluateAppGate({ config: baseConfig, appVersion: '1.2.0' })).toEqual({ status: 'ok' });
+    expect(evaluateAppGate({ config: baseConfig, appVersion: '2.0.0' })).toEqual({ status: 'ok' });
+  });
+
+  it('blocks outdated clients with a force-update result', () => {
+    expect(
+      evaluateAppGate({
+        config: { ...baseConfig, updateUrl: 'https://example.com/update' },
+        appVersion: '1.1.0',
+      })
+    ).toEqual({
+      status: 'force-update',
+      minimumAppVersion: '1.2.0',
+      updateUrl: 'https://example.com/update',
+    });
+  });
+
+  it('maintenance mode takes precedence over force-update', () => {
+    expect(
+      evaluateAppGate({
+        config: { ...baseConfig, maintenanceMode: true, maintenanceMessage: 'Back soon' },
+        appVersion: '1.0.0',
+      })
+    ).toEqual({ status: 'maintenance', message: 'Back soon' });
+  });
+
+  it('dev bypass flag skips both gates', () => {
+    expect(
+      evaluateAppGate({
+        config: { ...baseConfig, maintenanceMode: true },
+        appVersion: '0.0.1',
+        bypass: true,
+      })
+    ).toEqual({ status: 'ok' });
+  });
+});
+
+describe('checkAppGate', () => {
+  it('resolves ok without fetching when no config URL is set', async () => {
+    const fetchFn = jest.fn();
+
+    await expect(checkAppGate({ appVersion: '1.0.0', fetchFn })).resolves.toEqual({ status: 'ok' });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('resolves ok without fetching when the dev bypass is enabled', async () => {
+    const fetchFn = jest.fn();
+
+    await expect(
+      checkAppGate({
+        configUrl: 'https://config.example.com/app.json',
+        appVersion: '1.0.0',
+        bypass: true,
+        fetchFn,
+      })
+    ).resolves.toEqual({ status: 'ok' });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('evaluates the fetched config against the app version', async () => {
+    const fetchFn = fetchReturning({ minimumAppVersion: '1.2.0', maintenanceMode: false });
+
+    await expect(
+      checkAppGate({
+        configUrl: 'https://config.example.com/app.json',
+        appVersion: '1.1.0',
+        fetchFn,
+      })
+    ).resolves.toEqual({
+      status: 'force-update',
+      minimumAppVersion: '1.2.0',
+      updateUrl: undefined,
+    });
+  });
+
+  it('fails open when the config fetch rejects', async () => {
+    const fetchFn: FetchLike = jest.fn().mockRejectedValue(new Error('network down'));
+
+    await expect(
+      checkAppGate({
+        configUrl: 'https://config.example.com/app.json',
+        appVersion: '1.0.0',
+        fetchFn,
+      })
+    ).resolves.toEqual({ status: 'ok' });
+  });
+
+  it('fails open when the payload is malformed', async () => {
+    const fetchFn = fetchReturning({ minimumAppVersion: 42 });
+
+    await expect(
+      checkAppGate({
+        configUrl: 'https://config.example.com/app.json',
+        appVersion: '1.0.0',
+        fetchFn,
+      })
+    ).resolves.toEqual({ status: 'ok' });
+  });
+});

--- a/apps/mobile-wallet/src/config/environment.ts
+++ b/apps/mobile-wallet/src/config/environment.ts
@@ -21,6 +21,9 @@ export interface MobileWalletEnvironment extends NetworkConfig {
   readOnlyAccountId?: string;
   readOnlyAccountAddress?: string;
   walletConnectProjectId?: string;
+  remoteConfigUrl?: string;
+  appVersion?: string;
+  remoteConfigBypass?: boolean;
 }
 
 export type MobileWalletEnvSource = Record<string, string | undefined>;
@@ -118,6 +121,9 @@ export const loadMobileWalletEnvironment = (
     readOnlyAccountId: source.ANCORE_MOBILE_READONLY_ACCOUNT_ID?.trim() || undefined,
     readOnlyAccountAddress: source.ANCORE_MOBILE_READONLY_ACCOUNT_ADDRESS?.trim() || undefined,
     walletConnectProjectId: source.WALLETCONNECT_PROJECT_ID?.trim() || undefined,
+    remoteConfigUrl: source.ANCORE_MOBILE_REMOTE_CONFIG_URL?.trim() || undefined,
+    appVersion: source.ANCORE_MOBILE_APP_VERSION?.trim() || undefined,
+    remoteConfigBypass: source.ANCORE_MOBILE_REMOTE_CONFIG_BYPASS?.trim() === 'true',
   };
 };
 
@@ -133,6 +139,9 @@ export const loadMobileWalletEnvironmentFromEnv = (): MobileWalletEnvironment =>
     EXPO_PUBLIC_RELAYER_URL: process.env.EXPO_PUBLIC_RELAYER_URL,
     EXPO_PUBLIC_AI_AGENT_URL: process.env.EXPO_PUBLIC_AI_AGENT_URL,
     WALLETCONNECT_PROJECT_ID: process.env.WALLETCONNECT_PROJECT_ID,
+    ANCORE_MOBILE_REMOTE_CONFIG_URL: process.env.ANCORE_MOBILE_REMOTE_CONFIG_URL,
+    ANCORE_MOBILE_APP_VERSION: process.env.ANCORE_MOBILE_APP_VERSION,
+    ANCORE_MOBILE_REMOTE_CONFIG_BYPASS: process.env.ANCORE_MOBILE_REMOTE_CONFIG_BYPASS,
   };
 
   return loadMobileWalletEnvironment(source);

--- a/apps/mobile-wallet/src/config/hooks/useAppGate.ts
+++ b/apps/mobile-wallet/src/config/hooks/useAppGate.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { checkAppGate, type AppGateResult, type FetchLike } from '../remote-config';
+
+export interface UseAppGateOptions {
+  configUrl?: string;
+  appVersion?: string;
+  bypass?: boolean;
+  fetchFn?: FetchLike;
+}
+
+export interface AppGateState {
+  isLoading: boolean;
+  result: AppGateResult;
+}
+
+/**
+ * Runs the remote-config app gate before the main navigation renders.
+ * Resolves immediately to "ok" when no config URL or app version is set,
+ * or when the dev bypass flag is enabled.
+ */
+export function useAppGate({
+  configUrl,
+  appVersion,
+  bypass,
+  fetchFn,
+}: UseAppGateOptions): AppGateState {
+  const shouldCheck = Boolean(configUrl && appVersion && !bypass);
+
+  const [state, setState] = useState<AppGateState>({
+    isLoading: shouldCheck,
+    result: { status: 'ok' },
+  });
+
+  useEffect(() => {
+    if (!shouldCheck) {
+      return;
+    }
+
+    let cancelled = false;
+
+    checkAppGate({ configUrl, appVersion, bypass, fetchFn }).then((result) => {
+      if (!cancelled) {
+        setState({ isLoading: false, result });
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shouldCheck, configUrl, appVersion, bypass, fetchFn]);
+
+  return state;
+}

--- a/apps/mobile-wallet/src/config/remote-config.ts
+++ b/apps/mobile-wallet/src/config/remote-config.ts
@@ -1,0 +1,170 @@
+export interface RemoteAppConfig {
+  minimumAppVersion: string;
+  maintenanceMode: boolean;
+  maintenanceMessage?: string;
+  updateUrl?: string;
+}
+
+export type AppGateResult =
+  | { status: 'ok' }
+  | { status: 'force-update'; minimumAppVersion: string; updateUrl?: string }
+  | { status: 'maintenance'; message?: string };
+
+export class RemoteConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RemoteConfigError';
+  }
+}
+
+const SEMVER_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
+
+export const parseSemver = (version: string): [number, number, number] => {
+  const match = SEMVER_PATTERN.exec(version.trim());
+
+  if (!match) {
+    throw new RemoteConfigError(
+      `Invalid semver version "${version}". Expected MAJOR.MINOR.PATCH (optionally prefixed with "v").`
+    );
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+/** Compare two semver strings. Returns -1 when a < b, 0 when equal, 1 when a > b. */
+export const compareSemver = (a: string, b: string): -1 | 0 | 1 => {
+  const left = parseSemver(a);
+  const right = parseSemver(b);
+
+  for (let i = 0; i < 3; i += 1) {
+    if (left[i] < right[i]) {
+      return -1;
+    }
+    if (left[i] > right[i]) {
+      return 1;
+    }
+  }
+
+  return 0;
+};
+
+export const isVersionBelowMinimum = (current: string, minimum: string): boolean => {
+  return compareSemver(current, minimum) < 0;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const optionalString = (value: unknown, field: string): string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (typeof value !== 'string') {
+    throw new RemoteConfigError(`Remote config field "${field}" must be a string.`);
+  }
+
+  return value.trim() || undefined;
+};
+
+export const parseRemoteAppConfig = (input: unknown): RemoteAppConfig => {
+  if (!isRecord(input)) {
+    throw new RemoteConfigError('Remote config payload must be a JSON object.');
+  }
+
+  if (typeof input.minimumAppVersion !== 'string') {
+    throw new RemoteConfigError('Remote config field "minimumAppVersion" must be a string.');
+  }
+
+  parseSemver(input.minimumAppVersion);
+
+  if (typeof input.maintenanceMode !== 'boolean') {
+    throw new RemoteConfigError('Remote config field "maintenanceMode" must be a boolean.');
+  }
+
+  return {
+    minimumAppVersion: input.minimumAppVersion,
+    maintenanceMode: input.maintenanceMode,
+    maintenanceMessage: optionalString(input.maintenanceMessage, 'maintenanceMessage'),
+    updateUrl: optionalString(input.updateUrl, 'updateUrl'),
+  };
+};
+
+export type FetchLike = (
+  url: string
+) => Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
+
+export const fetchRemoteAppConfig = async (
+  url: string,
+  fetchFn: FetchLike = fetch
+): Promise<RemoteAppConfig> => {
+  const response = await fetchFn(url);
+
+  if (!response.ok) {
+    throw new RemoteConfigError(`Remote config request failed with status ${response.status}.`);
+  }
+
+  return parseRemoteAppConfig(await response.json());
+};
+
+export interface EvaluateAppGateOptions {
+  config: RemoteAppConfig;
+  appVersion: string;
+  /** Dev-only escape hatch so local builds are never blocked by the gate. */
+  bypass?: boolean;
+}
+
+export const evaluateAppGate = ({
+  config,
+  appVersion,
+  bypass,
+}: EvaluateAppGateOptions): AppGateResult => {
+  if (bypass) {
+    return { status: 'ok' };
+  }
+
+  if (config.maintenanceMode) {
+    return { status: 'maintenance', message: config.maintenanceMessage };
+  }
+
+  if (isVersionBelowMinimum(appVersion, config.minimumAppVersion)) {
+    return {
+      status: 'force-update',
+      minimumAppVersion: config.minimumAppVersion,
+      updateUrl: config.updateUrl,
+    };
+  }
+
+  return { status: 'ok' };
+};
+
+export interface CheckAppGateOptions {
+  configUrl?: string;
+  appVersion?: string;
+  bypass?: boolean;
+  fetchFn?: FetchLike;
+}
+
+/**
+ * Fetch the remote config and evaluate the gate. Fails open: when the config
+ * URL is not set, the fetch fails, or the payload is malformed, the app is
+ * allowed through — an unreachable config host must never brick the wallet.
+ */
+export const checkAppGate = async ({
+  configUrl,
+  appVersion,
+  bypass,
+  fetchFn,
+}: CheckAppGateOptions): Promise<AppGateResult> => {
+  if (!configUrl || !appVersion || bypass) {
+    return { status: 'ok' };
+  }
+
+  try {
+    const config = await fetchRemoteAppConfig(configUrl, fetchFn);
+    return evaluateAppGate({ config, appVersion, bypass });
+  } catch {
+    return { status: 'ok' };
+  }
+};

--- a/apps/mobile-wallet/src/index.ts
+++ b/apps/mobile-wallet/src/index.ts
@@ -2,12 +2,16 @@
 export * from './accounts';
 export * from './app';
 export * from './config/environment';
+export * from './config/remote-config';
+export * from './config/hooks/useAppGate';
 export * from './config/urls';
 export * from './linking';
 export * from './navigation';
 export * from './sdk';
 
 export { HistoryScreen } from './screens/history/HistoryScreen';
+export { ForceUpdateScreen } from './screens/gate/ForceUpdateScreen';
+export { MaintenanceScreen } from './screens/gate/MaintenanceScreen';
 
 export type {
   FetchTransactionPageParams,

--- a/apps/mobile-wallet/src/screens/gate/ForceUpdateScreen.tsx
+++ b/apps/mobile-wallet/src/screens/gate/ForceUpdateScreen.tsx
@@ -1,0 +1,17 @@
+type Props = {
+  minimumAppVersion: string;
+  currentVersion?: string;
+  updateUrl?: string;
+};
+
+export const ForceUpdateScreen = ({ minimumAppVersion, currentVersion, updateUrl }: Props) => (
+  <section role="alert">
+    <h1>Update required</h1>
+    <p>
+      This version of the app is no longer supported. Please update to version {minimumAppVersion}{' '}
+      or later to keep using your wallet.
+    </p>
+    {currentVersion ? <p>Installed version: {currentVersion}</p> : null}
+    {updateUrl ? <a href={updateUrl}>Update now</a> : null}
+  </section>
+);

--- a/apps/mobile-wallet/src/screens/gate/MaintenanceScreen.tsx
+++ b/apps/mobile-wallet/src/screens/gate/MaintenanceScreen.tsx
@@ -1,0 +1,11 @@
+type Props = {
+  message?: string;
+};
+
+export const MaintenanceScreen = ({ message }: Props) => (
+  <section role="alert">
+    <h1>Down for maintenance</h1>
+    <p>{message || 'The wallet is temporarily unavailable. Please try again shortly.'}</p>
+    <p>Your funds are safe — maintenance only affects app connectivity.</p>
+  </section>
+);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,9 @@
 # Ancore Roadmap
 
-> **Last updated:** July 2026 (status pass vs code on `main`)  
+> **Last updated:** July 2026 (status pass vs code on `main`; issue links reconciled against GitHub state)  
 > Status key: ✅ Done · 🔄 In progress / partial · 🔲 Planned · ❌ Blocked  
-> **Note:** Many rows were still marked 🔲 after implementation PRs landed. Statuses below were re-derived from source + recent git history; re-check issue mirrors with `scripts/sync-docs-issues-from-github.py` before planning sprints.
+> **Note:** Many original tracking issues were closed while code remains partial. Open hard issues (#957–#977 and later waves) supersede them: 🔲/🔄 rows below link their **open** successor as `#old → #new`. Rows still citing only a closed issue have no open successor tracker yet — file one before picking up the work. ✅ rows keep their closed issue as the done record.  
+> `scripts/sync-docs-issues-from-github.py` regenerates the `docs/issues/` offline mirrors; that tree is not currently checked in, so the script is a no-op here until it is restored.
 
 ---
 
@@ -16,15 +17,15 @@
 | 1.1 | Real BIP39 + HD key onboarding | #815 | 🔄 |
 | 1.2 | Mnemonic word-grid verification | #816 | 🔄 |
 | 1.3 | Smart account contract deploy on onboarding | #817 | 🔄 |
-| 1.4 | Remove demo auth router path | #818 | 🔲 |
+| 1.4 | Remove demo auth router path | #818 → #957 | 🔲 |
 | 1.5 | Wallet import (mnemonic recovery) | #819 | 🔄 |
-| 1.6 | Real send: vault decrypt + sign + relayer submit | #820 | 🔄 |
-| 1.7 | Soroban simulate before confirm | #821 | 🔄 |
-| 1.8 | Fee estimation on review screen | — | 🔄 |
-| 1.9 | Transaction confirmation polling | #822 | 🔄 |
-| 1.10 | Relayer: real Ed25519 signature verify | #854 | 🔄 |
-| 1.11 | Relayer: Postgres nonce replay table | #853 | 🔄 |
-| 1.12 | Relayer: real Soroban simulate | #852 | 🔄 |
+| 1.6 | Real send: vault decrypt + sign + relayer submit | #820 → #959 | 🔄 |
+| 1.7 | Soroban simulate before confirm | #821 → #959 | 🔄 |
+| 1.8 | Fee estimation on review screen | #959 | 🔄 |
+| 1.9 | Transaction confirmation polling | #822 → #959 | 🔄 |
+| 1.10 | Relayer: real Ed25519 signature verify | #854 → #969 | 🔄 |
+| 1.11 | Relayer: Postgres nonce replay table | #853 → #967 | 🔄 |
+| 1.12 | Relayer: real Soroban simulate | #852 → #968 | 🔄 |
 
 ---
 
@@ -45,10 +46,10 @@
 | 2.8 | wallet-api signAuthEntry (SEP-43) | #829 | ✅ |
 | 2.9 | wallet-api content script bridge implementation | #827 | ✅ |
 | 2.10 | SIGN_TRANSACTION background handler | #763 | ✅ |
-| 2.11 | signAuthEntry background handler (SEP-43) | #770 | ✅ |
-| 2.12 | Publish @ancore/wallet-api to npm | #779 | 🔄 |
+| 2.11 | signAuthEntry background handler (SEP-43) | #770 | 🔄 |
+| 2.12 | Publish @ancore/wallet-api to npm | #779 → #999 | 🔄 |
 | 2.13 | Chrome side panel signing UX | #814 | ✅ |
-| 2.14 | Session key request API for dApps | #873 | 🔄 |
+| 2.14 | Session key request API for dApps | #873 → #958 | 🔄 |
 
 ---
 
@@ -60,15 +61,15 @@
 | # | Item | Issue | Status |
 |---|------|-------|--------|
 | 3.1 | Internal contract security audit | #863 | 🔲 |
-| 3.2 | Contract fuzz tests | #833 | 🔲 |
-| 3.3 | Blockaid scan for dApp sign | #876 | 🔲 |
-| 3.4 | Blockaid scan for in-app send | #771 | 🔲 |
+| 3.2 | Contract fuzz tests | #833 → #994 | 🔲 |
+| 3.3 | Blockaid scan for dApp sign | #876 → #975 | 🔲 |
+| 3.4 | Blockaid scan for in-app send | #771 → #975 | 🔲 |
 | 3.5 | Memo-required check for mainnet sends | #823 | ✅ |
 | 3.6 | Session security hardening (SW restart, TTL) | #769 | 🔄 |
 | 3.7 | Connected sites management screen | #871 | 🔄 |
-| 3.8 | Expanded Playwright e2e suite | #826 | 🔄 |
+| 3.8 | Expanded Playwright e2e suite | #826 → #983 | 🔄 |
 | 3.9 | Relayer per-account rate limiting | #874 | ✅ |
-| 3.10 | Relay payload test vectors | #860 | 🔲 |
+| 3.10 | Relay payload test vectors | #860 → #969 | 🔲 |
 
 ---
 
@@ -79,22 +80,22 @@
 
 | # | Item | Issue | Status |
 |---|------|-------|--------|
-| 4.1 | Unify MobileSecureVault with core-sdk | #782 | 🔲 |
+| 4.1 | Unify MobileSecureVault with core-sdk | #782 → #965 | 🔲 |
 | 4.2 | react-native-keychain production adapter | #846 | 🔲 |
-| 4.3 | Mobile onboarding: real BIP39 keygen | #844 | 🔲 |
-| 4.4 | Mobile onboarding: mnemonic verification | #845 | 🔲 |
-| 4.5 | Mobile import: HD account discovery | #845 | 🔲 |
+| 4.3 | Mobile onboarding: real BIP39 keygen | #844 → #989 | 🔲 |
+| 4.4 | Mobile onboarding: mnemonic verification | #845 → #989 | 🔲 |
+| 4.5 | Mobile import: HD account discovery | #845 → #1002 | 🔲 |
 | 4.6 | Biometric native adapter (react-native-biometrics) | #847 | 🔲 |
-| 4.7 | WalletKit initialization | #839 | 🔲 |
-| 4.8 | stellar_signXDR WalletConnect handler | #840 | 🔲 |
-| 4.9 | stellar_signAuthEntry WalletConnect handler | #841 | 🔲 |
-| 4.10 | Session approval sheet UI | #842 | 🔲 |
-| 4.11 | Deep link handler (ancore://wc) | #843 | 🔄 |
-| 4.12 | iOS native project + Fastlane TestFlight | #848 | 🔄 |
-| 4.13 | Android native project + Fastlane Play | #849 | 🔄 |
-| 4.14 | Maestro e2e flows (basic + WalletConnect) | #786, #850 | 🔄 |
-| 4.15 | Mobile transaction builder + relayer submit | #851 | 🔲 |
-| 4.16 | HD account discovery scan on wallet import | #788 | 🔲 |
+| 4.7 | WalletKit initialization | #839 → #966 | 🔲 |
+| 4.8 | stellar_signXDR WalletConnect handler | #840 → #964 | 🔲 |
+| 4.9 | stellar_signAuthEntry WalletConnect handler | #841 → #964 | 🔲 |
+| 4.10 | Session approval sheet UI | #842 → #966 | 🔲 |
+| 4.11 | Deep link handler (ancore://wc) | #843 → #966 | 🔄 |
+| 4.12 | iOS native project + Fastlane TestFlight | #848 → #988 | 🔄 |
+| 4.13 | Android native project + Fastlane Play | #849 → #988 | 🔄 |
+| 4.14 | Maestro e2e flows (basic + WalletConnect) | #786, #850 → #987 | 🔄 |
+| 4.15 | Mobile transaction builder + relayer submit | #851 → #964 | 🔲 |
+| 4.16 | HD account discovery scan on wallet import | #788 → #1002 | 🔲 |
 
 ---
 
@@ -106,20 +107,20 @@
 | # | Item | Issue | Status |
 |---|------|-------|--------|
 | 5.1 | Contract: allowed_contracts in session key policy | #831 | ✅ |
-| 5.2 | Contract: spend limits and time window | #832 | 🔄 |
+| 5.2 | Contract: spend limits and time window | #832 → #962 | 🔄 |
 | 5.3 | Contract: ValidationModule hook interface | #835 | ✅ |
 | 5.4 | PasskeyModule: WebAuthn P-256 session key | #859 | ✅ |
-| 5.5 | WebAuthn onboarding design RFC | #869 | 🔄 |
-| 5.6 | Session Keys UI wired to contract | #773 | 🔄 |
+| 5.5 | WebAuthn onboarding design RFC | #869 → #971 | 🔄 |
+| 5.6 | Session Keys UI wired to contract | #773 → #963 | 🔄 |
 | 5.7 | Core SDK: deployAndInitializeAccount helper | #861 | 🔄 |
-| 5.8 | Core SDK: Ledger hardware wallet adapter | #872 | 🔄 |
-| 5.9 | AI agent: Claude Haiku NL→intent parsing | #836 | 🔲 |
+| 5.8 | Core SDK: Ledger hardware wallet adapter | #872 → #985 | 🔄 |
+| 5.9 | AI agent: Claude Haiku NL→intent parsing | #836 → #972 | 🔲 |
 | 5.10 | AI agent: risk score field | #837 | ✅ |
-| 5.11 | Indexer: Soroban contract event decoder | #856 | 🔄 |
-| 5.12 | Indexer: session_key_events table + REST API | #857 | 🔄 |
-| 5.13 | Indexer: contract address filter in activity | #858 | 🔄 |
-| 5.14 | Relayer: OpenTelemetry trace spans | #855 | 🔄 |
-| 5.15 | Relayer: Prometheus metrics + Grafana dashboard | #875 | 🔄 |
+| 5.11 | Indexer: Soroban contract event decoder | #856 → #974 | 🔄 |
+| 5.12 | Indexer: session_key_events table + REST API | #857 → #974 | 🔄 |
+| 5.13 | Indexer: contract address filter in activity | #858 → #974 | 🔄 |
+| 5.14 | Relayer: OpenTelemetry trace spans | #855 → #995 | 🔄 |
+| 5.15 | Relayer: Prometheus metrics + Grafana dashboard | #875 → #995 | 🔄 |
 
 ---
 
@@ -132,6 +133,20 @@
 - zk-proof validation modules
 - Decentralized relayer network
 - Swap / DEX integration
+
+---
+
+## Status pass checklist
+
+Use this checklist in the PR whenever roadmap statuses are refreshed:
+
+- [ ] Verify every ✅/🔄 change against code on `main` — issue state alone is not proof of done
+- [ ] Confirm cited issue states with `gh issue view <n> --json state`
+- [ ] Link 🔲/🔄 rows to their **open** successor tracker as `#old → #new`; ✅ rows keep the closed issue as the done record
+- [ ] Rows with no open successor: leave the closed reference and call it out in the PR so a tracker gets filed
+- [ ] Cross-check the detail tables in [docs/wallets/FREIGHTER_COMPARISON.md](./wallets/FREIGHTER_COMPARISON.md) (tracked by #976)
+- [ ] Regenerate `docs/issues/` mirrors with `scripts/sync-docs-issues-from-github.py` if that tree is checked in
+- [ ] Update the **Last updated** line at the top of this file
 
 ---
 

--- a/docs/indexer/contract-events.md
+++ b/docs/indexer/contract-events.md
@@ -2,6 +2,8 @@
 
 > Canonical reference for all events emitted by `contracts/account/src/lib.rs`.  
 > Use this document to map on-chain events to indexer ingestion actions.  
+> Query these events through the indexer contract-events endpoints — see
+> [`services/indexer/openapi.yaml`](../../services/indexer/openapi.yaml).  
 > Last updated: 2026-06-01
 
 ---

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -151,6 +151,24 @@ from `@ancore/account-abstraction` unless building advanced tooling.
 
 ---
 
+## Service API references
+
+HTTP service contracts are published as OpenAPI specs. Wallet teams calling a
+service directly must code against the spec, not against observed responses.
+
+| Service | Spec | Notes |
+|---------|------|-------|
+| Indexer | [`services/indexer/openapi.yaml`](../services/indexer/openapi.yaml) | Activity feed, statement rows, contract events (incl. session-key lifecycle events), cursor pagination examples |
+| Relayer | [`services/relayer/openapi.yaml`](../services/relayer/openapi.yaml) | Relay execute/validate/status |
+| AI agent | [`services/ai-agent/openapi.yaml`](../services/ai-agent/openapi.yaml) | Intent drafting |
+
+The indexer spec is linted in CI via `pnpm docs:lint-openapi` (Spectral,
+ruleset in [`.spectral.yaml`](../.spectral.yaml)). The contract event catalog
+behind the contract-events endpoints lives in
+[`docs/indexer/contract-events.md`](./indexer/contract-events.md).
+
+---
+
 ## Integration checklist
 
 Before shipping any feature that touches contract methods or SDK wrappers:

--- a/docs/wallets/FREIGHTER_COMPARISON.md
+++ b/docs/wallets/FREIGHTER_COMPARISON.md
@@ -2,7 +2,7 @@
 
 > **Purpose:** Learn from [Freighter extension](https://github.com/stellar/freighter) and [Freighter Mobile](https://github.com/stellar/freighter-mobile) — SDF’s production Stellar wallets — and document what Ancore should adopt, what it already does well, and what is incorrectly or incompletely implemented today.
 >
-> **Last reviewed:** 2026-07-16 (status pass; detail sections below may still lag)  
+> **Last reviewed:** 2026-07-16 (status pass; detail sections below may still lag — drift tracked in #976)  
 > **Freighter extension reference:** v5.42.x (`master`)  
 > **Freighter mobile reference:** v1.19.x (`main`)  
 > **Ancore reference:** `apps/extension-wallet`, `apps/mobile-wallet`, `apps/mobile-app`, `packages/core-sdk`
@@ -101,7 +101,7 @@ These are areas where Ancore is already aligned with Freighter-style wallet engi
 | Unlock rate limiting | Session handling | `unlock-rate-limit.ts` (exponential backoff) | ✅ Ancore adds explicit throttling |
 | Soroban awareness | First-class RPC + swap | Session keys, contract ops via `AncoreClient` | ⚠️ Different focus (AA vs classic) |
 | E2E tests | Playwright (12+ flows) | Playwright smoke (`tests/e2e/`) | ⚠️ Ancore much thinner |
-| i18n | en + pt, scanner in CI | English only | ❌ Gap |
+| i18n | en + pt, scanner in CI | `en` + `pt-BR` locale files, key-parity lint in CI (`check-i18n-keys.mjs`) | 🔄 Wiring + completeness gate tracked in #984 |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "indexer:lint-migrations": "node services/indexer/scripts/lint-migrations.mjs",
     "audit:security": "node tools/security-audit.js",
     "docs:validate-links": "node scripts/validate-doc-links.js",
+    "docs:lint-openapi": "npx --yes @stoplight/spectral-cli lint --fail-severity=warn services/indexer/openapi.yaml",
     "verify": "pnpm lint && pnpm typecheck && pnpm test",
     "prepare": "husky",
     "docs:check-structure": "node scripts/check-docs-repo-structure.mjs",

--- a/services/indexer/docs/API.md
+++ b/services/indexer/docs/API.md
@@ -1,5 +1,8 @@
 # Indexer Query API Documentation
 
+> Machine-readable contract: [`services/indexer/openapi.yaml`](../openapi.yaml)
+> (linted in CI via `pnpm docs:lint-openapi`).
+
 ## Overview
 
 The Ancore Indexer provides a comprehensive REST API for querying account activity data with cursor-based pagination, flexible filtering, and account-scoped security.

--- a/services/indexer/openapi.yaml
+++ b/services/indexer/openapi.yaml
@@ -1,0 +1,895 @@
+openapi: 3.1.0
+info:
+  title: Ancore Indexer Service API
+  description: |
+    HTTP query API for the Ancore indexer service. The indexer ingests Stellar
+    ledger data and Soroban contract events emitted by the Ancore account
+    contract, and exposes them to wallets through account-scoped activity
+    feeds, statement rows, and contract-event filters.
+
+    ## Pagination
+    Activity and statement endpoints use opaque cursor-based pagination.
+    Cursors are returned in the response envelope (`next_cursor` /
+    `prev_cursor`) and must be passed back verbatim via `cursor_after` or
+    `cursor_before`. Never construct or modify cursors client-side — the
+    encoding is an implementation detail and may change.
+
+    Contract-event endpoints use `limit` / `offset` pagination.
+
+    ## Session key events
+    There is no dedicated `session_key_events` route. Session-key lifecycle
+    events (`session_key_added`, `session_key_revoked`,
+    `session_key_ttl_refreshed`) are contract events emitted by the account
+    contract and are served by `/api/v1/contract-events` using the `type`
+    filter. They also surface in the account activity feed as
+    `activity_type` values. See `docs/indexer/contract-events.md` for the
+    canonical event catalog.
+
+    ## Errors
+    All errors return a structured envelope:
+    `{ "code": "...", "message": "...", "details"?: ... }` with
+    machine-readable codes: `INVALID_CURSOR`, `INVALID_FILTER`, `NOT_FOUND`,
+    `QUERY_TIMEOUT`, `DATABASE_ERROR`, `INTERNAL_ERROR`.
+
+    ## Rate limiting
+    All routes sit behind a token-bucket rate limiter configured via
+    `RATE_LIMIT_PER_SECOND` and `RATE_LIMIT_BURST_SIZE`; throttled requests
+    receive `429 Too Many Requests`.
+
+    ## Example: first page, then follow the cursor
+    ```bash
+    curl "http://localhost:3000/api/v1/accounts/GBVLTMFBHLPBFCP37PF5TRDHNXBFRZUFYVKPGVK4SEMHOKZDHYMOZNJS/activity?limit=20"
+    # → { "data": [...], "pagination": { "next_cursor": "eyJ0IjoiMjAyNi0wNy0...", ... } }
+
+    curl "http://localhost:3000/api/v1/accounts/GBVLTMFBHLPBFCP37PF5TRDHNXBFRZUFYVKPGVK4SEMHOKZDHYMOZNJS/activity?limit=20&cursor_after=eyJ0IjoiMjAyNi0wNy0wMVQxMjowMDowMCswMDowMCIsImkiOiI3ZjljMjRlOC0zYjJhLTRkNGYtOWM2Yi0yYTFmMGU4ZDVjM2IifQ=="
+    ```
+
+    ## Example: session-key events for a contract
+    ```bash
+    curl "http://localhost:3000/api/v1/contract-events?contract=CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526&type=session_key_added&limit=50"
+    ```
+  version: 1.0.0
+  contact:
+    name: Ancore Team
+    url: https://github.com/ancore-org/ancore
+
+servers:
+  - url: https://indexer.ancore.io
+    description: Production server
+  - url: https://indexer-staging.ancore.io
+    description: Staging server
+  - url: http://localhost:3000
+    description: Local development server
+
+tags:
+  - name: activity
+    description: Account-scoped activity feed with cursor pagination
+  - name: statements
+    description: Statement rows for export flows
+  - name: contract-events
+    description: Soroban contract events, including session-key lifecycle events
+  - name: health
+    description: Service health and operational metrics
+
+paths:
+  /api/v1/accounts/{account_id}/activity:
+    get:
+      tags:
+        - activity
+      summary: List account activity
+      description: |
+        Returns the activity timeline for an account with optional filters and
+        opaque cursor pagination. `cursor_after` and `cursor_before` are
+        mutually exclusive — passing both returns `400 INVALID_FILTER`.
+      operationId: listAccountActivity
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+        - name: cursor_after
+          in: query
+          description: |
+            Opaque cursor for forward pagination. Pass the `next_cursor` value
+            from a previous response verbatim.
+          schema:
+            type: string
+          example: 'eyJ0IjoiMjAyNi0wNy0wMVQxMjowMDowMCswMDowMCIsImkiOiI3ZjljMjRlOC0zYjJhLTRkNGYtOWM2Yi0yYTFmMGU4ZDVjM2IifQ=='
+        - name: cursor_before
+          in: query
+          description: |
+            Opaque cursor for backward pagination. Pass the `prev_cursor` value
+            from a previous response verbatim.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Records per page. Values outside [1, 100] are clamped.
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+        - name: activity_type
+          in: query
+          description: >
+            Exact-match filter on activity type
+            (e.g. `payment`, `execute`, `session_key_added`).
+          schema:
+            type: string
+          example: payment
+        - name: asset
+          in: query
+          description: >
+            Exact-match asset filter — `native` for XLM or `CODE:ISSUER` for
+            credit assets.
+          schema:
+            type: string
+          example: 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+        - name: counterparty
+          in: query
+          description: Exact-match filter on the counterparty address.
+          schema:
+            type: string
+        - name: ledger_min
+          in: query
+          description: Inclusive lower bound on ledger sequence. Must be <= `ledger_max`.
+          schema:
+            type: integer
+            format: int64
+        - name: ledger_max
+          in: query
+          description: Inclusive upper bound on ledger sequence.
+          schema:
+            type: integer
+            format: int64
+        - name: from_date
+          in: query
+          description: Inclusive lower bound on record timestamp (RFC 3339).
+          schema:
+            type: string
+            format: date-time
+          example: '2026-07-01T00:00:00Z'
+        - name: to_date
+          in: query
+          description: Inclusive upper bound on record timestamp (RFC 3339).
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: Page of activity records
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityListResponse'
+              example:
+                data:
+                  - id: '7f9c24e8-3b2a-4d4f-9c6b-2a1f0e8d5c3b'
+                    account_id: 'GBVLTMFBHLPBFCP37PF5TRDHNXBFRZUFYVKPGVK4SEMHOKZDHYMOZNJS'
+                    activity_type: 'payment'
+                    amount: '125.5000000'
+                    asset: 'native'
+                    asset_code: 'XLM'
+                    counterparty: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+                    tx_hash: '3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889'
+                    ledger_seq: 123456
+                    created_at: '2026-07-01T12:00:00Z'
+                    metadata:
+                      memo: 'invoice-42'
+                pagination:
+                  has_next_page: true
+                  has_previous_page: false
+                  next_cursor: 'eyJ0IjoiMjAyNi0wNy0wMVQxMjowMDowMCswMDowMCIsImkiOiI3ZjljMjRlOC0zYjJhLTRkNGYtOWM2Yi0yYTFmMGU4ZDVjM2IifQ=='
+                  count: 1
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '504':
+          $ref: '#/components/responses/QueryTimeout'
+
+  /api/v1/accounts/{account_id}/activity/types:
+    get:
+      tags:
+        - activity
+      summary: List distinct activity types for an account
+      description: >
+        Returns the distinct `activity_type` values recorded for the account,
+        suitable for populating filter dropdowns.
+      operationId: listAccountActivityTypes
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+      responses:
+        '200':
+          description: Distinct activity types
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityTypesResponse'
+              example:
+                data:
+                  - execute
+                  - payment
+                  - session_key_added
+                  - session_key_revoked
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/accounts/{account_id}/activity/{activity_id}:
+    get:
+      tags:
+        - activity
+      summary: Get a single activity record
+      description: >
+        Returns one activity record by UUID, scoped to the account. Returns
+        `404 NOT_FOUND` when the record does not exist or belongs to a
+        different account.
+      operationId: getAccountActivityById
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+        - name: activity_id
+          in: path
+          required: true
+          description: Activity record UUID.
+          schema:
+            type: string
+            format: uuid
+          example: '7f9c24e8-3b2a-4d4f-9c6b-2a1f0e8d5c3b'
+      responses:
+        '200':
+          description: Activity record
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/accounts/{account_id}/statements/rows:
+    get:
+      tags:
+        - statements
+      summary: List statement rows for a date range
+      description: |
+        Returns flattened statement rows (timestamp, counterparty, amount,
+        asset, status, memo/reference) for export flows. `from_date` and
+        `to_date` are required; forward-only pagination via `cursor_after`.
+      operationId: listStatementRows
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+        - name: from_date
+          in: query
+          required: true
+          description: Inclusive start of the statement window (RFC 3339). Must be <= `to_date`.
+          schema:
+            type: string
+            format: date-time
+          example: '2026-07-01T00:00:00Z'
+        - name: to_date
+          in: query
+          required: true
+          description: Inclusive end of the statement window (RFC 3339).
+          schema:
+            type: string
+            format: date-time
+          example: '2026-07-31T23:59:59Z'
+        - name: cursor_after
+          in: query
+          description: Opaque cursor from a previous response's `next_cursor`.
+          schema:
+            type: string
+          example: 'eyJ0IjoiMjAyNi0wNy0wMVQxMjowMDowMCswMDowMCIsImkiOiI3ZjljMjRlOC0zYjJhLTRkNGYtOWM2Yi0yYTFmMGU4ZDVjM2IifQ=='
+        - name: limit
+          in: query
+          description: Rows per page. Values outside [1, 100] are clamped.
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+      responses:
+        '200':
+          description: Page of statement rows
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatementRowsResponse'
+              example:
+                rows:
+                  - id: '7f9c24e8-3b2a-4d4f-9c6b-2a1f0e8d5c3b'
+                    timestamp: '2026-07-01T12:00:00Z'
+                    counterparty: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+                    amount: '125.5000000'
+                    asset: 'XLM'
+                    status: 'success'
+                    memo_or_reference: 'invoice-42'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/contract-events:
+    get:
+      tags:
+        - contract-events
+      summary: List contract events
+      description: |
+        Returns Soroban contract events with optional filters. Use
+        `contract` + `type` to query session-key lifecycle events
+        (`session_key_added`, `session_key_revoked`,
+        `session_key_ttl_refreshed`) for a smart account.
+      operationId: listContractEvents
+      parameters:
+        - name: contract
+          in: query
+          description: Filter by emitting contract address (C… address).
+          schema:
+            type: string
+          example: 'CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526'
+        - name: type
+          in: query
+          description: >
+            Exact-match filter on event type (e.g. `initialized`, `executed`,
+            `session_key_added`, `session_key_revoked`,
+            `session_key_ttl_refreshed`, `upgraded`, `migrated`).
+          schema:
+            type: string
+          example: session_key_added
+        - name: ledger_min
+          in: query
+          description: Inclusive lower bound on ledger sequence. Must be <= `ledger_max`.
+          schema:
+            type: integer
+            format: int64
+        - name: ledger_max
+          in: query
+          description: Inclusive upper bound on ledger sequence.
+          schema:
+            type: integer
+            format: int64
+        - name: limit
+          in: query
+          description: Records per page. Values outside [1, 200] are clamped.
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+        - name: offset
+          in: query
+          description: Number of records to skip (offset pagination).
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+      responses:
+        '200':
+          description: Contract events ordered by ledger sequence (descending)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractEventsListResponse'
+              example:
+                data:
+                  - id: '2a1f0e8d-5c3b-4d4f-9c6b-7f9c24e83b2a'
+                    contract_address: 'CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526'
+                    event_type: 'session_key_added'
+                    ledger_seq: 123460
+                    timestamp: '2026-07-01T12:05:00Z'
+                    tx_hash: '5a8f2c7b9a103389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db'
+                    data:
+                      public_key: 'a3f1c2d4e5b6978877665544332211aabbccddeeff00112233445566778899aa'
+                      expires_at: 1783123200
+                count: 1
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/contract-events/types:
+    get:
+      tags:
+        - contract-events
+      summary: List distinct event types for a contract
+      description: >
+        Returns the distinct `event_type` values recorded for the given
+        contract. The `contract` query parameter is required.
+      operationId: listContractEventTypes
+      parameters:
+        - name: contract
+          in: query
+          required: true
+          description: Contract address to scope the type list to.
+          schema:
+            type: string
+          example: 'CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526'
+      responses:
+        '200':
+          description: Distinct event types
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractEventTypesResponse'
+              example:
+                data:
+                  - executed
+                  - initialized
+                  - session_key_added
+                  - session_key_revoked
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/contract-events/{event_id}:
+    get:
+      tags:
+        - contract-events
+      summary: Get a single contract event
+      description: >
+        Returns one contract event by UUID. Returns `404 NOT_FOUND` when the
+        event does not exist.
+      operationId: getContractEventById
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          description: Contract event UUID.
+          schema:
+            type: string
+            format: uuid
+          example: '2a1f0e8d-5c3b-4d4f-9c6b-7f9c24e83b2a'
+      responses:
+        '200':
+          description: Contract event
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContractEventResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /health:
+    get:
+      tags:
+        - health
+      summary: Service health and ingest lag
+      description: >
+        Reports the latest indexed ledger, chain head, block/second lag, and
+        database schema migration state. Status is `degraded` when the lag
+        exceeds 100 ledgers or migrations are not up to date.
+      operationId: getHealth
+      responses:
+        '200':
+          description: Health report
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /metrics:
+    get:
+      tags:
+        - health
+      summary: Ingestion cursor metrics (JSON)
+      description: >
+        Returns cursor staleness metrics per ingestion stream. For Prometheus
+        text format, scrape the dedicated metrics port instead.
+      operationId: getMetrics
+      responses:
+        '200':
+          description: Cursor metrics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+components:
+  parameters:
+    AccountId:
+      name: account_id
+      in: path
+      required: true
+      description: Stellar public key — 56 characters starting with `G`.
+      schema:
+        type: string
+        pattern: '^G[A-Z2-7]{55}$'
+      example: 'GBVLTMFBHLPBFCP37PF5TRDHNXBFRZUFYVKPGVK4SEMHOKZDHYMOZNJS'
+
+  responses:
+    BadRequest:
+      description: Invalid filter, cursor, or parameter
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            code: 'INVALID_FILTER'
+            message: 'cannot specify both cursor_after and cursor_before'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            code: 'NOT_FOUND'
+            message: 'Resource not found'
+    RateLimited:
+      description: Rate limit exceeded
+    QueryTimeout:
+      description: Query timed out
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            code: 'QUERY_TIMEOUT'
+            message: 'query exceeded the configured timeout'
+    InternalError:
+      description: Internal server or database error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorEnvelope'
+          example:
+            code: 'INTERNAL_ERROR'
+            message: 'Internal server error'
+
+  schemas:
+    ErrorEnvelope:
+      type: object
+      description: Structured error envelope returned by all API routes.
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          description: Machine-readable error code.
+          enum:
+            - INVALID_CURSOR
+            - INVALID_FILTER
+            - NOT_FOUND
+            - QUERY_TIMEOUT
+            - DATABASE_ERROR
+            - INTERNAL_ERROR
+        message:
+          type: string
+          description: Human-readable description of the error.
+        details:
+          description: Optional structured details (validation context, field names).
+
+    ActivityRecord:
+      type: object
+      description: A single account activity record.
+      required:
+        - id
+        - account_id
+        - activity_type
+        - tx_hash
+        - ledger_seq
+        - created_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        account_id:
+          type: string
+          description: Stellar public key the record is scoped to.
+        activity_type:
+          type: string
+          description: >
+            Activity classification, e.g. `payment`, `execute`,
+            `session_key_added`, `session_key_revoked`.
+        amount:
+          type: ['string', 'null']
+          description: Amount as a decimal string.
+        asset:
+          type: ['string', 'null']
+          description: Raw asset identifier — `native` or `CODE:ISSUER`.
+        asset_code:
+          type: ['string', 'null']
+          description: Alphabetic asset code — `XLM` for native, or the credit-asset code.
+        asset_issuer:
+          type: ['string', 'null']
+          description: Issuing account address; null for native XLM.
+        counterparty:
+          type: ['string', 'null']
+        tx_hash:
+          type: string
+          description: Transaction hash (hex).
+        ledger_seq:
+          type: integer
+          format: int64
+        created_at:
+          type: string
+          format: date-time
+        metadata:
+          type: ['object', 'null']
+          description: Free-form metadata (memo, status, function, nonce, …).
+
+    PaginationInfo:
+      type: object
+      description: Cursor pagination envelope for activity lists.
+      required:
+        - has_next_page
+        - has_previous_page
+        - count
+      properties:
+        has_next_page:
+          type: boolean
+        has_previous_page:
+          type: boolean
+        next_cursor:
+          type: ['string', 'null']
+          description: Opaque cursor for the next page; pass as `cursor_after`.
+        prev_cursor:
+          type: ['string', 'null']
+          description: Opaque cursor for the previous page; pass as `cursor_before`.
+        count:
+          type: integer
+          description: Number of records in this page.
+
+    ActivityListResponse:
+      type: object
+      required:
+        - data
+        - pagination
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ActivityRecord'
+        pagination:
+          $ref: '#/components/schemas/PaginationInfo'
+
+    ActivityResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/ActivityRecord'
+
+    ActivityTypesResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            type: string
+
+    StatementRow:
+      type: object
+      required:
+        - id
+        - timestamp
+        - counterparty
+        - amount
+        - asset
+        - status
+        - memo_or_reference
+      properties:
+        id:
+          type: string
+          format: uuid
+        timestamp:
+          type: string
+          format: date-time
+        counterparty:
+          type: string
+        amount:
+          type: string
+        asset:
+          type: string
+        status:
+          type: string
+          description: Derived from record metadata; `unknown` when absent.
+        memo_or_reference:
+          type: string
+          description: Memo or reference from metadata, falling back to the tx hash.
+
+    StatementRowsResponse:
+      type: object
+      required:
+        - rows
+      properties:
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/StatementRow'
+        next_cursor:
+          type: ['string', 'null']
+          description: Opaque cursor for the next page; pass as `cursor_after`.
+
+    ContractEvent:
+      type: object
+      description: A decoded Soroban contract event.
+      required:
+        - id
+        - contract_address
+        - event_type
+        - ledger_seq
+        - timestamp
+        - tx_hash
+        - data
+      properties:
+        id:
+          type: string
+          format: uuid
+        contract_address:
+          type: string
+          description: Emitting contract address (C… address).
+        event_type:
+          type: string
+          description: >
+            Event name from the account contract, e.g. `initialized`,
+            `executed`, `session_key_added`, `session_key_revoked`,
+            `session_key_ttl_refreshed`, `upgraded`, `migrated`.
+        ledger_seq:
+          type: integer
+          format: int64
+        timestamp:
+          type: string
+          format: date-time
+        tx_hash:
+          type: string
+        data:
+          type: object
+          description: Decoded event payload; shape depends on `event_type`.
+
+    ContractEventsListResponse:
+      type: object
+      required:
+        - data
+        - count
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContractEvent'
+        count:
+          type: integer
+          description: Number of records in this page.
+
+    ContractEventResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/ContractEvent'
+
+    ContractEventTypesResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            type: string
+
+    HealthResponse:
+      type: object
+      required:
+        - timestamp
+        - status
+        - latest_indexed_ledger
+        - chain_head
+        - lag_blocks
+        - lag_seconds
+        - expected_schema_version
+        - migration_status
+        - applied_migrations
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum:
+            - ok
+            - degraded
+        latest_indexed_ledger:
+          type: integer
+          format: int64
+        chain_head:
+          type: integer
+          format: int64
+        lag_blocks:
+          type: integer
+          format: int64
+        lag_seconds:
+          type: integer
+          format: int64
+        schema_version:
+          type: ['integer', 'null']
+          description: Highest migration version applied to the database.
+        expected_schema_version:
+          type: integer
+        migration_status:
+          type: string
+          enum:
+            - up_to_date
+            - pending
+            - ahead
+            - unknown
+        latest_migration:
+          type: ['string', 'null']
+        migration_applied_at:
+          type: ['string', 'null']
+          format: date-time
+        applied_migrations:
+          type: integer
+          format: int64
+
+    CursorMetrics:
+      type: object
+      required:
+        - stream
+        - last_ledger_seq
+        - last_updated_at
+        - staleness_seconds
+        - is_stale
+      properties:
+        stream:
+          type: string
+          description: Name of the ingestion stream.
+        last_ledger_seq:
+          type: integer
+          format: int64
+        last_updated_at:
+          type: string
+          format: date-time
+        staleness_seconds:
+          type: integer
+          format: int64
+        is_stale:
+          type: boolean
+          description: True when staleness exceeds the 300s threshold.
+
+    MetricsResponse:
+      type: object
+      required:
+        - cursors
+        - status
+      properties:
+        cursors:
+          type: array
+          items:
+            $ref: '#/components/schemas/CursorMetrics'
+        status:
+          type: string
+          enum:
+            - ok
+            - degraded


### PR DESCRIPTION
## #1013 — Indexer OpenAPI complete for activity, session_key_events, and contract filters

Added `services/indexer/openapi.yaml` covering all live indexer routes read directly from `src/api/*.rs` and `src/main.rs`: account activity list/get/types, statement rows, and contract-events list/get/types. There is no dedicated `session_key_events` route in the codebase — session-key lifecycle events (`session_key_added`, `session_key_revoked`, `session_key_ttl_refreshed`) are contract events served by `/api/v1/contract-events`, which the spec documents explicitly with an example query. Cursor pagination is documented with worked curl examples (first page → follow `next_cursor`). Added `.spectral.yaml` and a `docs:lint-openapi` script, wired into the `services` CI job. Linked the spec from `docs/integration-guide.md` and `services/indexer/docs/API.md`, and referenced it from `docs/indexer/contract-events.md`.

## #1014 — Force-update and maintenance remote config gates

Added `apps/mobile-wallet/src/config/remote-config.ts`: a fetch-based remote config client (`checkAppGate`) that fails open on network/parse errors, a pure `evaluateAppGate` function (maintenance takes priority over force-update), and a semver comparator (`compareSemver` / `isVersionBelowMinimum`) with its own parser. Added `useAppGate` hook (`config/hooks/useAppGate.ts`) that runs the check before rendering the main shell in `App.tsx`, plus `ForceUpdateScreen` and `MaintenanceScreen` components under `screens/gate/`. Config source is a hosted JSON URL (`ANCORE_MOBILE_REMOTE_CONFIG_URL` / `remoteConfigUrl`) with a dev bypass flag (`ANCORE_MOBILE_REMOTE_CONFIG_BYPASS` / `remoteConfigBypass`) that skips the check entirely — both wired through the existing `loadMobileWalletEnvironment`. New fields default to `undefined`/`false` so existing hosts are unaffected until they opt in.

## #1015 — ROADMAP.md status pass

Verified every issue number cited in `docs/ROADMAP.md` and `docs/wallets/FREIGHTER_COMPARISON.md` against live GitHub state. Rows whose original tracking issue is closed but the work is still 🔲/🔄 in code now link their open successor as `#old → #new` (e.g. `#820 → #959`, `#857 → #974`), covering the #957–#977+ hard-issue wave. Corrected row 2.11 (signAuthEntry background handler) from ✅ to 🔄 — the handler exists but still falls back to placeholder `smartAccountId`/network defaults, matching open issue #770. Corrected the i18n row in FREIGHTER_COMPARISON from ❌ to 🔄 — `en` + `pt-BR` locale files and a CI key-parity check (`check-i18n-keys.mjs`) already exist; full parity is tracked by open issue #984. Added a "Status pass checklist" section to ROADMAP.md for future passes. `scripts/sync-docs-issues-from-github.py` targets `docs/issues/open` and `docs/issues/completed`, which are not present in this checkout, so it's a no-op here; noted that in the roadmap note instead of running it against a tree that doesn't exist.

## Test plan

- [x] `pnpm docs:lint-openapi` — passes clean against `services/indexer/openapi.yaml`
- [x] `pnpm --filter @ancore/mobile-wallet build` (tsc) — passes
- [x] `pnpm --filter @ancore/mobile-wallet test` — 285 passed, 1 pre-existing skip, including 24 new tests in `remote-config.test.ts`
- [x] Root `pnpm build && pnpm lint && pnpm format:check` (via pre-push hook) — all pass; remaining warnings are pre-existing and untouched by this PR
- [ ] Manual QA of `ForceUpdateScreen` / `MaintenanceScreen` against a real hosted config JSON (no staging config host wired up yet)


 
Closes #1013
Closes #1014
Closes #1015
Closes #1030 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added mobile wallet “app gate” behavior that can show maintenance messaging or a required update screen based on remote version rules.
* **Documentation**
  * Expanded integration and indexer API docs with clearer pointers to the machine-readable API contract.
  * Refreshed roadmap status and updated wallet comparison notes.
* **Quality Improvements**
  * Added stricter OpenAPI linting for indexer API documentation in CI.
* **Tests**
  * Introduced a new test suite covering remote-config parsing, evaluation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->