### PR TITLE
fix: enforce coverage gate and doc-link checks in CI, run security scans on PRs, fix invoice TTL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,10 @@ jobs:
       - name: Test
         run: pnpm turbo run test --filter=${{ matrix.filter }}
 
+      - name: Coverage gate (security-critical packages)
+        if: contains(fromJSON('["core-sdk", "account-abstraction", "crypto", "stellar"]'), matrix.name)
+        run: node scripts/coverage-gate.js
+
   app:
     name: App — ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -175,6 +179,9 @@ jobs:
 
       - name: Check documented repository structure
         run: pnpm docs:check-structure
+
+      - name: Validate documentation links
+        run: pnpm docs:validate-links
 
       - name: Lint OpenAPI specs
         run: pnpm docs:lint-openapi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday
   workflow_dispatch:
+  pull_request:
+    branches: [main, develop]
 
 jobs:
   dependency-review:

--- a/contracts/invoice/src/lib.rs
+++ b/contracts/invoice/src/lib.rs
@@ -92,7 +92,41 @@ mod storage {
     pub const INVOICE: Symbol = Symbol::short("INV");
 }
 
+const DAY_IN_LEDGERS: u32 = 17280; // 24 hours * 60 min * 60 sec / 5 sec per ledger
+const INSTANCE_BUMP_AMOUNT: u32 = 30 * DAY_IN_LEDGERS; // 30 days
+const INSTANCE_BUMP_THRESHOLD: u32 = 15 * DAY_IN_LEDGERS; // 15 days
+
 pub struct InvoiceContract;
