### PR TITLE
feat(mobile): add accessibility labels to primary onboarding buttons …

### DIFF
--- a/apps/mobile-wallet/src/screens/onboarding/OnboardingEntryScreen.tsx
+++ b/apps/mobile-wallet/src/screens/onboarding/OnboardingEntryScreen.tsx
@@ -22,13 +22,13 @@ export function OnboardingEntryScreen({
       </header>
 
       <div className="space-y-3">
-        <button onClick={onCreate} type="button">
+        <button aria-label="Create a new wallet" onClick={onCreate} type="button">
           Create a new wallet
         </button>
-        <button onClick={onImport} type="button">
+        <button aria-label="Import an existing wallet" onClick={onImport} type="button">
           Import an existing wallet
         </button>
-        <button onClick={onRecover} type="button">
+        <button aria-label="Recover from backup" onClick={onRecover} type="button">
           Recover from backup
         </button>
       </div>

--- a/apps/mobile-wallet/src/screens/onboarding/WalletCreateScreen.tsx
+++ b/apps/mobile-wallet/src/screens/onboarding/WalletCreateScreen.tsx
@@ -34,13 +34,13 @@ export function WalletCreateScreen({ onBack = noop, onCancel = noop, onContinue 
       </label>
 
       <div className="flex gap-3">
-        <button onClick={onBack} type="button">
+        <button aria-label="Go back" onClick={onBack} type="button">
           Back
         </button>
-        <button onClick={onCancel} type="button">
+        <button aria-label="Cancel wallet creation" onClick={onCancel} type="button">
           Cancel
         </button>
-        <button disabled={!canContinue} onClick={onContinue} type="button">
+        <button aria-label="Continue wallet creation" disabled={!canContinue} onClick={onContinue} type="button">
           Continue
         </button>
       </div>

--- a/apps/mobile-wallet/src/screens/onboarding/WalletImportScreen.tsx
+++ b/apps/mobile-wallet/src/screens/onboarding/WalletImportScreen.tsx
@@ -57,13 +57,13 @@ export function WalletImportScreen({ onBack = noop, onCancel = noop, onContinue 
       )}
 
       <div className="flex gap-3">
-        <button onClick={onBack} type="button">
+        <button aria-label="Go back" onClick={onBack} type="button">
           Back
         </button>
-        <button onClick={onCancel} type="button">
+        <button aria-label="Cancel wallet import" onClick={onCancel} type="button">
           Cancel
         </button>
-        <button disabled={!hasEnoughWords} onClick={handleContinue} type="button">
+        <button aria-label="Continue wallet import" disabled={!hasEnoughWords} onClick={handleContinue} type="button">
           Continue
         </button>
       </div>


### PR DESCRIPTION
#1046 — accessibility labels on onboarding buttons
#1048 — disable Send submit when amount is empty or has validation errors
#1043 — more aggressive pnpm cache in CI
#1058 — deep link unit tests for

closes #1046 closes #1048 closes #1043 closes #1058

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added accessible labels to onboarding setup, wallet creation, and wallet import actions.
  * Improved button semantics for Back, Cancel, and Continue controls without changing their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->