### PR TITLE
fix(relayer): mark scheduled transfers as failed after max consecutiv…

### DIFF
--- a/services/relayer/src/metrics/index.ts
+++ b/services/relayer/src/metrics/index.ts
@@ -138,11 +138,13 @@ class SimpleGauge {
  * scheduler_jobs_failed_total — count of failed executions.
  * scheduler_job_lag_seconds — seconds between next_run_at and actual execution time.
  * scheduler_consecutive_failures_total — times a transfer accumulated ≥2 consecutive failures.
+ * scheduler_max_failures_reached_total — times a transfer reached the max consecutive failure cap.
  */
 export const schedulerJobsExecuted = new SimpleCounter();
 export const schedulerJobsSucceeded = new SimpleCounter();
 export const schedulerJobsFailed = new SimpleCounter();
 export const schedulerConsecutiveFailures = new SimpleCounter();
+export const schedulerMaxFailuresReached = new SimpleCounter();
 
 /** Gauge: sum of lag seconds across all executions in this process lifetime. */
 export const schedulerJobLagSecondsTotal = new SimpleGauge();
@@ -218,6 +220,12 @@ export function renderPrometheusMetrics(): string {
   );
   lines.push('# TYPE scheduler_consecutive_failures_total counter');
   lines.push(`scheduler_consecutive_failures_total ${schedulerConsecutiveFailures.get()}`);
+
+  lines.push(
+    '# HELP scheduler_max_failures_reached_total Transfers that reached the max consecutive failures cap'
+  );
+  lines.push('# TYPE scheduler_max_failures_reached_total counter');
+  lines.push(`scheduler_max_failures_reached_total ${schedulerMaxFailuresReached.get()}`);
 
   lines.push(
     '# HELP scheduler_job_lag_seconds_total Cumulative seconds between next_run_at and actual execution'

--- a/services/relayer/src/scheduler/ScheduledTransferService.ts
+++ b/services/relayer/src/scheduler/ScheduledTransferService.ts
@@ -5,6 +5,7 @@ import { nextRetryAfter } from '../queue/backoff';
 import { ScheduledTransferStore } from './ScheduledTransferStore';
 import type { PgScheduledTransferStore } from './PgScheduledTransferStore';
 import { computeNextRunAt, isDue } from './schedule-utils';
+import { schedulerMaxFailuresReached } from '../metrics';
 import type {
   CreateScheduledTransferInput,
   ScheduledTransfer,
@@ -53,7 +54,12 @@ export class ScheduledTransferService {
 
   async cancel(id: string, callerId: string): Promise<ScheduledTransfer | undefined> {
     const transfer = await this.store.getByIdForCaller(id, callerId);
-    if (!transfer || transfer.status === 'cancelled' || transfer.status === 'completed') {
+    if (
+      !transfer ||
+      transfer.status === 'cancelled' ||
+      transfer.status === 'completed' ||
+      transfer.status === 'failed'
+    ) {
       return undefined;
     }
     return this.store.updateStatus(id, 'cancelled');
@@ -135,12 +141,15 @@ export class ScheduledTransferService {
 
       if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
         await this.store.updateAfterExecution(transfer.id, {
-          status: 'completed',
+          status: 'failed',
           nextRunAt: transfer.nextRunAt,
           lastExecutionAt: executedAt,
           consecutiveFailures,
         });
-        // Notify: max failures reached, transfer cancelled
+
+        schedulerMaxFailuresReached.inc();
+
+        // Notify: max failures reached, transfer terminated
         if (this.notifier) {
           await this.notifier.onMaxFailuresReached(transfer).catch(() => {});
         }

--- a/services/relayer/src/scheduler/schemas.ts
+++ b/services/relayer/src/scheduler/schemas.ts
@@ -54,7 +54,7 @@ export interface ScheduledTransfer {
   amount: string;
   asset: string;
   frequency: z.infer<typeof scheduleFrequencySchema>;
-  status: 'active' | 'paused' | 'cancelled' | 'completed';
+  status: 'active' | 'paused' | 'cancelled' | 'completed' | 'failed';
   startAt: string;
   nextRunAt: string;
   endAt?: string;

--- a/services/relayer/tests/unit/scheduledTransferServicePg.test.ts
+++ b/services/relayer/tests/unit/scheduledTransferServicePg.test.ts
@@ -124,6 +124,23 @@ describe('ScheduledTransferService — failure notifications', () => {
     );
   });
 
+  it('transitions to failed status when consecutive failures reach the cap', async () => {
+    const transfer = makeTransfer({ consecutiveFailures: 4, frequency: 'monthly' }); // will become 5
+    const store = makeAsyncStore([transfer]);
+    const relayService = makeRelayService(false);
+
+    const svc = new ScheduledTransferService(store, relayService);
+    await svc.processDueTransfers(new Date());
+
+    expect(store.updateAfterExecution).toHaveBeenCalledWith(
+      transfer.id,
+      expect.objectContaining({
+        status: 'failed',
+        consecutiveFailures: 5,
+      })
+    );
+  });
+
   it('calls onMaxFailuresReached when consecutive failures reach the cap', async () => {
     const transfer = makeTransfer({ consecutiveFailures: 4, frequency: 'monthly' }); // will become 5
     const store = makeAsyncStore([transfer]);
@@ -139,6 +156,10 @@ describe('ScheduledTransferService — failure notifications', () => {
 
     expect(notifier.onMaxFailuresReached).toHaveBeenCalledOnce();
     expect(notifier.onConsecutiveFailure).not.toHaveBeenCalled();
+    expect(store.updateAfterExecution).toHaveBeenCalledWith(
+      transfer.id,
+      expect.objectContaining({ status: 'failed' })
+    );
   });
 
   it('records failure notification in pg store on max failures', async () => {
@@ -153,6 +174,10 @@ describe('ScheduledTransferService — failure notifications', () => {
       transfer.id,
       'max_failures_reached',
       expect.objectContaining({ consecutiveFailures: 5 })
+    );
+    expect(store.updateAfterExecution).toHaveBeenCalledWith(
+      transfer.id,
+      expect.objectContaining({ status: 'failed' })
     );
   });
 


### PR DESCRIPTION
## Description

Update the scheduled-transfer worker to transition transfers into a terminal `failed` state after exceeding the maximum consecutive retry threshold. The final failure reason is persisted and exposed through logs/metrics, improving observability and preventing permanently failing transfers from remaining in an active state indefinitely. A regression test has been added to verify the failure-threshold transition.

## Related Issue

Closes #1116

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No console errors
- [ ] Uses Lucide icons consistently (N/A – backend infrastructure project)
- [x] Responsive design implemented (N/A)
- [x] Starknet best practices followed (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled transfers can now enter a terminal **failed** state after reaching the maximum consecutive failure limit.
  * Added monitoring metrics to track transfers reaching this limit.

* **Bug Fixes**
  * Transfers marked as failed can no longer be cancelled.
  * Failure handling now consistently records the transfer’s terminal status and failure count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->