### PR TITLE
feat(ai-agent): production LLM provider integration with guardrails and audit logging

### DIFF
--- a/apps/extension-wallet/src/hooks/__tests__/useAgentDraftIntent.test.ts
+++ b/apps/extension-wallet/src/hooks/__tests__/useAgentDraftIntent.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAgentDraftIntent } from '../useAgentDraftIntent';
+
+function fakeFetch(body: unknown, ok = true, status = 200): typeof fetch {
+  return vi
+    .fn()
+    .mockResolvedValue({ ok, status, json: async () => body }) as unknown as typeof fetch;
+}
+
+const draftResponse = {
+  status: 'draft' as const,
+  requiresConfirmation: true as const,
+  summary: 'Drafted payment intent',
+  intent: { type: 'payment' as const, destination: 'GDEST', amount: '10', asset: 'XLM' },
+  risk: { level: 'low' as const, reasons: [] },
+  source: 'deterministic' as const,
+};
+
+describe('useAgentDraftIntent', () => {
+  it('starts idle', () => {
+    const { result } = renderHook(() =>
+      useAgentDraftIntent({ accountId: 'GACC', fetcher: fakeFetch(draftResponse) })
+    );
+    expect(result.current.status).toBe('idle');
+    expect(result.current.draft).toBeNull();
+  });
+
+  it('transitions to ready with the draft on success', async () => {
+    const fetcher = fakeFetch(draftResponse);
+    const { result } = renderHook(() => useAgentDraftIntent({ accountId: 'GACC', fetcher }));
+
+    await act(async () => {
+      await result.current.submitPrompt('Send 10 XLM to Alice');
+    });
+
+    expect(result.current.status).toBe('ready');
+    expect(result.current.draft).toEqual(draftResponse);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not call the network for an empty prompt', async () => {
+    const fetcher = fakeFetch(draftResponse);
+    const { result } = renderHook(() => useAgentDraftIntent({ accountId: 'GACC', fetcher }));
+
+    await act(async () => {
+      await result.current.submitPrompt('   ');
+    });
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(result.current.status).toBe('error');
+    expect(result.current.draft).toBeNull();
+  });
+
+  it('transitions to error state when the request fails', async () => {
+    const fetcher = fakeFetch({ error: 'boom' }, false, 500);
+    const { result } = renderHook(() => useAgentDraftIntent({ accountId: 'GACC', fetcher }));
+
+    await act(async () => {
+      await result.current.submitPrompt('Send 10 XLM to Alice');
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe('boom');
+    expect(result.current.draft).toBeNull();
+  });
+
+  it('confirm() returns the draft without making any further network call', async () => {
+    const fetcher = fakeFetch(draftResponse);
+    const { result } = renderHook(() => useAgentDraftIntent({ accountId: 'GACC', fetcher }));
+
+    await act(async () => {
+      await result.current.submitPrompt('Send 10 XLM to Alice');
+    });
+
+    let confirmed;
+    act(() => {
+      confirmed = result.current.confirm();
+    });
+
+    expect(confirmed).toEqual(draftResponse);
+    // Only the original draft-intent POST — confirm() never calls fetch itself.
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('reject() clears the draft and returns to idle', async () => {
+    const fetcher = fakeFetch(draftResponse);
+    const { result } = renderHook(() => useAgentDraftIntent({ accountId: 'GACC', fetcher }));
+
+    await act(async () => {
+      await result.current.submitPrompt('Send 10 XLM to Alice');
+    });
+    expect(result.current.draft).not.toBeNull();
+
+    act(() => {
+      result.current.reject();
+    });
+
+    expect(result.current.draft).toBeNull();
+    expect(result.current.status).toBe('idle');
+  });
+});

--- a/apps/extension-wallet/src/hooks/useAgentDraftIntent.ts
+++ b/apps/extension-wallet/src/hooks/useAgentDraftIntent.ts
@@ -1,0 +1,69 @@
+import { useCallback, useState } from 'react';
+import {
+  createAiAgentClient,
+  type AgentDraftIntentResponse,
+  type AiAgentClientOptions,
+} from '@/services/ai-agent-client';
+
+export type AgentDraftStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface UseAgentDraftIntentOptions extends AiAgentClientOptions {
+  accountId: string;
+}
+
+/**
+ * Drives the natural-language "draft with AI" flow: submit a prompt, receive
+ * a draft intent, and require an explicit confirm or reject before anything
+ * else happens.
+ *
+ * GUARDRAIL: this hook never submits a transaction. `confirm()` only marks
+ * the draft accepted and returns it to the caller — the caller is
+ * responsible for routing the accepted draft through the normal
+ * review → confirm → sign flow. There is no code path here that reaches the
+ * network beyond the draft-intent request itself.
+ */
+export function useAgentDraftIntent({ accountId, endpoint, fetcher }: UseAgentDraftIntentOptions) {
+  const [status, setStatus] = useState<AgentDraftStatus>('idle');
+  const [draft, setDraft] = useState<AgentDraftIntentResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const client = createAiAgentClient({ endpoint, fetcher });
+
+  const submitPrompt = useCallback(
+    async (prompt: string) => {
+      const trimmed = prompt.trim();
+      if (!trimmed) {
+        setError('Enter a description of what you want to do.');
+        setStatus('error');
+        return;
+      }
+
+      setStatus('loading');
+      setError(null);
+      setDraft(null);
+
+      try {
+        const result = await client.draftIntent({ prompt: trimmed, accountId });
+        setDraft(result);
+        setStatus('ready');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to draft intent.');
+        setStatus('error');
+      }
+    },
+    [accountId, client]
+  );
+
+  /** Accepts the draft and hands it back to the caller. Never submits on-chain. */
+  const confirm = useCallback((): AgentDraftIntentResponse | null => {
+    return draft;
+  }, [draft]);
+
+  const reject = useCallback(() => {
+    setDraft(null);
+    setStatus('idle');
+    setError(null);
+  }, []);
+
+  return { status, draft, error, submitPrompt, confirm, reject };
+}

--- a/apps/extension-wallet/src/screens/Send/AiDraftPanel.tsx
+++ b/apps/extension-wallet/src/screens/Send/AiDraftPanel.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react';
+import { Button, Card, CardContent, CardHeader, CardTitle, cn } from '@ancore/ui-kit';
+import { Sparkles, AlertTriangle, X } from 'lucide-react';
+import { useAgentDraftIntent } from '@/hooks/useAgentDraftIntent';
+import type { AgentDraftIntent, AgentRiskLevel } from '@/services/ai-agent-client';
+
+interface AiDraftPanelProps {
+  accountId: string;
+  /** Called only when the user explicitly confirms the draft. Never called automatically. */
+  onAccept: (intent: AgentDraftIntent) => void;
+  onClose?: () => void;
+  endpoint?: string;
+  fetcher?: typeof fetch;
+}
+
+const RISK_STYLES: Record<AgentRiskLevel, string> = {
+  low: 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20',
+  medium: 'text-amber-300 bg-amber-500/10 border-amber-500/20',
+  high: 'text-red-300 bg-red-500/10 border-red-500/20',
+};
+
+function intentAmountLabel(intent: AgentDraftIntent): string {
+  return `${intent.amount} ${intent.asset}`;
+}
+
+function intentTargetLabel(intent: AgentDraftIntent): string {
+  return intent.type === 'payment' ? intent.destination : intent.recipient;
+}
+
+function intentTargetField(intent: AgentDraftIntent): string {
+  return intent.type === 'payment' ? 'Destination' : 'Recipient';
+}
+
+/**
+ * AiDraftPanel — natural-language "draft with AI" entry point for Send.
+ *
+ * Flow: type a request → call /agent/draft-intent → show the draft (type,
+ * amount, asset, destination/recipient, risk, summary) → the user explicitly
+ * confirms or rejects. Confirming only hands the drafted intent back to the
+ * parent (`onAccept`) so it can prefill the normal send form — this
+ * component never signs or submits a transaction itself.
+ */
+export function AiDraftPanel({
+  accountId,
+  onAccept,
+  onClose,
+  endpoint,
+  fetcher,
+}: AiDraftPanelProps) {
+  const [prompt, setPrompt] = useState('');
+  const { status, draft, error, submitPrompt, confirm, reject } = useAgentDraftIntent({
+    accountId,
+    endpoint,
+    fetcher,
+  });
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    void submitPrompt(prompt);
+  };
+
+  const handleConfirm = () => {
+    const accepted = confirm();
+    if (accepted) {
+      onAccept(accepted.intent);
+    }
+  };
+
+  const handleReject = () => {
+    reject();
+    setPrompt('');
+  };
+
+  return (
+    <Card className="wallet-card border-white/10 bg-white/[0.03]" data-testid="ai-draft-panel">
+      <CardHeader className="flex flex-row items-center justify-between gap-2 pb-2">
+        <CardTitle className="flex items-center gap-2 text-[14px] font-semibold text-foreground">
+          <Sparkles className="h-4 w-4 text-teal-300" aria-hidden />
+          Draft with AI
+        </CardTitle>
+        {onClose && (
+          <button
+            type="button"
+            aria-label="Close AI draft"
+            onClick={onClose}
+            className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-white/10 hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-[12px] leading-relaxed text-muted-foreground">
+          Describe what you want to do — e.g. &quot;Send 10 XLM to Alice&quot; or &quot;Invoice Bob
+          for 25 USDC&quot;. Nothing is sent until you review and confirm.
+        </p>
+
+        {!draft && (
+          <form onSubmit={handleSubmit} className="space-y-2">
+            <textarea
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder="Send 10 XLM to Alice"
+              rows={2}
+              maxLength={2000}
+              aria-label="Describe what you want to do"
+              className="w-full resize-none rounded-xl border border-white/10 bg-white/5 p-3 text-[13px] text-foreground placeholder:text-muted-foreground focus:border-teal-400/50 focus:outline-none"
+            />
+            {error && (
+              <p className="flex items-center gap-1.5 text-[12px] text-red-400" role="alert">
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                {error}
+              </p>
+            )}
+            <Button
+              type="submit"
+              disabled={status === 'loading' || prompt.trim().length === 0}
+              className={cn('w-full')}
+            >
+              {status === 'loading' ? 'Drafting…' : 'Draft intent'}
+            </Button>
+          </form>
+        )}
+
+        {draft && (
+          <div className="space-y-3" data-testid="ai-draft-result">
+            <div className="rounded-xl border border-white/10 bg-white/5 p-3 text-[13px]">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Type</span>
+                <span className="font-medium capitalize text-foreground">{draft.intent.type}</span>
+              </div>
+              <div className="mt-1.5 flex items-center justify-between">
+                <span className="text-muted-foreground">Amount</span>
+                <span className="font-medium text-foreground">
+                  {intentAmountLabel(draft.intent)}
+                </span>
+              </div>
+              <div className="mt-1.5 flex items-center justify-between gap-2">
+                <span className="shrink-0 text-muted-foreground">
+                  {intentTargetField(draft.intent)}
+                </span>
+                <span
+                  className="truncate font-medium text-foreground"
+                  title={intentTargetLabel(draft.intent)}
+                >
+                  {intentTargetLabel(draft.intent)}
+                </span>
+              </div>
+              <div className="mt-2 flex items-center justify-between">
+                <span className="text-muted-foreground">Risk</span>
+                <span
+                  className={cn(
+                    'rounded-full border px-2 py-0.5 text-[11px] font-medium uppercase',
+                    RISK_STYLES[draft.risk.level]
+                  )}
+                  data-testid="ai-draft-risk-badge"
+                >
+                  {draft.risk.level}
+                </span>
+              </div>
+              {draft.risk.reasons.length > 0 && (
+                <ul className="mt-2 space-y-1 text-[11px] text-amber-200/80">
+                  {draft.risk.reasons.map((reason) => (
+                    <li key={reason}>• {reason}</li>
+                  ))}
+                </ul>
+              )}
+              <p className="mt-2 text-[12px] text-muted-foreground">{draft.summary}</p>
+            </div>
+
+            <p className="text-[11px] text-muted-foreground">
+              This is a draft only — nothing has been sent. Confirm to review it in the normal send
+              flow, or reject to start over.
+            </p>
+
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" className="flex-1" onClick={handleReject}>
+                Reject
+              </Button>
+              <Button type="button" className="flex-1" onClick={handleConfirm}>
+                Confirm draft
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/extension-wallet/src/screens/Send/SendScreen.tsx
+++ b/apps/extension-wallet/src/screens/Send/SendScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { isMemoRequired } from '@/utils/memoCheck';
 import { AddressInput, cn } from '@ancore/ui-kit';
 import { BASE_SEND_RESERVE, DEFAULT_SEND_FEE } from '@/utils/amount';
@@ -8,11 +8,15 @@ import {
   type SendService,
 } from '@/hooks/useSendTransaction';
 import { useRecentRecipients } from '@/hooks/useRecentRecipients';
+import { useAccountStore } from '@/stores/account';
+import { DEMO_ACCOUNT_ADDRESS } from '@/services/scheduler-client';
 import { ConfirmDialog } from '@/screens/Send/ConfirmDialog';
 import { ReviewScreen } from '@/screens/Send/ReviewScreen';
 import { StatusScreen } from '@/screens/Send/StatusScreen';
+import { AiDraftPanel } from '@/screens/Send/AiDraftPanel';
+import type { AgentDraftIntent } from '@/services/ai-agent-client';
 import { TransferNoteInput } from '@/components/TransferNoteInput';
-import { AlertCircle, ArrowLeftRight, Delete } from 'lucide-react';
+import { AlertCircle, ArrowLeftRight, Delete, Sparkles } from 'lucide-react';
 import {
   ScheduleControls,
   createDefaultScheduleConfig,
@@ -52,6 +56,28 @@ export function SendScreen({
   const send = useSendTransaction({ balance, assetDecimals, service, pollIntervalMs });
   const { recipients, addRecipient } = useRecentRecipients();
   const [memoWarning, setMemoWarning] = useState<string | null>(null);
+  const [showAiDraft, setShowAiDraft] = useState(false);
+
+  const activeAccountId = useAccountStore((state) => state.activeAccountId);
+  const accounts = useAccountStore((state) => state.accounts);
+  const accountAddress = useMemo(
+    () => accounts.find((a) => a.id === activeAccountId)?.address ?? DEMO_ACCOUNT_ADDRESS,
+    [accounts, activeAccountId]
+  );
+
+  /**
+   * Accepts an AI-drafted intent and prefills the form for the user to
+   * review. GUARDRAIL: this only sets local form state — it does not touch
+   * `send.tx`, does not call `send.goToReview`, and does not submit
+   * anything. The user still has to go through Continue → Review → Confirm
+   * → Sign like any other send.
+   */
+  const handleAiDraftAccept = (intent: AgentDraftIntent) => {
+    if (intent.type === 'payment') {
+      setForm((current) => ({ ...current, to: intent.destination, amount: intent.amount }));
+    }
+    setShowAiDraft(false);
+  };
 
   const isMainnet = send.tx?.fee?.network === 'mainnet' || !send.tx;
 
@@ -143,11 +169,27 @@ export function SendScreen({
 
   return (
     <div className="wallet-sheet">
-      <header className="wallet-header">
+      <header className="wallet-header flex items-center justify-between">
         <h1 className="wallet-title">Send</h1>
+        <button
+          type="button"
+          onClick={() => setShowAiDraft((current) => !current)}
+          className="flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:bg-white/15"
+        >
+          <Sparkles className="h-3.5 w-3.5 text-teal-300" aria-hidden />
+          {showAiDraft ? 'Manual form' : 'Draft with AI'}
+        </button>
       </header>
 
       <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-5 pb-6">
+        {showAiDraft && (
+          <AiDraftPanel
+            accountId={accountAddress}
+            onAccept={handleAiDraftAccept}
+            onClose={() => setShowAiDraft(false)}
+          />
+        )}
+
         {/* Source asset card */}
         <div className="wallet-card space-y-5">
           <div className="flex items-center justify-between gap-3">

--- a/apps/extension-wallet/src/screens/Send/__tests__/AiDraftPanel.test.tsx
+++ b/apps/extension-wallet/src/screens/Send/__tests__/AiDraftPanel.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AiDraftPanel } from '../AiDraftPanel';
+
+function fakeFetch(body: unknown, ok = true, status = 200): typeof fetch {
+  return vi
+    .fn()
+    .mockResolvedValue({ ok, status, json: async () => body }) as unknown as typeof fetch;
+}
+
+const paymentDraft = {
+  status: 'draft',
+  requiresConfirmation: true,
+  summary: 'Drafted payment intent',
+  intent: { type: 'payment', destination: 'GDEST123', amount: '10', asset: 'XLM' },
+  risk: { level: 'low', reasons: [] },
+  source: 'deterministic',
+};
+
+const highRiskInvoiceDraft = {
+  status: 'draft',
+  requiresConfirmation: true,
+  summary: 'Drafted invoice intent',
+  intent: {
+    type: 'invoice',
+    recipient: 'Alice',
+    amount: '50000',
+    asset: 'XLM',
+    dueDate: '2026-12-31',
+  },
+  risk: { level: 'high', reasons: ['High-value transfer: 50000 XLM exceeds 10000'] },
+  source: 'llm',
+};
+
+describe('AiDraftPanel', () => {
+  it('renders the prompt form and never calls fetch before submission', () => {
+    const fetcher = fakeFetch(paymentDraft);
+    render(<AiDraftPanel accountId="GACC" onAccept={vi.fn()} fetcher={fetcher} />);
+
+    expect(screen.getByLabelText(/describe what you want to do/i)).toBeInTheDocument();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('shows the draft with type, amount, destination, risk, and summary after submitting', async () => {
+    const user = userEvent.setup();
+    const fetcher = fakeFetch(paymentDraft);
+    render(<AiDraftPanel accountId="GACC" onAccept={vi.fn()} fetcher={fetcher} />);
+
+    await user.type(screen.getByLabelText(/describe what you want to do/i), 'Send 10 XLM to Alice');
+    await user.click(screen.getByRole('button', { name: /draft intent/i }));
+
+    await waitFor(() => expect(screen.getByTestId('ai-draft-result')).toBeInTheDocument());
+
+    expect(screen.getByText('payment')).toBeInTheDocument();
+    expect(screen.getByText('10 XLM')).toBeInTheDocument();
+    expect(screen.getByText('GDEST123')).toBeInTheDocument();
+    expect(screen.getByTestId('ai-draft-risk-badge')).toHaveTextContent('low');
+    expect(screen.getByText('Drafted payment intent')).toBeInTheDocument();
+  });
+
+  it('calls onAccept with the intent only when the user clicks Confirm draft', async () => {
+    const user = userEvent.setup();
+    const fetcher = fakeFetch(paymentDraft);
+    const onAccept = vi.fn();
+    render(<AiDraftPanel accountId="GACC" onAccept={onAccept} fetcher={fetcher} />);
+
+    await user.type(screen.getByLabelText(/describe what you want to do/i), 'Send 10 XLM to Alice');
+    await user.click(screen.getByRole('button', { name: /draft intent/i }));
+    await waitFor(() => expect(screen.getByTestId('ai-draft-result')).toBeInTheDocument());
+
+    expect(onAccept).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /confirm draft/i }));
+
+    expect(onAccept).toHaveBeenCalledTimes(1);
+    expect(onAccept).toHaveBeenCalledWith(paymentDraft.intent);
+  });
+
+  it('does not call onAccept when the user rejects the draft, and clears the form', async () => {
+    const user = userEvent.setup();
+    const fetcher = fakeFetch(paymentDraft);
+    const onAccept = vi.fn();
+    render(<AiDraftPanel accountId="GACC" onAccept={onAccept} fetcher={fetcher} />);
+
+    await user.type(screen.getByLabelText(/describe what you want to do/i), 'Send 10 XLM to Alice');
+    await user.click(screen.getByRole('button', { name: /draft intent/i }));
+    await waitFor(() => expect(screen.getByTestId('ai-draft-result')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /reject/i }));
+
+    expect(onAccept).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('ai-draft-result')).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/describe what you want to do/i)).toHaveValue('');
+  });
+
+  it('renders high-risk invoice drafts with the risk reasons and recipient field', async () => {
+    const user = userEvent.setup();
+    const fetcher = fakeFetch(highRiskInvoiceDraft);
+    render(<AiDraftPanel accountId="GACC" onAccept={vi.fn()} fetcher={fetcher} />);
+
+    await user.type(
+      screen.getByLabelText(/describe what you want to do/i),
+      'Invoice Alice for 50000 XLM'
+    );
+    await user.click(screen.getByRole('button', { name: /draft intent/i }));
+    await waitFor(() => expect(screen.getByTestId('ai-draft-result')).toBeInTheDocument());
+
+    expect(screen.getByText('invoice')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByTestId('ai-draft-risk-badge')).toHaveTextContent('high');
+    expect(screen.getByText(/High-value transfer/)).toBeInTheDocument();
+  });
+
+  it('shows an error message and never renders a draft when the request fails', async () => {
+    const user = userEvent.setup();
+    const fetcher = fakeFetch({ error: 'Too many draft-intent requests.' }, false, 429);
+    render(<AiDraftPanel accountId="GACC" onAccept={vi.fn()} fetcher={fetcher} />);
+
+    await user.type(screen.getByLabelText(/describe what you want to do/i), 'Send 10 XLM to Alice');
+    await user.click(screen.getByRole('button', { name: /draft intent/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText('Too many draft-intent requests.')).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('ai-draft-result')).not.toBeInTheDocument();
+  });
+});

--- a/apps/extension-wallet/src/services/__tests__/ai-agent-client.test.ts
+++ b/apps/extension-wallet/src/services/__tests__/ai-agent-client.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AiAgentRequestError, createAiAgentClient } from '../ai-agent-client';
+
+function fakeFetch(body: unknown, ok = true, status = 200): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => body,
+  }) as unknown as typeof fetch;
+}
+
+describe('createAiAgentClient', () => {
+  it('posts to /agent/draft-intent and returns the parsed draft', async () => {
+    const responseBody = {
+      status: 'draft',
+      requiresConfirmation: true,
+      summary: 'Drafted payment intent',
+      intent: { type: 'payment', destination: 'GDEST', amount: '10', asset: 'XLM' },
+      risk: { level: 'low', reasons: [] },
+      source: 'deterministic',
+    };
+    const fetcher = fakeFetch(responseBody);
+
+    const client = createAiAgentClient({ endpoint: 'http://localhost:3001', fetcher });
+    const result = await client.draftIntent({ prompt: 'Send 10 XLM to Alice', accountId: 'GACC' });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:3001/agent/draft-intent',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'Send 10 XLM to Alice', accountId: 'GACC' }),
+      })
+    );
+    expect(result).toEqual(responseBody);
+  });
+
+  it('strips a trailing slash from the endpoint', async () => {
+    const fetcher = fakeFetch({
+      status: 'draft',
+      requiresConfirmation: true,
+      summary: 's',
+      intent: { type: 'payment', destination: 'G', amount: '1', asset: 'XLM' },
+      risk: { level: 'low', reasons: [] },
+    });
+    const client = createAiAgentClient({ endpoint: 'http://localhost:3001/', fetcher });
+    await client.draftIntent({ prompt: 'x', accountId: 'GACC' });
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://localhost:3001/agent/draft-intent',
+      expect.anything()
+    );
+  });
+
+  it('throws AiAgentRequestError with the server error message on non-ok response', async () => {
+    const fetcher = fakeFetch({ error: 'Too many draft-intent requests.' }, false, 429);
+    const client = createAiAgentClient({ endpoint: 'http://localhost:3001', fetcher });
+
+    await expect(client.draftIntent({ prompt: 'x', accountId: 'GACC' })).rejects.toThrow(
+      AiAgentRequestError
+    );
+    await expect(client.draftIntent({ prompt: 'x', accountId: 'GACC' })).rejects.toThrow(
+      'Too many draft-intent requests.'
+    );
+  });
+
+  it('rejects a response that is not an explicit confirmation-required draft', async () => {
+    const fetcher = fakeFetch({
+      status: 'executed',
+      requiresConfirmation: false,
+      summary: 's',
+      intent: { type: 'payment', destination: 'G', amount: '1', asset: 'XLM' },
+      risk: { level: 'low', reasons: [] },
+    });
+    const client = createAiAgentClient({ endpoint: 'http://localhost:3001', fetcher });
+
+    await expect(client.draftIntent({ prompt: 'x', accountId: 'GACC' })).rejects.toThrow(
+      /non-draft/i
+    );
+  });
+});

--- a/apps/extension-wallet/src/services/ai-agent-client.ts
+++ b/apps/extension-wallet/src/services/ai-agent-client.ts
@@ -1,0 +1,116 @@
+/**
+ * Client for the ai-agent service's /agent/draft-intent endpoint (issue #1005).
+ *
+ * IMPORTANT: this client only ever *drafts* an intent — it never signs or
+ * submits anything on-chain. The response is always a draft that requires
+ * explicit user confirmation; see useAgentDraftIntent for the confirm/reject
+ * flow that consumes it.
+ */
+
+export type AgentDraftIntentType = 'payment' | 'invoice';
+
+export interface AgentDraftPaymentIntent {
+  type: 'payment';
+  destination: string;
+  amount: string;
+  asset: string;
+}
+
+export interface AgentDraftInvoiceIntent {
+  type: 'invoice';
+  recipient: string;
+  amount: string;
+  asset: string;
+  dueDate: string;
+}
+
+export type AgentDraftIntent = AgentDraftPaymentIntent | AgentDraftInvoiceIntent;
+
+export type AgentRiskLevel = 'low' | 'medium' | 'high';
+
+export interface AgentRiskScore {
+  level: AgentRiskLevel;
+  reasons: string[];
+}
+
+export type AgentDraftSource = 'llm' | 'deterministic';
+
+export interface AgentDraftIntentResponse {
+  status: 'draft';
+  requiresConfirmation: true;
+  summary: string;
+  intent: AgentDraftIntent;
+  risk: AgentRiskScore;
+  source?: AgentDraftSource;
+}
+
+export interface AiAgentClientOptions {
+  endpoint?: string;
+  fetcher?: typeof fetch;
+}
+
+export class AiAgentRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number
+  ) {
+    super(message);
+    this.name = 'AiAgentRequestError';
+  }
+}
+
+function resolveDefaultEndpoint(): string {
+  const configured =
+    typeof import.meta !== 'undefined' ? import.meta.env?.VITE_AI_AGENT_URL : undefined;
+  return configured ?? 'http://localhost:3001';
+}
+
+/**
+ * Creates a client for the ai-agent service. `fetcher` is injectable for
+ * tests; `endpoint` defaults to VITE_AI_AGENT_URL or localhost:3001.
+ */
+export function createAiAgentClient({
+  endpoint = resolveDefaultEndpoint(),
+  fetcher = fetch,
+}: AiAgentClientOptions = {}) {
+  return {
+    async draftIntent(params: {
+      prompt: string;
+      accountId: string;
+      context?: Record<string, unknown>;
+    }): Promise<AgentDraftIntentResponse> {
+      const response = await fetcher(`${endpoint.replace(/\/$/, '')}/agent/draft-intent`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(params),
+      });
+
+      if (!response.ok) {
+        let message = `Draft request failed with HTTP ${response.status}`;
+        try {
+          const data = await response.json();
+          if (data && typeof data.error === 'string') {
+            message = data.error;
+          }
+        } catch {
+          // response body wasn't JSON — keep the generic message
+        }
+        throw new AiAgentRequestError(message, response.status);
+      }
+
+      const data = (await response.json()) as AgentDraftIntentResponse;
+
+      // Belt-and-suspenders client-side guardrail check: never trust a
+      // response that isn't an explicit, confirmation-required draft.
+      if (data.status !== 'draft' || data.requiresConfirmation !== true) {
+        throw new AiAgentRequestError(
+          'ai-agent service returned a non-draft response — refusing to display it'
+        );
+      }
+
+      return data;
+    },
+  };
+}
+
+export const draftAiAgentIntent = createAiAgentClient().draftIntent;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,6 +962,9 @@ importers:
 
   services/ai-agent:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.115.0
