### PR TITLE
ci: pin Rust toolchain consistently to 1.81.0 across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
       - name: Lint indexer migrations
         run: pnpm indexer:lint-migrations
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.81.0
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.81.0
         with:
           components: rustfmt,clippy
           targets: wasm32-unknown-unknown
@@ -136,7 +136,7 @@ jobs:
       - name: npm audit (high+)
         run: pnpm audit --audit-level=high
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.81.0
 
       - name: Install cargo-audit
         run: cargo install --locked cargo-audit

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.81.0"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
## Summary
Standardizes Rust toolchain pinning to 1.81.0 across all GitHub Actions workflows and rust-toolchain.toml.

## Problem
Workflows previously mixed pinned 1.81.0 with @stable. Unpinned @stable could silently change toolchain behavior and break builds.

## Changes
- Set channel = 1.81.0 in root rust-toolchain.toml.
- Updated all dtolnay/rust-toolchain@stable step references in ci.yml and release-gate.yml to dtolnay/rust-toolchain@1.81.0.

Closes #1134