### PR TITLE
feat(web-dashboard): add zod env validation for VITE_HORIZON_URL and VITE_DEMO_MODE

### DIFF
--- a/apps/web-dashboard/.env.example
+++ b/apps/web-dashboard/.env.example
@@ -20,3 +20,11 @@ VITE_INDEXER_BASE_URL=http://localhost:4000
 # Set to "true" to show the button; any other value (or omitting) disables it.
 # Optional. Default: false.
 VITE_STATEMENT_PDF_EXPORT=false
+
+# Horizon RPC/REST endpoint for Stellar account queries.
+# Optional. Default: https://horizon-testnet.stellar.org
+VITE_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Enable demo mode for the Send flow (hides live transaction submission).
+# Optional. Default: false.
+VITE_DEMO_MODE=false

--- a/apps/web-dashboard/src/components/SendFlow.tsx
+++ b/apps/web-dashboard/src/components/SendFlow.tsx
@@ -17,11 +17,13 @@ import { useSendTransaction } from '../hooks/useSendTransaction';
 import { useSendFeeEstimate } from '../hooks/useSendFeeEstimate';
 import { useWalletConnection } from '../hooks/useWalletConnection';
 
+import { env } from '../lib/env';
+
 // ---------------------------------------------------------------------------
 // Feature flag
 // ---------------------------------------------------------------------------
 
-const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true';
+const DEMO_MODE = env.VITE_DEMO_MODE === 'true';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/apps/web-dashboard/src/lib/__tests__/env.test.ts
+++ b/apps/web-dashboard/src/lib/__tests__/env.test.ts
@@ -1,21 +1,11 @@
-import { z } from 'zod';
-
-// Re-export the schema under test without importing env.ts directly,
-// since env.ts calls parseEnv() at module load time (touching import.meta.env).
-// Testing the schema in isolation is faster and avoids Vite globals.
-
-const urlSchema = z.string().url();
-
-const envSchema = z.object({
-  VITE_RELAYER_URL: urlSchema,
-  VITE_INDEXER_BASE_URL: urlSchema,
-  VITE_STATEMENT_PDF_EXPORT: z.enum(['true', 'false']).default('false'),
-});
+import { envSchema, parseEnv } from '../env';
 
 const VALID_ENV = {
   VITE_RELAYER_URL: 'http://localhost:3000',
   VITE_INDEXER_BASE_URL: 'http://localhost:4000',
   VITE_STATEMENT_PDF_EXPORT: 'false' as const,
+  VITE_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+  VITE_DEMO_MODE: 'false' as const,
 };
 
 describe('env schema', () => {
@@ -30,6 +20,7 @@ describe('env schema', () => {
         ...VALID_ENV,
         VITE_RELAYER_URL: 'https://relayer.example.com',
         VITE_INDEXER_BASE_URL: 'https://indexer.example.com',
+        VITE_HORIZON_URL: 'https://horizon.stellar.org',
       });
       expect(result.success).toBe(true);
     });
@@ -48,6 +39,32 @@ describe('env schema', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.VITE_STATEMENT_PDF_EXPORT).toBe('true');
+      }
+    });
+
+    it('defaults VITE_HORIZON_URL to testnet when omitted', () => {
+      const { VITE_HORIZON_URL: _, ...rest } = VALID_ENV;
+      const result = envSchema.safeParse(rest);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.VITE_HORIZON_URL).toBe('https://horizon-testnet.stellar.org');
+      }
+    });
+
+    it('defaults VITE_DEMO_MODE to "false" when omitted', () => {
+      const { VITE_DEMO_MODE: _, ...rest } = VALID_ENV;
+      const result = envSchema.safeParse(rest);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.VITE_DEMO_MODE).toBe('false');
+      }
+    });
+
+    it('accepts "true" for VITE_DEMO_MODE', () => {
+      const result = envSchema.safeParse({ ...VALID_ENV, VITE_DEMO_MODE: 'true' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.VITE_DEMO_MODE).toBe('true');
       }
     });
   });
@@ -92,6 +109,24 @@ describe('env schema', () => {
       }
     });
 
+    it('fails for an unrecognised VITE_DEMO_MODE value', () => {
+      const result = envSchema.safeParse({ ...VALID_ENV, VITE_DEMO_MODE: 'yes' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const paths = result.error.issues.map((i) => i.path.join('.'));
+        expect(paths).toContain('VITE_DEMO_MODE');
+      }
+    });
+
+    it('fails when VITE_HORIZON_URL is not a valid URL', () => {
+      const result = envSchema.safeParse({ ...VALID_ENV, VITE_HORIZON_URL: 'not-a-url' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const paths = result.error.issues.map((i) => i.path.join('.'));
+        expect(paths).toContain('VITE_HORIZON_URL');
+      }
+    });
+
     it('error messages are descriptive for invalid URL', () => {
       const result = envSchema.safeParse({ ...VALID_ENV, VITE_RELAYER_URL: 'not-a-url' });
       expect(result.success).toBe(false);
@@ -101,5 +136,28 @@ describe('env schema', () => {
         expect(issue?.message).toBeTruthy();
       }
     });
+  });
+});
+
+describe('parseEnv()', () => {
+  it('returns parsed data for valid input', () => {
+    const env = parseEnv(VALID_ENV);
+    expect(env.VITE_RELAYER_URL).toBe('http://localhost:3000');
+    expect(env.VITE_INDEXER_BASE_URL).toBe('http://localhost:4000');
+    expect(env.VITE_STATEMENT_PDF_EXPORT).toBe('false');
+    expect(env.VITE_HORIZON_URL).toBe('https://horizon-testnet.stellar.org');
+    expect(env.VITE_DEMO_MODE).toBe('false');
+  });
+
+  it('throws when DEV is true and config is invalid', () => {
+    const originalDev = import.meta.env.DEV;
+    try {
+      (import.meta.env as Record<string, unknown>).DEV = true;
+      expect(() => parseEnv({ VITE_RELAYER_URL: 'bad' })).toThrow(
+        '[env] Invalid environment configuration'
+      );
+    } finally {
+      (import.meta.env as Record<string, unknown>).DEV = originalDev;
+    }
   });
 });

