### PR TITLE
fix: retry ceiling, fee-stats NaN guard, missing type guards

### DIFF
--- a/packages/stellar/src/__tests__/fee-stats.test.ts
+++ b/packages/stellar/src/__tests__/fee-stats.test.ts
@@ -180,4 +180,49 @@ describe('fetchFeeStats', () => {
 
     expect(caughtError).toBeInstanceOf(NetworkError);
   });
+
+  // ── Malformed inputs ────────────────────────────────────────────────────
+
+  it('returns fallback when Horizon returns non-numeric fee values', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          fee_charged: { min: 'not-a-number', mode: '250', p90: '1000' },
+        }),
+    });
+
+    const result = await fetchFeeStats({ horizonUrl: HORIZON_URL });
+
+    expect(result.isFallback).toBe(true);
+    expect(result.minFee).toBe(FALLBACK_FEE_STATS.minFee);
+  });
+
+  it('returns fallback when Horizon returns negative fee values', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          fee_charged: { min: '-100', mode: '250', p90: '1000' },
+        }),
+    });
+
+    const result = await fetchFeeStats({ horizonUrl: HORIZON_URL });
+
+    expect(result.isFallback).toBe(true);
+  });
+
+  it('returns fallback when fee values are NaN strings', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          fee_charged: { min: 'NaN', mode: 'NaN', p90: 'NaN' },
+        }),
+    });
+
+    const result = await fetchFeeStats({ horizonUrl: HORIZON_URL });
+
+    expect(result.isFallback).toBe(true);
+  });
 });

--- a/packages/stellar/src/__tests__/retry.test.ts
+++ b/packages/stellar/src/__tests__/retry.test.ts
@@ -36,6 +36,21 @@ describe('retry', () => {
       expect(calculateDelay(2, 500, true)).toBe(1000);
       expect(calculateDelay(3, 500, true)).toBe(2000);
     });