+        version: 0.115.0(zod@3.25.76)
       express:
         specifier: ^4.18.2
         version: 4.22.2
@@ -1084,6 +1087,15 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.115.0':
+    resolution: {integrity: sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -3439,6 +3451,9 @@ packages:
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@stellar/js-xdr@3.1.2':
     resolution: {integrity: sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==}
 
@@ -5447,6 +5462,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -6444,6 +6462,10 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -8200,6 +8222,9 @@ packages:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -8492,6 +8517,9 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -9188,6 +9216,13 @@ snapshots:
   '@adraffy/ens-normalize@1.11.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.115.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 3.25.76
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -11932,6 +11967,8 @@ snapshots:
   '@sinonjs/fake-timers@15.4.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@stablelib/base64@1.0.1': {}
 
   '@stellar/js-xdr@3.1.2': {}
 
@@ -14950,6 +14987,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -16342,6 +16381,11 @@ snapshots:
   json-parse-better-errors@1.0.2: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -18537,6 +18581,11 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
@@ -18903,6 +18952,8 @@ snapshots:
       punycode: 2.3.1
 
   tree-kill@1.2.2: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/services/ai-agent/README.md
+++ b/services/ai-agent/README.md
@@ -22,11 +22,12 @@ AI-assisted financial workflow orchestration service for the Ancore account abst
 
 ## Environment Variables
 
-| Variable          | Required | Default      | Description                                        |
-| ----------------- | -------- | ------------ | -------------------------------------------------- |
-| `PORT`            | No       | `3001`       | HTTP listen port                                   |
-| `NODE_ENV`        | No       | `production` | Runtime environment (`production` / `development`) |
-| `SERVICE_VERSION` | No       | `0.1.0`      | Version string returned by the `/health` endpoint  |
+| Variable            | Required | Default      | Description                                                                                                                                                                                                                                                         |
+| ------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`              | No       | `3001`       | HTTP listen port                                                                                                                                                                                                                                                    |
+| `NODE_ENV`          | No       | `production` | Runtime environment (`production` / `development`)                                                                                                                                                                                                                  |
+| `SERVICE_VERSION`   | No       | `0.1.0`      | Version string returned by the `/health` endpoint                                                                                                                                                                                                                   |
+| `ANTHROPIC_API_KEY` | No       | unset        | Enables the Claude Haiku (`claude-haiku-4-5`) provider for `/agent/draft-intent`. When unset, unavailable, or when the LLM errors/times out/returns invalid output, the endpoint transparently falls back to a deterministic parser — the endpoint always succeeds. |
 
 ---
 
@@ -52,6 +53,10 @@ No authentication required.
 ### `POST /agent/draft-intent`
 
 Drafts financial action intents from natural language prompts. Rate-limited to 60 requests/minute and maximum prompt length of 2000 characters.
+
+Backed by Claude Haiku (`claude-haiku-4-5`, tool-forced structured output validated against the same Zod schemas as `/v1/intents/validate`) when `ANTHROPIC_API_KEY` is set, with an automatic, dependency-free deterministic fallback parser when the LLM is unavailable, errors, times out, or returns output that fails schema validation. The response's `source` field (`"llm"` or `"deterministic"`) tells you which path produced the draft.
+
+**Every response is a draft only** — `status` is always `"draft"` and `requiresConfirmation` is always `true`, enforced server-side by `enforceNoAutonomousExecution()` before the response is returned (a guardrail violation is a `500`, never a silent pass-through). Nothing in this service ever signs or submits a transaction.
 
 **Request Body:**
 
@@ -224,6 +229,8 @@ All requests are logged as structured JSON objects to `stdout` by a request logg
 ### Privacy and Redaction
 
 To prevent PII and prompt leaks, the logging system automatically redacts sensitive fields like `prompt` and `freeText` from all log output, even when `NODE_ENV` is not production. If you run the service with debug logging enabled, the full request bodies will still never expose user prompts.
+
+`/agent/draft-intent` additionally writes a `draft_intent_audit` log entry per request (`timestamp`, `accountId`, `source`, `intentType`, `riskLevel`, and a `promptRedacted` field). `promptRedacted` runs the prompt through `redactSecrets()` (`src/logging/redact-secrets.ts`), which replaces Stellar secret keys (`S` + 55 base32 chars), seed phrases (12+ consecutive lowercase words), and API-key-shaped tokens with `[REDACTED]` — see `src/logging/__tests__/redact-secrets.test.ts` for the exact patterns covered.
 
 **Example log entry:**
 

--- a/services/ai-agent/package.json
+++ b/services/ai-agent/package.json
@@ -17,6 +17,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.115.0",
     "express": "^4.18.2",
     "zod": "^3.22.4"
   },

--- a/services/ai-agent/src/__tests__/draft-intent-route.test.ts
+++ b/services/ai-agent/src/__tests__/draft-intent-route.test.ts
@@ -1,0 +1,85 @@
+import request from 'supertest';
+import { createApp } from '../server';
+import { log } from '../logging/logger';
+
+describe('POST /agent/draft-intent — LLM integration, guardrail, and audit logging', () => {
+  const app = createApp();
+  let infoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(log, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  it('falls back to the deterministic source when ANTHROPIC_API_KEY is unset (no real API call)', async () => {
+    expect(process.env['ANTHROPIC_API_KEY']).toBeUndefined();
+
+    const res = await request(app)
+      .post('/agent/draft-intent')
+      .send({ prompt: 'Send 10 XLM to Alice', accountId: 'GABC123' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('draft');
+    expect(res.body.requiresConfirmation).toBe(true);
+    expect(res.body.source).toBe('deterministic');
+  });
+
+  it('always returns a guardrail-satisfying draft response (status=draft, requiresConfirmation=true)', async () => {
+    const res = await request(app)
+      .post('/agent/draft-intent')
+      .send({ prompt: 'Create an invoice for 50 XLM', accountId: 'GABC123' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('draft');
+    expect(res.body.requiresConfirmation).toBe(true);
+    expect(res.body.intent).toBeDefined();
+    expect(res.body.risk).toBeDefined();
+  });
+
+  it('writes an audit log entry with timestamp, accountId, source, intentType, and riskLevel', async () => {
+    await request(app)
+      .post('/agent/draft-intent')
+      .send({ prompt: 'Send 10 XLM to Alice', accountId: 'GABC123' });
+
+    const auditCall = infoSpy.mock.calls.find(([, message]) => message === 'draft_intent_audit');
+    expect(auditCall).toBeDefined();
+
+    const [payload] = auditCall as [Record<string, unknown>, string];
+    expect(payload).toMatchObject({
+      accountId: 'GABC123',
+      source: 'deterministic',
+      intentType: 'payment',
+      riskLevel: expect.any(String),
+    });
+    expect(typeof payload['timestamp']).toBe('string');
+    expect(Date.parse(payload['timestamp'] as string)).not.toBeNaN();
+  });
+
+  it('never lets a secret embedded in the prompt reach the logger verbatim', async () => {
+    const fakeSecret = 'S' + 'A'.repeat(55);
+    const promptWithSecret = `Send 10 XLM to Alice, my secret key is ${fakeSecret}`;
+
+    const res = await request(app)
+      .post('/agent/draft-intent')
+      .send({ prompt: promptWithSecret, accountId: 'GABC123' });
+
+    expect(res.status).toBe(200);
+
+    // The secret must never appear verbatim anywhere log.info was called with.
+    for (const call of infoSpy.mock.calls) {
+      expect(JSON.stringify(call)).not.toContain(fakeSecret);
+    }
+
+    // The response body itself must not echo the raw secret either.
+    expect(JSON.stringify(res.body)).not.toContain(fakeSecret);
+
+    const auditCall = infoSpy.mock.calls.find(([, message]) => message === 'draft_intent_audit');
+    expect(auditCall).toBeDefined();
+    const [payload] = auditCall as [Record<string, unknown>, string];
+    expect(payload['promptRedacted']).toContain('[REDACTED]');
+    expect(payload['promptRedacted']).not.toContain(fakeSecret);
+  });
+});

--- a/services/ai-agent/src/__tests__/draft-intent.test.ts
+++ b/services/ai-agent/src/__tests__/draft-intent.test.ts
@@ -1,0 +1,71 @@
+import { generateDraftIntent } from '../draft-intent';
+import type { DraftIntentInput, LlmProvider, ProviderDraftResult } from '../providers/types';
+
+function stubProvider(overrides: Partial<LlmProvider>): LlmProvider {
+  return {
+    name: 'stub',
+    isAvailable: () => true,
+    draftIntent: async () => {
+      throw new Error('not implemented');
+    },
+    ...overrides,
+  };
+}
+
+describe('generateDraftIntent', () => {
+  const input: DraftIntentInput = { prompt: 'Send 10 XLM to Alice', accountId: 'GACC' };
+
+  it('uses the LLM provider and reports source "llm" when it succeeds', async () => {
+    const llmResult: ProviderDraftResult = {
+      intent: { type: 'payment', amount: '10', asset: 'XLM', destination: 'GDEST' },
+      summary: 'from llm',
+    };
+    const provider = stubProvider({
+      isAvailable: () => true,
+      draftIntent: async () => llmResult,
+    });
+
+    const result = await generateDraftIntent(input, provider);
+
+    expect(result.source).toBe('llm');
+    expect(result.intent).toEqual(llmResult.intent);
+    expect(result.summary).toBe('from llm');
+  });
+
+  it('falls back to the deterministic parser and reports source "deterministic" when the provider throws', async () => {
+    const provider = stubProvider({
+      isAvailable: () => true,
+      draftIntent: async () => {
+        throw new Error('LLM exploded');
+      },
+    });
+
+    const result = await generateDraftIntent(input, provider);
+
+    expect(result.source).toBe('deterministic');
+    expect(result.intent.type).toBe('payment');
+  });
+
+  it('falls back to the deterministic parser without calling the provider when unavailable', async () => {
+    const draftIntent = jest.fn();
+    const provider = stubProvider({ isAvailable: () => false, draftIntent });
+
+    const result = await generateDraftIntent(input, provider);
+
+    expect(draftIntent).not.toHaveBeenCalled();
+    expect(result.source).toBe('deterministic');
+  });
+
+  it('falls back to the deterministic parser when the provider times out', async () => {
+    const provider = stubProvider({
+      isAvailable: () => true,
+      draftIntent: async () => {
+        throw new Error('timeout of 8000ms exceeded');
+      },
+    });
+
+    const result = await generateDraftIntent(input, provider);
+
+    expect(result.source).toBe('deterministic');
+  });
+});

--- a/services/ai-agent/src/__tests__/request-logger.test.ts
+++ b/services/ai-agent/src/__tests__/request-logger.test.ts
@@ -36,9 +36,15 @@ describe('Request Logger Middleware', () => {
       'request_complete'
     );
 
-    // Ensure prompt substring does not appear in the arguments
-    const logArgs = infoSpy.mock.calls[0];
-    const logArgsStr = JSON.stringify(logArgs);
-    expect(logArgsStr).not.toContain('Send $5 to Bob');
+    // Ensure the prompt substring does not appear in the generic
+    // request-complete log call (the request logger never reads req.body.prompt).
+    // A separate, intentionally-scoped draft_intent_audit log call also fires for
+    // this route — see src/__tests__/draft-intent-route.test.ts — and is allowed
+    // to carry secret-redacted (not fully blanked) prompt content by design.
+    const requestCompleteCall = infoSpy.mock.calls.find(
+      ([, message]) => message === 'request_complete'
+    );
+    expect(requestCompleteCall).toBeDefined();
+    expect(JSON.stringify(requestCompleteCall)).not.toContain('Send $5 to Bob');
   });
 });

--- a/services/ai-agent/src/draft-intent.ts
+++ b/services/ai-agent/src/draft-intent.ts
@@ -1,0 +1,50 @@
+import { AnthropicProvider } from './providers/anthropic';
+import { deterministicDraftIntent } from './providers/deterministic';
+import type {
+  DraftIntentInput,
+  DraftSource,
+  LlmProvider,
+  ProviderDraftResult,
+} from './providers/types';
+import { log } from './logging/logger';
+
+export interface DraftIntentResult extends ProviderDraftResult {
+  source: DraftSource;
+}
+
+// Lazily-constructed singleton — the Anthropic client itself is only created
+// inside AnthropicProvider on first use, so importing this module has no
+// side effects when ANTHROPIC_API_KEY is unset (e.g. in tests).
+const defaultProvider: LlmProvider = new AnthropicProvider();
+
+/**
+ * Produces a structured draft intent for a natural-language prompt.
+ *
+ * Tries the LLM provider first when it's configured (ANTHROPIC_API_KEY set).
+ * Any failure — unavailable, network error, timeout, or output that fails
+ * schema validation — falls back to the deterministic parser so the endpoint
+ * always succeeds, per issue #1005 item 3. The returned `source` field lets
+ * callers and audit logs distinguish which path produced the draft.
+ */
+export async function generateDraftIntent(
+  input: DraftIntentInput,
+  provider: LlmProvider = defaultProvider
+): Promise<DraftIntentResult> {
+  if (provider.isAvailable()) {
+    try {
+      const result = await provider.draftIntent(input);
+      return { ...result, source: 'llm' };
+    } catch (err) {
+      log.error(
+        {
+          accountId: input.accountId,
+          provider: provider.name,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        'llm_provider_failed_falling_back_to_deterministic'
+      );
+    }
+  }
+
+  return { ...deterministicDraftIntent(input), source: 'deterministic' };
+}

--- a/services/ai-agent/src/logging/__tests__/redact-secrets.test.ts
+++ b/services/ai-agent/src/logging/__tests__/redact-secrets.test.ts
@@ -1,0 +1,67 @@
+import { redactSecrets } from '../redact-secrets';
+
+describe('redactSecrets', () => {
+  it('redacts a Stellar secret key (S + 55 base32 chars)', () => {
+    const secret = 'S' + 'A'.repeat(55);
+    expect(secret).toHaveLength(56);
+    const text = `Please use my secret ${secret} to sign this.`;
+    const result = redactSecrets(text);
+    expect(result).not.toContain(secret);
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('does not redact a Stellar public key (G-prefixed)', () => {
+    const pub = 'G' + 'A'.repeat(55);
+    const text = `Send to ${pub}`;
+    const result = redactSecrets(text);
+    expect(result).toContain(pub);
+  });
+
+  it('redacts a BIP-39-shaped 12-word seed phrase', () => {
+    const seed =
+      'abandon ability able about above absent absorb abstract absurd abuse access accident';
+    const text = `Here is my wallet recovery phrase: ${seed}. Please import it.`;
+    const result = redactSecrets(text);
+    expect(result).not.toContain(seed);
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('redacts an Anthropic-shaped API key', () => {
+    const key = 'sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789';
+    const text = `My key is ${key}, keep it safe.`;
+    const result = redactSecrets(text);
+    expect(result).not.toContain(key);
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('redacts a GitHub-shaped token', () => {
+    const token = 'ghp_' + 'x'.repeat(36);
+    const text = `token: ${token}`;
+    const result = redactSecrets(text);
+    expect(result).not.toContain(token);
+  });
+
+  it('redacts an AWS access key id', () => {
+    const key = 'AKIAABCDEFGHIJKLMNOP';
+    const text = `aws key ${key}`;
+    const result = redactSecrets(text);
+    expect(result).not.toContain(key);
+  });
+
+  it('redacts a raw Bearer token', () => {
+    const text = 'Authorization: Bearer abc123.def456-ghi789_jklmno';
+    const result = redactSecrets(text);
+    expect(result).not.toContain('abc123.def456-ghi789_jklmno');
+  });
+
+  it('leaves ordinary prompt text untouched', () => {
+    const text = 'Send 10 XLM to Alice for lunch';
+    expect(redactSecrets(text)).toBe(text);
+  });
+
+  it('handles empty and non-string input safely', () => {
+    expect(redactSecrets('')).toBe('');
+    expect(redactSecrets(undefined as unknown as string)).toBeUndefined();
+    expect(redactSecrets(null as unknown as string)).toBeNull();
+  });
+});

--- a/services/ai-agent/src/logging/redact-secrets.ts
+++ b/services/ai-agent/src/logging/redact-secrets.ts
@@ -1,0 +1,46 @@
+/**
+ * Redacts secret-shaped substrings from free-text before it reaches any log
+ * sink. This is deliberately conservative — it is safer to over-redact a
+ * false positive than to leak a real credential into audit logs.
+ *
+ * Distinct from `redactForLog` in ./logger.ts, which wipes entire fields by
+ * key name (e.g. any field literally named "prompt"). This module instead
+ * scans free text *content* for secret-shaped patterns so a partially-safe
+ * prompt can still be logged for audit purposes with only the sensitive
+ * spans removed.
+ */
+
+const REDACTED = '[REDACTED]';
+
+/** Stellar secret seeds: "S" followed by 55 base32 (RFC4648, A-Z2-7) characters. */
+const STELLAR_SECRET_KEY_RE = /\bS[A-Z2-7]{55}\b/g;
+
+/**
+ * API-key-shaped tokens: common vendor prefixes (Anthropic, OpenAI, GitHub,
+ * Slack, AWS) plus a generic "Bearer <token>" form.
+ */
+const API_KEY_RE =
+  /\b(?:sk-ant-[A-Za-z0-9_-]{10,}|sk-[A-Za-z0-9_-]{16,}|gh[oprsu]_[A-Za-z0-9]{20,}|xox[abp]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|Bearer\s+[A-Za-z0-9._-]{10,})\b/gi;
+
+/**
+ * Seed / recovery phrases: 12 or more consecutive lowercase alphabetic words.
+ * BIP-39 phrases are always 12/15/18/21/24 words, but we redact any run of
+ * 12+ to stay conservative against partial or non-standard phrases.
+ */
+const SEED_PHRASE_RE = /\b(?:[a-z]{3,10}\s+){11,}[a-z]{3,10}\b/g;
+
+/**
+ * Redacts Stellar secret keys, seed phrases, and API-key-shaped tokens from
+ * a string, replacing each match with "[REDACTED]". Non-string input is
+ * returned unchanged.
+ */
+export function redactSecrets(text: string): string {
+  if (typeof text !== 'string' || text.length === 0) {
+    return text;
+  }
+
+  return text
+    .replace(STELLAR_SECRET_KEY_RE, REDACTED)
+    .replace(API_KEY_RE, REDACTED)
+    .replace(SEED_PHRASE_RE, REDACTED);
+}

--- a/services/ai-agent/src/providers/__tests__/anthropic.test.ts
+++ b/services/ai-agent/src/providers/__tests__/anthropic.test.ts
@@ -1,0 +1,166 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import { AnthropicProvider, LlmOutputValidationError } from '../anthropic';
+
+/** Builds a fake Anthropic client — no real SDK instance, no network calls. */
+function fakeClient(create: jest.Mock): Anthropic {
+  return { messages: { create } } as unknown as Anthropic;
+}
+
+function toolUseResponse(input: Record<string, unknown>) {
+  return {
+    content: [{ type: 'tool_use', id: 'tu_1', name: 'draft_intent', input }],
+  };
+}
+
+describe('AnthropicProvider', () => {
+  const originalKey = process.env['ANTHROPIC_API_KEY'];
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env['ANTHROPIC_API_KEY'];
+    } else {
+      process.env['ANTHROPIC_API_KEY'] = originalKey;
+    }
+  });
+
+  describe('isAvailable', () => {
+    it('is unavailable when ANTHROPIC_API_KEY is unset and no client was injected', () => {
+      delete process.env['ANTHROPIC_API_KEY'];
+      const provider = new AnthropicProvider();
+      expect(provider.isAvailable()).toBe(false);
+    });
+
+    it('is available when ANTHROPIC_API_KEY is set', () => {
+      process.env['ANTHROPIC_API_KEY'] = 'sk-ant-test-key';
+      const provider = new AnthropicProvider();
+      expect(provider.isAvailable()).toBe(true);
+    });
+
+    it('is available when a client is injected regardless of env var', () => {
+      delete process.env['ANTHROPIC_API_KEY'];
+      const provider = new AnthropicProvider(fakeClient(jest.fn()));
+      expect(provider.isAvailable()).toBe(true);
+    });
+  });
+
+  describe('draftIntent — successful structured parse', () => {
+    it('returns a validated payment intent from the tool_use block', async () => {
+      const create = jest.fn().mockResolvedValue(
+        toolUseResponse({
+          type: 'payment',
+          amount: '42',
+          asset: 'USDC',
+          destination: 'GCZST3XVCDTUJ76ZAV2HA72KYPJW5YJSNXVZTSKNBPWTXGVLNPXQ4JH',
+          summary: 'Send 42 USDC',
+        })
+      );
+      const provider = new AnthropicProvider(fakeClient(create));
+
+      const result = await provider.draftIntent({ prompt: 'send 42 usdc', accountId: 'GACC' });
+
+      expect(create).toHaveBeenCalledTimes(1);
+      const [params, options] = create.mock.calls[0];
+      expect(params.model).toBe('claude-haiku-4-5');
+      expect(params.tool_choice).toEqual({ type: 'tool', name: 'draft_intent' });
+      expect(options).toMatchObject({ timeout: expect.any(Number) });
+
+      expect(result.intent).toEqual({
+        type: 'payment',
+        amount: '42',
+        asset: 'USDC',
+        destination: 'GCZST3XVCDTUJ76ZAV2HA72KYPJW5YJSNXVZTSKNBPWTXGVLNPXQ4JH',
+      });
+      expect(result.summary).toBe('Send 42 USDC');
+    });
+
+    it('returns a validated invoice intent from the tool_use block', async () => {
+      const create = jest.fn().mockResolvedValue(
+        toolUseResponse({
+          type: 'invoice',
+          amount: '15',
+          asset: 'XLM',
+          recipient: 'Alice',
+          dueDate: '2026-12-31T00:00:00Z',
+          summary: 'Invoice Alice for 15 XLM',
+        })
+      );
+      const provider = new AnthropicProvider(fakeClient(create));
+
+      const result = await provider.draftIntent({
+        prompt: 'invoice Alice for 15 XLM',
+        accountId: 'GACC',
+      });
+
+      expect(result.intent).toEqual({
+        type: 'invoice',
+        amount: '15',
+        asset: 'XLM',
+        recipient: 'Alice',
+        dueDate: '2026-12-31T00:00:00Z',
+      });
+    });
+  });
+
+  describe('draftIntent — malformed output falls back', () => {
+    it('throws LlmOutputValidationError when amount fails the numeric-string regex', async () => {
+      const create = jest.fn().mockResolvedValue(
+        toolUseResponse({
+          type: 'payment',
+          amount: 'a lot',
+          asset: 'XLM',
+          destination: 'GDEST',
+          summary: 'bad',
+        })
+      );
+      const provider = new AnthropicProvider(fakeClient(create));
+
+      await expect(
+        provider.draftIntent({ prompt: 'send a lot of xlm', accountId: 'GACC' })
+      ).rejects.toThrow(LlmOutputValidationError);
+    });
+
+    it('throws when the response has no tool_use block', async () => {
+      const create = jest
+        .fn()
+        .mockResolvedValue({ content: [{ type: 'text', text: 'no tool call' }] });
+      const provider = new AnthropicProvider(fakeClient(create));
+
+      await expect(provider.draftIntent({ prompt: 'hello', accountId: 'GACC' })).rejects.toThrow(
+        LlmOutputValidationError
+      );
+    });
+
+    it('throws when required fields are missing for the intent type', async () => {
+      const create = jest
+        .fn()
+        .mockResolvedValue(
+          toolUseResponse({ type: 'payment', amount: '10', asset: 'XLM', summary: 'missing dest' })
+        );
+      const provider = new AnthropicProvider(fakeClient(create));
+
+      await expect(provider.draftIntent({ prompt: 'send xlm', accountId: 'GACC' })).rejects.toThrow(
+        LlmOutputValidationError
+      );
+    });
+  });
+
+  describe('draftIntent — timeout / error falls back', () => {
+    it('propagates network/timeout errors from the SDK client', async () => {
+      const create = jest.fn().mockRejectedValue(new Error('timeout of 8000ms exceeded'));
+      const provider = new AnthropicProvider(fakeClient(create));
+
+      await expect(provider.draftIntent({ prompt: 'send xlm', accountId: 'GACC' })).rejects.toThrow(
+        'timeout of 8000ms exceeded'
+      );
+    });
+
+    it('throws when the provider is unavailable', async () => {
+      delete process.env['ANTHROPIC_API_KEY'];
+      const provider = new AnthropicProvider();
+
+      await expect(provider.draftIntent({ prompt: 'send xlm', accountId: 'GACC' })).rejects.toThrow(
+        /unavailable/i
+      );
+    });
+  });
+});

--- a/services/ai-agent/src/providers/__tests__/deterministic.test.ts
+++ b/services/ai-agent/src/providers/__tests__/deterministic.test.ts
@@ -1,0 +1,63 @@
+import { deterministicDraftIntent } from '../deterministic';
+
+describe('deterministicDraftIntent', () => {
+  it('drafts a payment intent by default', () => {
+    const result = deterministicDraftIntent({ prompt: 'Send 10 XLM to Alice', accountId: 'GACC' });
+    expect(result.intent.type).toBe('payment');
+    if (result.intent.type === 'payment') {
+      expect(result.intent.amount).toBe('10');
+      expect(result.intent.asset).toBe('XLM');
+    }
+    expect(result.summary).toBe('Drafted payment intent');
+  });
+
+  it('drafts an invoice intent when the prompt mentions "invoice"', () => {
+    const result = deterministicDraftIntent({
+      prompt: 'Create an invoice for 50 USDC',
+      accountId: 'GACC',
+    });
+    expect(result.intent.type).toBe('invoice');
+    if (result.intent.type === 'invoice') {
+      expect(result.intent.amount).toBe('50');
+      expect(result.intent.asset).toBe('USDC');
+      expect(result.intent.recipient).toBe('GACC');
+      expect(Date.parse(result.intent.dueDate)).not.toBeNaN();
+    }
+  });
+
+  it('extracts a Stellar destination address when present in the prompt', () => {
+    // 56 chars total ("G" + 55 base32 chars) — the real Stellar strkey length.
+    const dest = 'GDKRY7GNU3CJQX6FMT2BIPW5ELSZAHOV4DKRY7GNU3CJQX6FMT2BIPW5';
+    const result = deterministicDraftIntent({
+      prompt: `Send 25 XLM to ${dest}`,
+      accountId: 'GACC',
+    });
+    expect(result.intent.type).toBe('payment');
+    if (result.intent.type === 'payment') {
+      expect(result.intent.destination).toBe(dest);
+    }
+  });
+
+  it('falls back to a default destination when no address is present', () => {
+    const result = deterministicDraftIntent({ prompt: 'Send 10 XLM to Bob', accountId: 'GACC' });
+    if (result.intent.type === 'payment') {
+      expect(result.intent.destination).toBe('G123');
+    }
+  });
+
+  it('defaults amount to "10" when no number is present in the prompt', () => {
+    const result = deterministicDraftIntent({ prompt: 'Send some XLM to Bob', accountId: 'GACC' });
+    if (result.intent.type === 'payment') {
+      expect(result.intent.amount).toBe('10');
+    }
+  });
+
+  it('always produces schema-valid output', () => {
+    const result = deterministicDraftIntent({
+      prompt: 'invoice bill me for 1.5 usdc',
+      accountId: 'GACC',
+    });
+    // amount must satisfy the ^\d+(\.\d+)?$ format required by the Zod schemas
+    expect(result.intent.amount).toMatch(/^\d+(\.\d+)?$/);
+  });
+});

--- a/services/ai-agent/src/providers/anthropic.ts
+++ b/services/ai-agent/src/providers/anthropic.ts
@@ -1,0 +1,194 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { intentSchema } from '../schemas/intent';
+import type { DraftIntentInput, LlmProvider, ProviderDraftResult } from './types';
+
+/** Claude Haiku — fast, low-cost, sufficient for structured intent extraction. */
+const MODEL = 'claude-haiku-4-5';
+
+/** Hard ceiling on how long we wait for the LLM before falling back. */
+const REQUEST_TIMEOUT_MS = 8_000;
+
+const MAX_TOKENS = 512;
+
+const TOOL_NAME = 'draft_intent';
+
+/**
+ * Tool schema mirrors docs/ai/intents.md exactly:
+ *  - payment: type, amount, asset, destination
+ *  - invoice: type, amount, asset, recipient, dueDate
+ * `summary` is additionally requested for the human-readable draft summary.
+ * Forced tool_choice guarantees the model's entire response is this shape —
+ * final validation still happens against the Zod schemas in ../schemas/intent
+ * before anything is trusted (see draftIntent() below).
+ */
+const DRAFT_INTENT_TOOL: Anthropic.Tool = {
+  name: TOOL_NAME,
+  description:
+    'Record a structured draft of the financial intent described in the prompt. ' +
+    'This never executes anything — it only produces a draft for human confirmation.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      type: {
+        type: 'string',
+        enum: ['payment', 'invoice'],
+        description:
+          '"payment" to send funds to a destination; "invoice" to request funds from someone.',
+      },
+      amount: {
+        type: 'string',
+        description: 'Numeric amount as a string, e.g. "10" or "10.5". No currency symbols.',
+      },
+      asset: {
+        type: 'string',
+        enum: ['XLM', 'USDC'],
+        description: 'Asset code. Default to XLM if the prompt does not specify a currency.',
+      },
+      destination: {
+        type: 'string',
+        description: 'Required when type is "payment": the receiving address or identifier.',
+      },
+      recipient: {
+        type: 'string',
+        description:
+          'Required when type is "invoice": the identifier of the person/entity being billed.',
+      },
+      dueDate: {
+        type: 'string',
+        description:
+          'Required when type is "invoice": ISO 8601 due date. Default to 7 days from now if unspecified.',
+      },
+      summary: {
+        type: 'string',
+        description: 'One short sentence summarizing the draft for display to the user.',
+      },
+    },
+    required: ['type', 'amount', 'asset', 'summary'],
+  },
+};
+
+function buildSystemPrompt(accountId: string): string {
+  return [
+    'You draft structured Stellar payment and invoice intents from natural-language requests.',
+    `The requesting account is "${accountId}".`,
+    'You NEVER execute, submit, or sign any transaction — you only produce a draft that a human will review and explicitly confirm.',
+    'Always call the draft_intent tool exactly once with your best-effort structured extraction.',
+    'If the prompt is ambiguous, make a reasonable assumption (default asset XLM) rather than refusing.',
+  ].join(' ');
+}
+
+export class LlmOutputValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LlmOutputValidationError';
+  }
+}
+
+/**
+ * Claude Haiku implementation of LlmProvider, gated on ANTHROPIC_API_KEY.
+ *
+ * Never throws an un-typed error to the caller for "expected" failure modes
+ * (missing key, timeout, malformed output) — every failure path throws so the
+ * orchestrator (see ../draft-intent.ts) can fall back to the deterministic
+ * parser, per issue #1005 item 3.
+ */
+export class AnthropicProvider implements LlmProvider {
+  readonly name = 'anthropic';
+
+  private client: Anthropic | null;
+
+  /**
+   * @param client Optional pre-built client — used by tests to inject a mock
+   *   in place of the real `@anthropic-ai/sdk` client (no real API calls).
+   *   Production code should omit this; the client is lazily constructed
+   *   from ANTHROPIC_API_KEY on first use.
+   */
+  constructor(client?: Anthropic) {
+    this.client = client ?? null;
+  }
+
+  private getClient(): Anthropic {
+    if (!this.client) {
+      this.client = new Anthropic({ apiKey: process.env['ANTHROPIC_API_KEY'] });
+    }
+    return this.client;
+  }
+
+  isAvailable(): boolean {
+    return this.client !== null || Boolean(process.env['ANTHROPIC_API_KEY']?.trim());
+  }
+
+  async draftIntent(input: DraftIntentInput): Promise<ProviderDraftResult> {
+    if (!this.isAvailable()) {
+      throw new Error('AnthropicProvider unavailable: ANTHROPIC_API_KEY is not set');
+    }
+
+    const client = this.getClient();
+
+    const response = await client.messages.create(
+      {
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system: buildSystemPrompt(input.accountId),
+        tools: [DRAFT_INTENT_TOOL],
+        tool_choice: { type: 'tool', name: TOOL_NAME },
+        messages: [{ role: 'user', content: input.prompt }],
+      },
+      { timeout: REQUEST_TIMEOUT_MS }
+    );
+
+    const toolUse = response.content.find(
+      (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use'
+    );
+
+    if (!toolUse) {
+      throw new LlmOutputValidationError('Anthropic response did not include a tool_use block');
+    }
+
+    return parseToolOutput(toolUse.input);
+  }
+}
+
+/**
+ * Validates raw tool input against the same Zod schemas used for
+ * /v1/intents/validate. Invalid output throws — never trusted, never returned.
+ */
+function parseToolOutput(rawInput: unknown): ProviderDraftResult {
+  if (typeof rawInput !== 'object' || rawInput === null) {
+    throw new LlmOutputValidationError('Anthropic tool input was not an object');
+  }
+
+  const input = rawInput as Record<string, unknown>;
+  const summary =
+    typeof input['summary'] === 'string' && input['summary'].trim() ? input['summary'] : undefined;
+
+  const candidate =
+    input['type'] === 'invoice'
+      ? {
+          type: 'invoice' as const,
+          amount: input['amount'],
+          asset: input['asset'],
+          recipient: input['recipient'],
+          dueDate: input['dueDate'],
+        }
+      : {
+          type: 'payment' as const,
+          amount: input['amount'],
+          asset: input['asset'],
+          destination: input['destination'],
+        };
+
+  const parsed = intentSchema.safeParse(candidate);
+  if (!parsed.success) {
+    throw new LlmOutputValidationError(
+      `Anthropic tool output failed schema validation: ${parsed.error.message}`
+    );
+  }
+
+  return {
+    intent: parsed.data,
+    summary:
+      summary ??
+      (parsed.data.type === 'invoice' ? 'Drafted invoice intent' : 'Drafted payment intent'),
+  };
+}

--- a/services/ai-agent/src/providers/deterministic.ts
+++ b/services/ai-agent/src/providers/deterministic.ts
@@ -1,0 +1,57 @@
+import type { Intent } from '../schemas/intent';
+import type { DraftIntentInput, ProviderDraftResult } from './types';
+
+const INVOICE_KEYWORDS = ['invoice', 'bill me', 'request payment', 'request a payment'];
+
+const STELLAR_ADDRESS_RE = /\bG[A-Z2-7]{55}\b/;
+const AMOUNT_RE = /(\d+(?:\.\d+)?)/;
+
+function isInvoicePrompt(prompt: string): boolean {
+  const lower = prompt.toLowerCase();
+  return INVOICE_KEYWORDS.some((keyword) => lower.includes(keyword));
+}
+
+function extractAmount(prompt: string): string {
+  const match = prompt.match(AMOUNT_RE);
+  return match ? match[1] : '10';
+}
+
+function extractAsset(prompt: string): 'XLM' | 'USDC' {
+  return /\busdc\b/i.test(prompt) ? 'USDC' : 'XLM';
+}
+
+function extractDestination(prompt: string, fallback: string): string {
+  const match = prompt.match(STELLAR_ADDRESS_RE);
+  return match ? match[0] : fallback;
+}
+
+/**
+ * Deterministic, offline fallback parser.
+ *
+ * Used when the LLM provider is unavailable, times out, errors, or produces
+ * output that fails schema validation. Deliberately simple and dependency-free
+ * so it always succeeds — this is the guaranteed-availability floor beneath
+ * the LLM path (item 3 of issue #1005).
+ */
+export function deterministicDraftIntent({
+  prompt,
+  accountId,
+}: DraftIntentInput): ProviderDraftResult {
+  const amount = extractAmount(prompt);
+  const asset = extractAsset(prompt);
+
+  if (isInvoicePrompt(prompt)) {
+    const intent: Intent = {
+      type: 'invoice',
+      amount,
+      asset,
+      recipient: accountId,
+      dueDate: new Date().toISOString(),
+    };
+    return { intent, summary: 'Drafted invoice intent' };
+  }
+
+  const destination = extractDestination(prompt, 'G123');
+  const intent: Intent = { type: 'payment', destination, amount, asset };
+  return { intent, summary: 'Drafted payment intent' };
+}

--- a/services/ai-agent/src/providers/types.ts
+++ b/services/ai-agent/src/providers/types.ts
@@ -1,0 +1,41 @@
+import type { Intent } from '../schemas/intent';
+
+/** Where a drafted intent came from — surfaced in the API response and audit logs. */
+export type DraftSource = 'llm' | 'deterministic';
+
+export interface DraftIntentInput {
+  /** Natural-language description of the intended operation */
+  prompt: string;
+  /** Stellar account address of the initiating user */
+  accountId: string;
+  /** Optional context for the intent (e.g. invoice ID, session key) */
+  context?: Record<string, unknown>;
+}
+
+export interface ProviderDraftResult {
+  /** Structured intent — MUST validate against the Zod schemas in ../schemas/intent */
+  intent: Intent;
+  /** Human-readable summary for display */
+  summary: string;
+}
+
+/**
+ * Provider interface for turning a natural-language prompt into a structured,
+ * schema-conformant draft intent.
+ *
+ * Implementations MUST NOT execute any financial operation — they only produce
+ * a draft. See ../guardrail.ts for the enforcement of that invariant.
+ */
+export interface LlmProvider {
+  /** Provider identifier, used in logs (e.g. "anthropic") */
+  readonly name: string;
+  /** Whether this provider is configured and usable (e.g. API key present) */
+  isAvailable(): boolean;
+  /**
+   * Produce a structured draft intent from a natural-language prompt.
+   * @throws if the provider is unavailable, times out, errors, or produces
+   *   output that fails schema validation — callers should fall back to the
+   *   deterministic parser on any rejection.
+   */
+  draftIntent(input: DraftIntentInput): Promise<ProviderDraftResult>;
+}

--- a/services/ai-agent/src/server.ts
+++ b/services/ai-agent/src/server.ts
@@ -1,26 +1,18 @@
 import express, { Express, Request, Response } from 'express';
-import { intentSchema, HIGH_VALUE_PAYMENT_THRESHOLD, type Intent } from './schemas/intent';
+import { intentSchema, HIGH_VALUE_PAYMENT_THRESHOLD } from './schemas/intent';
 import { requestLogger } from './middleware/request-logger';
 import { draftIntentRateLimiter } from './middleware/rate-limiter';
 import { scoreRisk } from './risk';
+import { generateDraftIntent } from './draft-intent';
+import { enforceNoAutonomousExecution } from './guardrail';
+import { redactSecrets } from './logging/redact-secrets';
+import { log } from './logging/logger';
+import type { DraftIntentResponse } from './types';
 
 const MAX_PROMPT_LENGTH = 2000;
 const MAX_ACCOUNT_ID_LENGTH = 128;
 
 const startTime = Date.now();
-
-/**
- * Determines if a payment intent requires confirmation based on amount.
- * High-value payments (e.g., >100 USDC or >1000 XLM) require confirmation.
- */
-function requiresConfirmation(intent: any): boolean {
-  if (intent.type === 'payment') {
-    const amount = parseFloat(intent.amount);
-    const threshold = intent.asset === 'USDC' ? 100 : 1000;
-    return amount > threshold;
-  }
-  return false;
-}
 
 /**
  * App factory — exported for testing.
@@ -49,7 +41,10 @@ export function createApp(): Express {
   });
 
   // ── Draft Intent endpoint ──────────────────────────────────────────────────
-  app.post('/agent/draft-intent', draftIntentRateLimiter, (req: Request, res: Response) => {
+  // LLM-backed (Claude Haiku, env-gated) with a deterministic offline fallback.
+  // GUARDRAIL: every response is validated by enforceNoAutonomousExecution()
+  // before it is returned — a violation is a 500, never a silent pass-through.
+  app.post('/agent/draft-intent', draftIntentRateLimiter, async (req: Request, res: Response) => {
     const { prompt, accountId } = req.body;
     if (!prompt || !accountId || typeof prompt !== 'string' || typeof accountId !== 'string') {
       return res.status(400).json({ error: 'Invalid request: prompt and accountId required' });
@@ -67,23 +62,42 @@ export function createApp(): Express {
       });
     }
 
-    const isInvoice = prompt.toLowerCase().includes('invoice');
-    const draftIntent: Intent = isInvoice
-      ? {
-          type: 'invoice',
-          amount: '10',
-          asset: 'XLM',
-          recipient: accountId,
-          dueDate: new Date().toISOString(),
-        }
-      : { type: 'payment', destination: 'G123', amount: '10', asset: 'XLM' };
-    return res.status(200).json({
-      status: 'draft',
-      requiresConfirmation: true,
-      summary: isInvoice ? 'Drafted invoice intent' : 'Drafted payment intent',
-      intent: draftIntent,
-      risk: scoreRisk(draftIntent),
-    });
+    try {
+      const { intent, summary, source } = await generateDraftIntent({ prompt, accountId });
+      const risk = scoreRisk(intent);
+
+      const response = {
+        status: 'draft' as const,
+        requiresConfirmation: true as const,
+        summary,
+        intent,
+        risk,
+        source,
+      };
+
+      // Fail closed: never return a response that hasn't passed the guardrail.
+      enforceNoAutonomousExecution(response as unknown as DraftIntentResponse);
+
+      log.info(
+        {
+          timestamp: new Date().toISOString(),
+          accountId,
+          source,
+          intentType: intent.type,
+          riskLevel: risk.level,
+          promptRedacted: redactSecrets(prompt),
+        },
+        'draft_intent_audit'
+      );
+
+      return res.status(200).json(response);
+    } catch (err) {
+      log.error(
+        { accountId, error: err instanceof Error ? err.message : String(err) },
+        'draft_intent_failed'
+      );
+      return res.status(500).json({ error: 'Failed to draft intent' });
+    }
   });
 
   // ── Intent validation ──────────────────────────────────────────────────────

--- a/services/relayer/src/scheduler/handlers.ts
+++ b/services/relayer/src/scheduler/handlers.ts
@@ -80,16 +80,16 @@ export function createCancelScheduledTransferHandler(service: ScheduledTransferS
 }
 
 export function createListExecutionsHandler(service: ScheduledTransferService) {
-  return (req: Request, res: Response): void => {
+  return async (req: Request, res: Response): Promise<void> => {
     const callerId = getCallerId(res);
-    const transfer = service.get(req.params['id'] ?? '', callerId);
+    const transfer = await service.get(req.params['id'] ?? '', callerId);
 
     if (!transfer) {
       res.status(404).json({ error: 'NOT_FOUND', message: 'Scheduled transfer not found' });
       return;
     }
 
-    const executions = service.listExecutions(transfer.id, callerId);
+    const executions = await service.listExecutions(transfer.id, callerId);
     res.status(200).json({ data: executions });
   };
 }


### PR DESCRIPTION
## Summary

Implements all 5 proposed-solution items from #1005: a real, env-gated Claude Haiku provider for `/agent/draft-intent`, replacing the deterministic `prompt.includes('invoice')` placeholder from #972 with LLM-backed structured extraction, a schema-validated fallback path, secret-redacting audit logs, and a "draft with AI" UI in the extension wallet. The never-auto-execute guardrail is enforced on every response.

**Model used:** `claude-haiku-4-5` (per ROADMAP 5.9 and the issue's explicit ask), via `@anthropic-ai/sdk`.

### 1. Provider interface + Haiku implementation behind API keys
- `services/ai-agent/src/providers/types.ts` — `LlmProvider` interface (`isAvailable()`, `draftIntent()`).
- `services/ai-agent/src/providers/anthropic.ts` — `AnthropicProvider`, gated on `ANTHROPIC_API_KEY`. Lazily constructs the SDK client only on first use, so importing the module has no side effects when the key is unset (e.g. in tests/CI).

### 2. JSON-schema constrained intents
- Forces `tool_choice: {type: "tool", name: "draft_intent"}` with a tool schema mirroring `docs/ai/intents.md` exactly (payment: `type/amount/asset/destination`; invoice: `type/amount/asset/recipient/dueDate`).
- The tool output is re-validated against the *same* Zod `intentSchema` used by `/v1/intents/validate` before it's trusted (`parseToolOutput` in `anthropic.ts`) — never returned unvalidated.
- `requiresConfirmation` is always `true`; `enforceNoAutonomousExecution()` (previously written but called nowhere) is now invoked on every `/agent/draft-intent` response before it's returned — a guardrail violation is a `500`, never a silent pass-through (`server.ts`).

### 3. Deterministic parser fallback offline
- `services/ai-agent/src/providers/deterministic.ts` — dependency-free fallback (keeps + modestly improves the original `includes('invoice')` heuristic with amount/asset/Stellar-address extraction). Always succeeds.
- `services/ai-agent/src/draft-intent.ts` — orchestrator: tries the LLM provider when available, catches *any* failure (unavailable, network error, timeout, malformed output) and falls back to the deterministic parser. The response's `source: 'llm' | 'deterministic'` field tells callers/logs which path produced the draft.

### 4. Audit logs redacting secrets
- `services/ai-agent/src/logging/redact-secrets.ts` — `redactSecrets()` replaces (a) Stellar secret keys (`S` + 55 base32 chars), (b) 12+-word seed phrases, and (c) API-key-shaped tokens (Anthropic/GitHub/AWS/Bearer) with `[REDACTED]`, leaving the rest of the text intact.
- Every `/agent/draft-intent` request logs a `draft_intent_audit` entry (`timestamp`, `accountId`, `source`, `intentType`, `riskLevel`, `promptRedacted`) via the existing `log` module.
- Unit test proving a secret never appears verbatim in what reaches the logger: `services/ai-agent/src/__tests__/draft-intent-route.test.ts` (embeds a fake Stellar secret in the prompt, spies on `log.info`, asserts the raw secret string is absent from every logged call and from the HTTP response body) + `services/ai-agent/src/logging/__tests__/redact-secrets.test.ts` (unit-level coverage of each pattern).
- Kept the existing full-field wipe in `redactForLog` (any field literally named `prompt`/`freeText`) untouched — `redactSecrets` is a separate, content-level tool used only for the audit field, which is deliberately *not* named `prompt` so it isn't double-wiped.

### 5. Draft-payment UI (extension-wallet)
**Why extension-wallet, not `useSendDraft`:** `useSendDraft` (`apps/extension-wallet/src/hooks/useSendDraft.ts`) turned out to back a different, not-currently-routed component (`SendFlow.tsx`) — the router (`src/router/index.tsx`) actually mounts `SendScreen.tsx` at `/send`. I built the AI draft UI against the live route instead, for a working feature rather than dead code:
- `apps/extension-wallet/src/services/ai-agent-client.ts` — typed fetch client for `/agent/draft-intent` (injectable `fetcher`/`endpoint`, `VITE_AI_AGENT_URL` env default), with a belt-and-suspenders client-side check that refuses to surface any response that isn't an explicit `status: 'draft'` + `requiresConfirmation: true`.
- `apps/extension-wallet/src/hooks/useAgentDraftIntent.ts` — drives submit → draft → confirm/reject. `confirm()` only returns the draft to the caller; it never calls the network again and never touches the send/sign flow itself.
- `apps/extension-wallet/src/screens/Send/AiDraftPanel.tsx` — NL prompt textarea → draft card (type, amount+asset, destination/recipient, risk badge + reasons, summary) → explicit **Confirm draft** / **Reject** buttons.
- Wired into `SendScreen.tsx` behind a "Draft with AI" toggle. Confirming only prefills the existing form's `to`/`amount` fields (payment intents only) — the user still goes through the unchanged Continue → Review → Confirm → Sign flow to actually send anything. **Nothing in this stack can submit a transaction on its own.**

## Redaction approach
Two independent layers: (1) the pre-existing `redactForLog` wipes any log field literally named `prompt`/`freeText` regardless of content (defense in depth, untouched), and (2) the new `redactSecrets()` scans free text for secret-*shaped* substrings (Stellar seeds, seed phrases, API keys) and redacts only those spans, so the audit log's `promptRedacted` field stays useful for operators while never leaking a credential. Deliberately conservative (e.g. redacts *any* 12+-word lowercase run, which can false-positive on ordinary prose) — better to over-redact than leak.

## Frontend choice
`SendScreen.tsx` (the actual `/send` route) over `SendFlow.tsx`/`useSendDraft` (unrouted) — see item 5 above for the full reasoning.

## Test/build/lint output (real, pasted)

**`services/ai-agent`** — `npx tsc --noEmit` clean; `npx eslint src/` → `0 errors, 7 warnings` (all pre-existing `no-explicit-any` warnings in files I didn't touch); `npx jest --coverage`:
```
Test Suites: 12 passed, 12 total
Tests:       95 passed, 95 total
```
Coverage on new modules: `draft-intent.ts` 100%, `providers/anthropic.ts` 94.4%, `providers/deterministic.ts` 100%, `logging/redact-secrets.ts` 100%.

Covers: successful structured parse (payment + invoice), malformed-output fallback (bad amount regex, missing required field, no tool_use block), timeout/network-error fallback, guardrail always firing, and the secret-redaction proof above. The Anthropic SDK is mocked via constructor injection (`new AnthropicProvider(fakeClient)`) — no real API calls in any test.

**`apps/extension-wallet`** (touched files) — `npx eslint <touched files>` → clean; `pnpm build` (after building the workspace deps it needs: `@ancore/ui-kit`, `@ancore/crypto`, `@ancore/types`, `@ancore/stellar`, `@ancore/core-sdk`, `@ancore/account-abstraction`, `@ancore/wallet-shared`) → succeeds; `npx vitest run` full suite:
```
Test Files  6 failed | 60 passed (66)
     Tests  28 failed | 583 passed | 2 skipped (613)
```
The 28 failures are pre-existing and unrelated (`useSettingsStore` missing `setNetwork`/`reset`/etc. actions in `src/stores/settings.ts` and its consumers) — confirmed via `git stash` against `main`, same 7 failures/28 tests fail with zero changes applied. My 3 new test files (16 tests: `ai-agent-client.test.ts`, `useAgentDraftIntent.test.ts`, `AiDraftPanel.test.tsx`) all pass, and no previously-passing test regressed. One existing test (`request-logger.test.ts`) needed a small, intentional update: it asserted `log.info`'s first call never contains the raw prompt, which broke once a second, deliberately-scoped `draft_intent_audit` call was added — updated it to check the `request_complete` call specifically by message name (see the code comment added there) rather than blindly indexing `[0]`.

Fixed one incidental, pre-existing build break encountered while verifying (`services/relayer/src/scheduler/handlers.ts`: `service.get()`/`listExecutions()` are `async` but were called without `await`, so `transfer.id` didn't type-check) — unrelated to #1005, included only because it blocked `pnpm build` for the whole workspace.

## Guardrail
`enforceNoAutonomousExecution()` now runs on every `/agent/draft-intent` response (previously written, called nowhere). `status` is always `'draft'` and `requiresConfirmation` is always `true`, hardcoded at the call site — a violation would mean the process itself is broken, and is treated as a `500`, never swallowed. `/v1/intents/validate` was left untouched.

Closes #1005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Draft with AI” to the Send flow for creating payment and invoice drafts from natural-language prompts.
  * Draft previews show amounts, recipients, summaries, and risk details before confirmation.
  * Accepted payment drafts pre-fill the Send form without initiating a transaction.
  * AI-generated drafts fall back to deterministic parsing when unavailable or unsuccessful.

* **Security**
  * Added secret redaction for prompts and privacy-focused audit logging.
  * Drafts always require explicit confirmation and cannot execute transactions autonomously.

* **Documentation**
  * Expanded guidance for configuration, fallback behavior, guardrails, and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->