+
+impl InvoiceContract {
+    /// Extend the contract instance's storage TTL after a write.
+    ///
+    /// Mirrors the account contract's TTL-bump pattern: a fixed 30-day bump by
+    /// default, extended further when an invoice has a `due_date` further out
+    /// than that, so long-lived invoices don't become inaccessible once their
+    /// entry TTL lapses.
+    fn extend_ttl(env: &Env, due_date: Option<u64>) {
+        let (threshold, amount) = match due_date {
+            Some(due) => {
+                let current_timestamp = env.ledger().timestamp();
+                if due > current_timestamp {
+                    // 5 seconds per ledger (see DAY_IN_LEDGERS), plus the default
+                    // 30-day buffer so the entry outlives the invoice's due date.
+                    let diff_seconds = due.saturating_sub(current_timestamp);
+                    let calculated_ledgers = (diff_seconds / 5).try_into().unwrap_or(u32::MAX);
+                    let ledgers_to_live = calculated_ledgers.saturating_add(INSTANCE_BUMP_AMOUNT);
+                    let threshold = ledgers_to_live.saturating_sub(INSTANCE_BUMP_AMOUNT / 2);
+                    (threshold, ledgers_to_live)
+                } else {
+                    (INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT)
+                }
+            }
+            None => (INSTANCE_BUMP_THRESHOLD, INSTANCE_BUMP_AMOUNT),
+        };
+
+        env.storage().instance().extend_ttl(threshold, amount);
+    }
+}
 
 #[contractimpl]
 impl InvoiceContract {
@@ -146,6 +180,9 @@ impl InvoiceContract {
         // Store invoice
         let key = (storage::INVOICE, id.clone());
         env.storage().instance().set(&key, &invoice);
+
+        // Extend instance TTL, sized to the invoice's due date when present
+        Self::extend_ttl(env, invoice.due_date);
 
         // Emit event
         env.events().publish(
@@ -201,6 +238,9 @@ impl InvoiceContract {
 
         env.storage().instance().set(&(storage::INVOICE, id), &invoice);
 
+        // Extend instance TTL, sized to the invoice's due date when present
+        Self::extend_ttl(env, invoice.due_date);
+
         // Emit event
         env.events().publish(events::invoice_paid(env), (id, invoice.payment_tx));
     }
@@ -223,6 +263,9 @@ impl InvoiceContract {
 
         env.storage().instance().set(&(storage::INVOICE, id), &invoice);
 
+        // Extend instance TTL, sized to the invoice's due date when present
+        Self::extend_ttl(env, invoice.due_date);
+
         // Emit event
         env.events().publish(events::invoice_cancelled(env), id);
     }
@@ -232,5 +275,50 @@ impl InvoiceContract {
         // This is a simplified implementation
         // In production, you'd want to use an index for efficient querying
         Vec::new(env)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::Address;
+
+    /// Issue #1129: writes must extend the instance TTL so long-lived invoices
+    /// (with a future `due_date`) remain readable after the ledger advances well
+    /// past the default (non-extended) instance TTL.
+    #[test]
+    fn test_invoice_readable_after_ledger_advance_past_default_ttl() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, InvoiceContract);
+        let client = InvoiceContractClient::new(&env, &contract_id);
+
+        let account = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let asset = Symbol::new(&env, "USDC");
+
+        // Due 90 days out — the TTL bump should be sized to cover it.
+        let due_date = env.ledger().timestamp() + 90 * 24 * 60 * 60;
+
+        let id = client.create(
+            &account,
+            &recipient,
+            &1000i128,
+            &asset,
+            &None,
+            &Some(due_date),
+            &None,
+        );
+
+        // Advance the ledger well past the default 30-day bump (INSTANCE_BUMP_AMOUNT)
+        // that would apply without a due-date-aware extension.
+        env.ledger().with_mut(|li| {
+            li.sequence_number = li.sequence_number.saturating_add(40 * DAY_IN_LEDGERS);
+        });
+
+        let invoice = client.get(&id);
+        assert_eq!(invoice.id, id);
+        assert_eq!(invoice.status, InvoiceStatus::Open);
     }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "indexer:check": "cd services/indexer && cargo check",
     "indexer:lint-migrations": "node services/indexer/scripts/lint-migrations.mjs",
     "audit:security": "node tools/security-audit.js",
+    "coverage:gate": "node scripts/coverage-gate.js",
     "docs:validate-links": "node scripts/validate-doc-links.js",
     "docs:lint-openapi": "npx --yes @stoplight/spectral-cli lint --fail-severity=warn services/indexer/openapi.yaml",
     "verify": "pnpm lint && pnpm typecheck && pnpm test",


### PR DESCRIPTION
- **#1132** — `scripts/coverage-gate.js` defined coverage thresholds for the security-critical packages (`core-sdk`, `account-abstraction`, `crypto`, `stellar`) but was never invoked anywhere. Added a `coverage:gate` script (`node scripts/coverage-gate.js`) to `package.json`, and wired it into the `package` job of `.github/workflows/ci.yml` as a step that runs after `Test` for those four matrix entries (gated via `if: contains(fromJSON(...), matrix.name)`), so a coverage drop below threshold now fails CI.
- **#1131** — `docs:validate-links` (`node scripts/validate-doc-links.js`) already existed in `package.json` but no workflow ran it. Added a `Validate documentation links` step (`pnpm docs:validate-links`) to the `services` job in `ci.yml`, right after the existing `docs:check-structure` step, matching that job's convention (no path-filtering is used elsewhere in this workflow, so none was added here).
- **#1130** — `.github/workflows/security.yml` only triggered on `schedule` and `workflow_dispatch`, so the `if: github.event_name == 'pull_request'` conditions on the dependency-review and CodeQL steps never fired. Added a `pull_request: branches: [main, develop]` trigger to the `on:` block, matching the branch list used by `ci.yml`.
- **#1129** — The invoice contract stored invoice data via instance storage on `create`/`pay`/`cancel` but never called `extend_ttl`, unlike the account contract's consistent TTL-bump pattern. Added an `extend_ttl` helper mirroring the account contract's `INSTANCE_BUMP_THRESHOLD`/`INSTANCE_BUMP_AMOUNT` convention, sized to the invoice's `due_date` when present (so invoices with a far-future due date get a correspondingly larger TTL bump), and call it after each write. Added a test (`test_invoice_readable_after_ledger_advance_past_default_ttl`) that creates an invoice with a 90-day due date, advances the ledger sequence 40 days worth of ledgers past the default 30-day bump, and asserts the invoice is still readable.

  **Follow-up needed (out of scope for this PR):** the invoice contract crate is currently excluded from `contracts/Cargo.toml`'s workspace `members`, and I confirmed why — attempting to add it surfaces 11 pre-existing compile errors unrelated to TTL (event `publish()` calls passing bare `Symbol` instead of a `Topics`-tuple, an `IntoVal` trait not being in scope, an `id` variable moved into a storage-key tuple then reused, and the invoice ID type stored as `Hash<32>` where the struct field expects `BytesN<32>`). Fixing all of that is a real restructuring of the crate, not a small config change, so I left `contracts/Cargo.toml` untouched and did not add `invoice` to CI's contracts job. The TTL fix and its test are correct by inspection and mirror the account contract's pattern exactly, but **could not be run with `cargo test`** because of this pre-existing breakage — that verification will need to happen once the crate is made to compile (worth its own issue).

**Test plan**
- [x] `cargo test -p ancore-account` — 40/40 passing, unaffected by these changes (sanity check that nothing else in the workspace regressed).
- [x] `cargo clippy -- -D warnings` on the actual workspace (account + validation-modules) — clean.
- [x] YAML syntax validated for `ci.yml` and `security.yml` via `python3 -c "import yaml; yaml.safe_load(open(...))"`.
- [x] `package.json` validated via `python3 -c "import json; json.load(open('package.json'))"`.
- [ ] The CI workflow changes themselves (coverage-gate step, docs:validate-links step, and the new `pull_request` trigger on `security.yml`) cannot be exercised locally — GitHub Actions can't run outside GitHub. This PR itself is the first real test: the `package`/`services` jobs from `ci.yml` and the `security.yml` PR run should be visible in this PR's checks once opened.
- [ ] `cargo test -p ancore-invoice` — not run; the crate does not currently compile for reasons unrelated to this change (see follow-up note above).

Fixes #1132
Fixes #1131
Fixes #1130
Fixes #1129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoices with future due dates now remain readable for longer after creation, payment, or cancellation.
* **Quality Improvements**
  * Automated checks now enforce coverage thresholds for security-sensitive packages.
  * Documentation links are validated during continuous integration.
  * Security checks now also run for pull requests targeting the main development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->