### PR TITLE
ci: add cargo audit to PR CI for contracts and indexer workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,26 @@ jobs:
       - name: Validate pnpm audit allowlist
         run: node scripts/check-audit-allowlist.js
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@1.81.0
+
+      - name: Cache cargo-audit
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: ${{ runner.os }}-cargo-audit-v0.21
+
+      - name: Install cargo-audit
+        run: which cargo-audit || cargo install --locked cargo-audit
+
+      - name: Cargo audit contracts
+        working-directory: ./contracts
+        run: cargo audit
+
+      - name: Cargo audit indexer
+        working-directory: ./services/indexer
+        run: cargo audit
+
   format:
     name: Format Check
     runs-on: ubuntu-latest

--- a/contracts/audit.toml
+++ b/contracts/audit.toml
@@ -1,0 +1,5 @@
+# Cargo Audit configuration for contracts workspace
+# Add triaged advisory IDs to `ignore` to allowlist known false positives.
+
+[advisories]
+ignore = []

--- a/services/indexer/audit.toml
+++ b/services/indexer/audit.toml
@@ -1,0 +1,5 @@
+# Cargo Audit configuration for indexer workspace
+# Add triaged advisory IDs to `ignore` to allowlist known false positives.
+
+[advisories]
+ignore = []


### PR DESCRIPTION
## Summary
Adds cargo audit security scanning for the Rust workspaces (contracts/ and services/indexer/) directly into the PR CI audit job.

## Changes
- Created contracts/audit.toml and services/indexer/audit.toml allowlist configuration files so false positives or triaged advisories can be ignored.
- Added Rust setup, caching, and cargo audit execution steps for both workspaces to .github/workflows/ci.yml.

Closes #1133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Rust dependency vulnerability audits for contracts and indexer components.
  * CI now installs, caches, and runs the audit tooling during validation.
  * Added audit configuration files to support tracking approved advisory exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->