--- a/apps/web-dashboard/src/lib/env.ts
+++ b/apps/web-dashboard/src/lib/env.ts
@@ -2,24 +2,30 @@ import { z } from 'zod';
 
 const urlSchema = z.string().url({ message: 'must be a valid URL (include http:// or https://)' });
 
-const envSchema = z.object({
+export const envSchema = z.object({
   /** Base URL for the Ancore relayer service. */
   VITE_RELAYER_URL: urlSchema,
   /** Base URL for the Ancore indexer service. */
   VITE_INDEXER_BASE_URL: urlSchema,
   /** Set to "true" to enable the PDF export button on the Statements page. */
   VITE_STATEMENT_PDF_EXPORT: z.enum(['true', 'false']).default('false'),
+  /** Horizon RPC/REST endpoint. Defaults to Stellar testnet. */
+  VITE_HORIZON_URL: urlSchema.default('https://horizon-testnet.stellar.org'),
+  /** Enable demo mode for the Send flow. */
+  VITE_DEMO_MODE: z.enum(['true', 'false']).default('false'),
 });
 
-type Env = z.infer<typeof envSchema>;
+export type Env = z.infer<typeof envSchema>;
 
-function parseEnv(): Env {
-  const raw = {
+export function parseEnv(
+  raw: Record<string, unknown> = {
     VITE_RELAYER_URL: import.meta.env.VITE_RELAYER_URL,
     VITE_INDEXER_BASE_URL: import.meta.env.VITE_INDEXER_BASE_URL,
     VITE_STATEMENT_PDF_EXPORT: import.meta.env.VITE_STATEMENT_PDF_EXPORT,
-  };
-
+    VITE_HORIZON_URL: import.meta.env.VITE_HORIZON_URL,
+    VITE_DEMO_MODE: import.meta.env.VITE_DEMO_MODE,
+  }
+): Env {
   const result = envSchema.safeParse(raw);
 
   if (!result.success) {
@@ -38,4 +44,6 @@ function parseEnv(): Env {
   return result.success ? result.data : (raw as unknown as Env);
 }
 
-export const env = parseEnv();
+// Eagerly parse in non-test environments so main.tsx can `import './lib/env'`
+// as a side-effect. Tests import envSchema / parseEnv directly instead.
+export const env: Env = import.meta.env.MODE === 'test' ? ({} as Env) : parseEnv();

--- a/apps/web-dashboard/src/lib/horizon.ts
+++ b/apps/web-dashboard/src/lib/horizon.ts
@@ -6,7 +6,9 @@
  * and independent of indexer work.
  */
 
-const HORIZON_URL = import.meta.env.VITE_HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
+import { env } from './env';
+
+const HORIZON_URL = env.VITE_HORIZON_URL;
 
 export interface HorizonAccountData {
   id: string;

--- a/apps/web-dashboard/src/pages/Send.tsx
+++ b/apps/web-dashboard/src/pages/Send.tsx
@@ -6,7 +6,9 @@ import { useWalletConnection } from '../hooks/useWalletConnection';
 import type { SendStrategy } from '../services/send-service';
 import type { Transaction } from '../types/dashboard';
 
-const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true';
+import { env } from '../lib/env';
+
+const DEMO_MODE = env.VITE_DEMO_MODE === 'true';
 
 function StatusBadge({ status }: { status: Transaction['status'] }) {
   const styles: Record<string, string> = {


### PR DESCRIPTION
## Summary

Extend the existing zod env schema to cover `VITE_HORIZON_URL` and `VITE_DEMO_MODE`, which were previously accessed directly via `import.meta.env` with ad-hoc fallbacks, bypassing runtime validation.

## Changes

- **`src/lib/env.ts`** — Add `VITE_HORIZON_URL` (optional, defaults to testnet) and `VITE_DEMO_MODE` (optional, defaults to `false`) to the zod schema. Export `envSchema`, `parseEnv`, and `Env` type for direct test imports. Guard eager `parseEnv()` behind `MODE !== 'test'` so tests can import without side effects.
- **`src/lib/horizon.ts`** — Route through validated `env.VITE_HORIZON_URL` instead of raw `import.meta.env`.
- **`src/pages/Send.tsx`**, **`src/components/SendFlow.tsx`** — Route through validated `env.VITE_DEMO_MODE`.
- **`.env.example`** — Document the two new vars.
- **`src/lib/__tests__/env.test.ts`** — Import schema directly from `env.ts` (eliminates drift). Add 6 new tests covering defaults, validation, and `parseEnv()` behavior.

## Test plan

- [x] `pnpm --filter @ancore/web-dashboard test` — 17/17 pass
- [x] `pnpm --filter @ancore/web-dashboard lint` — no new errors
- [x] Typecheck — no new errors (pre-existing workspace resolution errors unchanged)

closes #1062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Stellar Horizon endpoint settings.
  * Added an optional demo mode for the Send flow, disabled by default.
* **Bug Fixes**
  * Improved environment configuration validation, including clearer handling of invalid URLs and demo mode values.
  * Ensured account and balance requests consistently use the configured Horizon endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->