### PR TITLE
test: add edge-case tests for permission bitmask and contract-vec conversions

### DIFF
--- a/packages/account-abstraction/src/__tests__/permissions.test.ts
+++ b/packages/account-abstraction/src/__tests__/permissions.test.ts
@@ -104,4 +104,109 @@ describe('permissions', () => {
   it('documents PERMISSION_EXECUTE for session-key execute authorization', () => {
     expect(PERMISSION_EXECUTE).toBe(1);
   });
+
+  describe('edge cases', () => {
+    describe('permissionsToBitmask', () => {
+      it('returns 0 for empty array', () => {
+        expect(permissionsToBitmask([])).toBe(0);
+      });
+
+      it('deduplicates repeated permissions', () => {
+        const duped = [
+          SessionPermission.SEND_PAYMENT,
+          SessionPermission.SEND_PAYMENT,
+          SessionPermission.MANAGE_DATA,
+          SessionPermission.MANAGE_DATA,
+        ];
+        const single = [SessionPermission.SEND_PAYMENT, SessionPermission.MANAGE_DATA];
+        expect(permissionsToBitmask(duped)).toBe(permissionsToBitmask(single));
+      });
+    });
+
+    describe('bitmaskToPermissions', () => {
+      it('returns empty array for bitmask 0', () => {
+        expect(bitmaskToPermissions(0)).toEqual([]);
+      });
+
+      it('ignores unknown high bits', () => {
+        const known = bitmaskToPermissions(0b111);
+        const withExtra = bitmaskToPermissions(0b1111_0000_0000 | 0b111);
+        expect(withExtra).toEqual(known);
+      });
+
+      it('returns empty for bitmask with only unknown bits', () => {
+        expect(bitmaskToPermissions(0b1111_0000_0000)).toEqual([]);
+      });
+    });
+
+    describe('permissionsToContractVec', () => {
+      it('returns empty array for empty input', () => {
+        expect(permissionsToContractVec([])).toEqual([]);
+      });
+
+      it('deduplicates repeated permissions', () => {
+        const duped = [
+          SessionPermission.INVOKE_CONTRACT,
+          SessionPermission.INVOKE_CONTRACT,
+          SessionPermission.SEND_PAYMENT,
+        ];
+        expect(permissionsToContractVec(duped)).toEqual([0, 2]);
+      });
+
+      it('sorts values ascending regardless of input order', () => {
+        const unsorted = [
+          SessionPermission.INVOKE_CONTRACT,
+          SessionPermission.SEND_PAYMENT,
+          SessionPermission.MANAGE_DATA,
+        ];
+        expect(permissionsToContractVec(unsorted)).toEqual([0, 1, 2]);
+      });
+    });
+
+    describe('contractVecToPermissions', () => {
+      it('returns empty array for empty input', () => {
+        expect(contractVecToPermissions([])).toEqual([]);
+      });
+
+      it('drops unknown out-of-range values', () => {
+        expect(contractVecToPermissions([0, 2, 99, 255])).toEqual([
+          SessionPermission.SEND_PAYMENT,
+          SessionPermission.INVOKE_CONTRACT,
+        ]);
+      });
+
+      it('returns empty when all values are unknown', () => {
+        expect(contractVecToPermissions([99, 100, 255])).toEqual([]);
+      });
+
+      it('preserves duplicates (no dedup)', () => {
+        expect(contractVecToPermissions([0, 0, 1])).toEqual([
+          SessionPermission.SEND_PAYMENT,
+          SessionPermission.SEND_PAYMENT,
+          SessionPermission.MANAGE_DATA,
+        ]);
+      });
+    });
+
+    describe('round-trip stability', () => {
+      it('permissions → bitmask → permissions is stable', () => {
+        const original = [SessionPermission.MANAGE_DATA, SessionPermission.INVOKE_CONTRACT];
+        const bitmask = permissionsToBitmask(original);
+        const recovered = bitmaskToPermissions(bitmask);
+        expect(recovered).toEqual(original);
+      });
+
+      it('permissions → contractVec → permissions is stable', () => {
+        const original = [SessionPermission.SEND_PAYMENT, SessionPermission.INVOKE_CONTRACT];
+        const vec = permissionsToContractVec(original);
+        const recovered = contractVecToPermissions(vec);
+        expect(recovered).toEqual(original);
+      });
+
+      it('empty round-trips are stable', () => {
+        expect(bitmaskToPermissions(permissionsToBitmask([]))).toEqual([]);
+        expect(contractVecToPermissions(permissionsToContractVec([]))).toEqual([]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
adds edge-case tests for the permission conversion functions in account-abstraction.

covers empty inputs, duplicate dedup, out-of-range bitmask bits, unknown contract-vec values, and round-trip stability.

fixes #1141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for empty, duplicate, unknown, and out-of-range permission values.
  * Verified consistent ordering and duplicate handling during permission conversions.
  * Added round-trip stability checks for bitmask and contract-vector conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->