+
+    it('should clamp delay to maxDelayMs', () => {
+      expect(calculateDelay(10, 1000, true, 5000)).toBe(5000);
+      expect(calculateDelay(20, 1000, true, 5000)).toBe(5000);
+    });
+
+    it('should never exceed default 30s ceiling', () => {
+      for (let attempt = 1; attempt <= 20; attempt++) {
+        expect(calculateDelay(attempt, 1000, true)).toBeLessThanOrEqual(30_000);
+      }
+    });
+
+    it('should clamp linear delay to maxDelayMs', () => {
+      expect(calculateDelay(1, 50000, false, 30000)).toBe(30000);
+    });
   });
 
   describe('withRetry', () => {

--- a/packages/stellar/src/fee-stats.ts
+++ b/packages/stellar/src/fee-stats.ts
@@ -93,13 +93,16 @@ async function fetchRaw(horizonUrl: string): Promise<HorizonFeeStats> {
   return response.json() as Promise<HorizonFeeStats>;
 }
 
-function normalize(raw: HorizonFeeStats): FeeStats {
-  return {
-    minFee: parseInt(raw.fee_charged.min, 10),
-    modeFee: parseInt(raw.fee_charged.mode, 10),
-    p90Fee: parseInt(raw.fee_charged.p90, 10),
-    isFallback: false,
-  };
+function normalize(raw: HorizonFeeStats): FeeStats | null {
+  const minFee = parseInt(raw.fee_charged.min, 10);
+  const modeFee = parseInt(raw.fee_charged.mode, 10);
+  const p90Fee = parseInt(raw.fee_charged.p90, 10);
+
+  if (!Number.isFinite(minFee) || minFee < 0) return null;
+  if (!Number.isFinite(modeFee) || modeFee < 0) return null;
+  if (!Number.isFinite(p90Fee) || p90Fee < 0) return null;
+
+  return { minFee, modeFee, p90Fee, isFallback: false };
 }
 
 /**
@@ -133,7 +136,9 @@ export async function fetchFeeStats(options: FeeStatsOptions): Promise<FeeStats>
       isRetryable: retryOptions.isRetryable ?? defaultIsRetryable,
     });
 
-    return normalize(raw);
+    const normalized = normalize(raw);
+    if (normalized) return normalized;
+    return { ...fallback, isFallback: true };
   } catch {
     return { ...fallback, isFallback: true };
   }

--- a/packages/stellar/src/retry.ts
+++ b/packages/stellar/src/retry.ts
@@ -9,6 +9,8 @@ export interface RetryOptions {
   maxRetries?: number;
   /** Base delay in milliseconds (default: 1000) */
   baseDelayMs?: number;
+  /** Maximum delay in milliseconds (default: 30000) */
+  maxDelayMs?: number;
   /** Whether to use exponential backoff (default: true) */
   exponential?: boolean;
   /** Optional function to determine if error is retryable */
@@ -38,6 +40,7 @@ export type RetryPresetName = keyof typeof RETRY_PRESETS;
 const DEFAULT_OPTIONS: Required<Omit<RetryOptions, 'isRetryable'>> = {
   maxRetries: 3,
   baseDelayMs: 1000,
+  maxDelayMs: 30_000,
   exponential: true,
 };
 
@@ -68,16 +71,18 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 /**
  * Calculate delay for a given attempt using exponential backoff
  * Attempt 1: 1s, Attempt 2: 2s, Attempt 3: 4s
+ * Delay is clamped to maxDelayMs (default: 30s)
  */
 export const calculateDelay = (
   attempt: number,
   baseDelayMs: number,
-  exponential: boolean
+  exponential: boolean,
+  maxDelayMs: number = 30_000
 ): number => {
   if (!exponential) {
-    return baseDelayMs;
+    return Math.min(baseDelayMs, maxDelayMs);
   }
-  return baseDelayMs * Math.pow(2, attempt - 1);
+  return Math.min(baseDelayMs * Math.pow(2, attempt - 1), maxDelayMs);
 };
 
 /**
@@ -97,7 +102,7 @@ export const calculateDelay = (
  * ```
  */
 export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
-  const { maxRetries, baseDelayMs, exponential } = {
+  const { maxRetries, baseDelayMs, maxDelayMs, exponential } = {
     ...DEFAULT_OPTIONS,
     ...options,
   };
@@ -122,7 +127,7 @@ export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions =
       }
 
       // Calculate and wait for delay before next attempt
-      const delay = calculateDelay(attempt, baseDelayMs, exponential);
+      const delay = calculateDelay(attempt, baseDelayMs, exponential, maxDelayMs);
       await sleep(delay);
     }
   }

--- a/packages/types/src/__tests__/guards.test.ts
+++ b/packages/types/src/__tests__/guards.test.ts
@@ -1,4 +1,13 @@
-import { isSmartAccount, isSessionKey, isValidPermission } from '../guards';
+import {
+  isSmartAccount,
+  isSessionKey,
+  isValidPermission,
+  isInvoice,
+  isTransferPolicy,
+  isScheduledTransfer,
+  isSessionKeyPolicy,
+  isStatementRow,
+} from '../guards';
 
 describe('guards', () => {
   test('isSmartAccount returns true for valid object', () => {
@@ -26,5 +35,105 @@ describe('guards', () => {
     expect(isValidPermission(2)).toBe(true);
     expect(isValidPermission(99)).toBe(false);
     expect(isValidPermission('x')).toBe(false);
+  });
+
+  // ── Invoice ─────────────────────────────────────────────────────────────
+
+  test('isInvoice returns true for valid invoice', () => {
+    const invoice = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      accountAddress: 'G'.padEnd(56, 'A'),
+      recipientAddress: 'G'.padEnd(56, 'B'),
+      amount: '100',
+      asset: 'XLM',
+      status: 'open',
+      createdAt: '2025-01-01T00:00:00Z',
+      updatedAt: '2025-01-01T00:00:00Z',
+    };
+    expect(isInvoice(invoice)).toBe(true);
+  });
+
+  test('isInvoice returns false for invalid invoice', () => {
+    expect(isInvoice(null)).toBe(false);
+    expect(isInvoice({})).toBe(false);
+    expect(isInvoice({ id: 123 })).toBe(false);
+  });
+
+  // ── TransferPolicy ──────────────────────────────────────────────────────
+
+  test('isTransferPolicy returns true for valid policy', () => {
+    expect(isTransferPolicy({ dailyLimit: 1000, stepUpThreshold: 250 })).toBe(true);
+  });
+
+  test('isTransferPolicy returns false for invalid policy', () => {
+    expect(isTransferPolicy(null)).toBe(false);
+    expect(isTransferPolicy({ dailyLimit: -1, stepUpThreshold: 250 })).toBe(false);
+    expect(isTransferPolicy({ dailyLimit: 100 })).toBe(false);
+  });
+
+  // ── ScheduledTransfer ───────────────────────────────────────────────────
+
+  test('isScheduledTransfer returns true for valid transfer', () => {
+    const transfer = {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      accountId: 'G'.padEnd(56, 'A'),
+      callerId: 'caller1',
+      to: 'G'.padEnd(56, 'B'),
+      amount: '50',
+      asset: 'XLM',
+      frequency: 'daily',
+      status: 'active',
+      startAt: '2025-06-01T00:00:00Z',
+      nextRunAt: '2025-06-02T00:00:00Z',
+      userApprovedAt: '2025-05-30T00:00:00Z',
+      relayPayload: {
+        sessionKey: 'a'.repeat(64),
+        operation: 'relay_execute',
+        parameters: {},
+        signature: 'b'.repeat(128),
+        nonce: 0,
+      },
+      consecutiveFailures: 0,
+      createdAt: '2025-05-30T00:00:00Z',
+      updatedAt: '2025-05-30T00:00:00Z',
+    };
+    expect(isScheduledTransfer(transfer)).toBe(true);
+  });
+
+  test('isScheduledTransfer returns false for invalid transfer', () => {
+    expect(isScheduledTransfer(null)).toBe(false);
+    expect(isScheduledTransfer({})).toBe(false);
+  });
+
+  // ── SessionKeyPolicy ────────────────────────────────────────────────────
+
+  test('isSessionKeyPolicy returns true for valid policy', () => {
+    expect(isSessionKeyPolicy({ expiresAt: Date.now() + 86400000, permissions: 0b111 })).toBe(true);
+  });
+
+  test('isSessionKeyPolicy returns false for invalid policy', () => {
+    expect(isSessionKeyPolicy(null)).toBe(false);
+    expect(isSessionKeyPolicy({ expiresAt: -1, permissions: 0 })).toBe(false);
+    expect(isSessionKeyPolicy({ permissions: 0 })).toBe(false);
+  });
+
+  // ── StatementRow ────────────────────────────────────────────────────────
+
+  test('isStatementRow returns true for valid row', () => {
+    const row = {
+      id: 'tx1',
+      date: '2025-01-01',
+      type: 'payment',
+      amount: '100',
+      asset: 'XLM',
+      status: 'completed',
+    };
+    expect(isStatementRow(row)).toBe(true);
+  });
+
+  test('isStatementRow returns false for invalid row', () => {
+    expect(isStatementRow(null)).toBe(false);
+    expect(isStatementRow({})).toBe(false);
+    expect(isStatementRow({ id: 'tx1', status: 'bogus' })).toBe(false);
   });
 });

--- a/packages/types/src/guards.ts
+++ b/packages/types/src/guards.ts
@@ -6,6 +6,11 @@ import { SmartAccount } from './smart-account';
 import { SessionKey } from './session-key';
 import { UserOperation, TransactionResult } from './user-operation';
 import { WalletState } from './wallet';
+import { Invoice, InvoiceSchema } from './invoice';
+import { TransferPolicy, TransferPolicySchema } from './transfer-policy';
+import { ScheduledTransfer, ScheduledTransferSchema } from './scheduled-transfer';
+import { SessionKeyPolicy, SessionKeyPolicySchema } from './session-key-policy';
+import { StatementRow } from './statement';
 
 export function isSmartAccount(value: unknown): value is SmartAccount {
   if (typeof value !== 'object' || value === null) return false;
@@ -68,4 +73,50 @@ export function isTransactionResult(value: unknown): value is TransactionResult 
  */
 export function isWalletState(value: unknown): value is WalletState {
   return typeof value === 'string' && ['uninitialized', 'locked', 'unlocked'].includes(value);
+}
+
+/**
+ * Type guard for Invoice.
+ */
+export function isInvoice(value: unknown): value is Invoice {
+  return InvoiceSchema.safeParse(value).success;
+}
+
+/**
+ * Type guard for TransferPolicy.
+ */
+export function isTransferPolicy(value: unknown): value is TransferPolicy {
+  return TransferPolicySchema.safeParse(value).success;
+}
+
+/**
+ * Type guard for ScheduledTransfer.
+ */
+export function isScheduledTransfer(value: unknown): value is ScheduledTransfer {
+  return ScheduledTransferSchema.safeParse(value).success;
+}
+
+/**
+ * Type guard for SessionKeyPolicy.
+ */
+export function isSessionKeyPolicy(value: unknown): value is SessionKeyPolicy {
+  return SessionKeyPolicySchema.safeParse(value).success;
+}
+
+/**
+ * Type guard for StatementRow.
+ * StatementRow has no Zod schema, so we check the shape manually.
+ */
+export function isStatementRow(value: unknown): value is StatementRow {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    typeof v.date === 'string' &&
+    typeof v.type === 'string' &&
+    typeof v.amount === 'string' &&
+    typeof v.asset === 'string' &&
+    typeof v.status === 'string' &&
+    ['completed', 'pending', 'failed', 'unknown'].includes(v.status as string)
+  );
 }


### PR DESCRIPTION
three small fixes in one PR:

1. retry calculateDelay now has a maxDelayMs ceiling (default 30s) so exponential backoff cant overflow with large attempt counts
2. fee-stats normalize returns fallback instead of NaN when horizon returns non-numeric or negative fee values
3. added type guards for Invoice, TransferPolicy, ScheduledTransfer, SessionKeyPolicy, and StatementRow

fixes #1137
fixes #1138
fixes #1139
fixes #1141 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum delays for retry attempts, with a default cap of 30 seconds.
  * Added validation helpers for invoices, transfer policies, scheduled transfers, session key policies, and statement rows.

* **Bug Fixes**
  * Invalid or malformed fee data now safely falls back to reliable default fee statistics instead of being used.

* **Tests**
  * Expanded coverage for fee validation, retry delay limits, and data shape validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->