### PR TITLE
feat(monorepo): add dedicated typecheck turbo task and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,26 @@ jobs:
       - name: Check formatting
         run: pnpm format:check
 
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run typecheck
+        run: pnpm typecheck
+
   lint-translations:
     name: Extension Translation Lint
     runs-on: ubuntu-latest

--- a/apps/extension-wallet/package.json
+++ b/apps/extension-wallet/package.json
@@ -20,7 +20,8 @@
     "test:e2e:visual": "playwright test --config=tests/playwright.visual.config.ts",
     "test:e2e:ui": "playwright test --config=tests/playwright.config.ts --ui",
     "analyze": "node scripts/analyze-bundle.js",
-    "check:csp": "node scripts/check-csp.js"
+    "check:csp": "node scripts/check-csp.js",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ancore/account-abstraction": "workspace:*",

--- a/apps/mobile-app/package.json
+++ b/apps/mobile-app/package.json
@@ -10,7 +10,8 @@
     "build:android": "react-native build-android",
     "lint": "eslint src/",
     "test": "jest --config jest.config.cjs",
-    "postinstall": "rn-nodeify --install buffer,crypto,stream,events,process --hack"
+    "postinstall": "rn-nodeify --install buffer,crypto,stream,events,process --hack",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ancore/mobile-wallet": "workspace:*",

--- a/apps/mobile-wallet/package.json
+++ b/apps/mobile-wallet/package.json
@@ -18,7 +18,8 @@
     "test": "jest --config ./jest.config.cjs --coverage --runInBand",
     "lint": "eslint src/",
     "clean": "rm -rf dist coverage",
-    "test:ci": "pnpm run build && pnpm run test"
+    "test:ci": "pnpm run build && pnpm run test",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ancore/core-sdk": "workspace:*",

--- a/apps/web-dashboard/package.json
+++ b/apps/web-dashboard/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ancore/core-sdk": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:ui": "pnpm --filter @ancore/ui-kit run test",
     "test": "turbo run test",
     "lint": "turbo run lint",
-    "typecheck": "turbo run build",
+    "typecheck": "turbo run typecheck",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "clean": "turbo run clean && rm -rf node_modules",

--- a/packages/account-abstraction/package.json
+++ b/packages/account-abstraction/package.json
@@ -10,7 +10,8 @@
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "test": "jest",
     "lint": "eslint src/",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/packages/core-sdk/package.json
+++ b/packages/core-sdk/package.json
@@ -19,7 +19,8 @@
     "check": "tsc -p tsconfig.json --noEmit",
     "test:integration": "jest --testPathPattern=integration --no-coverage",
     "lint": "eslint src/",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -10,7 +10,8 @@
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "test": "jest --coverage --runInBand",
     "lint": "eslint src/",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/packages/stellar/package.json
+++ b/packages/stellar/package.json
@@ -17,7 +17,8 @@
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "test": "node ./node_modules/jest/bin/jest.js --coverage",
     "lint": "eslint src/",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/packages/test-fixtures/package.json
+++ b/packages/test-fixtures/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --tsconfig tsconfig.build.json",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,7 +17,8 @@
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "test": "jest --coverage",
     "lint": "eslint src/",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -22,7 +22,8 @@
     "build-storybook": "storybook build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "verify:theme-tokens": "pnpm --dir ../.. verify:theme-tokens"
+    "verify:theme-tokens": "pnpm --dir ../.. verify:theme-tokens",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/packages/wallet-api/package.json
+++ b/packages/wallet-api/package.json
@@ -17,7 +17,8 @@
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "test": "jest --coverage",
     "lint": "eslint src/",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/packages/wallet-shared/package.json
+++ b/packages/wallet-shared/package.json
@@ -17,7 +17,8 @@
     "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
     "test": "jest --coverage",
     "lint": "eslint src/",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/services/ai-agent/package.json
+++ b/services/ai-agent/package.json
@@ -8,7 +8,8 @@
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
     "test": "jest --coverage",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/services/relayer/package.json
+++ b/services/relayer/package.json
@@ -7,7 +7,8 @@
     "build": "tsc --project tsconfig.json",
     "test": "jest --coverage",
     "lint": "eslint src/",
-    "check:log-redaction": "node scripts/check-log-redaction.js"
+    "check:log-redaction": "node scripts/check-log-redaction.js",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "ancore",

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,10 @@
       "dependsOn": ["^build"],
       "outputs": []
     },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary
Adds a dedicated type-only check task (`tsc --noEmit`) across monorepo packages using Turborepo, updates the root `package.json` `typecheck` script, and introduces a `typecheck` job in CI.

## Problem Statement
Root `package.json` defined `"typecheck": "turbo run build"`, so type checking was only implicit via bundler builds and `pnpm verify` did not run a real type-only check.

## Changes
- Defined `typecheck` task in `turbo.json`.
- Updated root `package.json` `typecheck` script to `"turbo run typecheck"`.
- Added `"typecheck": "tsc --noEmit"` to workspace `package.json` files.
- Added dedicated `typecheck` job to `.github/workflows/ci.yml`.

Closes #1135
