### PR TITLE
fix(web-dashboard): treat unparseable fee as an error state

### DIFF
--- a/apps/web-dashboard/src/hooks/__tests__/useSendFeeEstimate.test.ts
+++ b/apps/web-dashboard/src/hooks/__tests__/useSendFeeEstimate.test.ts
@@ -85,4 +85,31 @@ describe('useSendFeeEstimate', () => {
     expect(result.current.fee).toBe('0.0000100');
     expect(result.current.minBalance).toBe('0.0050100');
   });
+
+  it('handles unparseable fee as an error state', async () => {
+    vi.mock('@ancore/stellar', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@ancore/stellar')>();
+      return {
+        ...actual,
+        createStellarClient: () => ({
+          simulateTransaction: vi.fn().mockResolvedValue({ fee: 'not-a-number' }),
+        }),
+      };
+    });
+
+    const { useSendFeeEstimate } = await import('../useSendFeeEstimate');
+    const { result } = renderHook(() => useSendFeeEstimate(VALID_ADDRESS, '10', { debounceMs: 0 }));
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.fee).toBe('0.0000100');
+    expect(result.current.minBalance).toBe('0.0050100');
+    expect(result.current.error).toBe('fee unavailable');
+    
+    vi.doUnmock('@ancore/stellar');
+  });
 });

--- a/apps/web-dashboard/src/hooks/useSendFeeEstimate.ts
+++ b/apps/web-dashboard/src/hooks/useSendFeeEstimate.ts
@@ -104,13 +104,22 @@ export function useSendFeeEstimate(
           if (cancelledRef.current) return;
 
           if ('fee' in result && typeof result.fee === 'string') {
-            const feeNum = parseFloat(result.fee) || 0;
-            setState({
-              fee: result.fee,
-              minBalance: (0.5 + feeNum).toFixed(7),
-              loading: false,
-              error: null,
-            });
+            const feeNum = parseFloat(result.fee);
+            if (Number.isFinite(feeNum)) {
+              setState({
+                fee: result.fee,
+                minBalance: (0.5 + feeNum).toFixed(7),
+                loading: false,
+                error: null,
+              });
+            } else {
+              setState({
+                fee: '0.0000100',
+                minBalance: '0.0050100',
+                loading: false,
+                error: 'fee unavailable',
+              });
+            }
           } else {
             const errorMsg =
               'error' in result && typeof result.error === 'string'

--- a/apps/web-dashboard/src/services/__tests__/send-service.test.ts
+++ b/apps/web-dashboard/src/services/__tests__/send-service.test.ts
@@ -37,6 +37,24 @@ describe('WalletApiSendStrategy', () => {
     const available = await strategy.isAvailable();
     expect(available).toBe(false);
   });
+
+  it('throws fee unavailable when simulated fee is unparseable', async () => {
+    vi.mock('@ancore/stellar', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('@ancore/stellar')>();
+      return {
+        ...actual,
+        createStellarClient: () => ({
+          simulateTransaction: vi.fn().mockResolvedValue({ fee: 'not-a-number' }),
+        }),
+      };
+    });
+
+    const { WalletApiSendStrategy } = await import('../send-service');
+    const strategy = new WalletApiSendStrategy(TESTNET_DEPS);
+    await expect(strategy.estimateFee({ recipient: VALID_ADDRESS, amount: '10' })).rejects.toThrow('fee unavailable');
+    
+    vi.doUnmock('@ancore/stellar');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web-dashboard/src/services/send-service.ts
+++ b/apps/web-dashboard/src/services/send-service.ts
@@ -166,7 +166,10 @@ export class WalletApiSendStrategy implements SendStrategy {
           minBalance: calculateMinBalance(result.fee),
         };
       }
-    } catch {
+    } catch (err) {
+      if (err instanceof Error && err.message === 'fee unavailable') {
+        throw err;
+      }
       // Fall through to default
     }
 
@@ -277,7 +280,10 @@ function resolveAsset(asset: SendParams['asset']): Asset {
 }
 
 function calculateMinBalance(feeXlm: string): string {
-  const feeNum = parseFloat(feeXlm) || 0;
+  const feeNum = parseFloat(feeXlm);
+  if (!Number.isFinite(feeNum)) {
+    throw new Error('fee unavailable');
+  }
   // Base reserve is 0.5 XLM + fee
   return (0.5 + feeNum).toFixed(7);
 }


### PR DESCRIPTION
Closes #1182 
## Description

When fetching fee estimates, the `parseFloat(fee) || 0` fallback in both `useSendFeeEstimate.ts` and `send-service.ts` collapses malformed or non-numeric strings to `0`. This effectively removes the network fee from the `minBalance` calculation, potentially misrepresenting the required balance and pushing user accounts below reserve thresholds.

This PR treats unparseable fee strings strictly as an error state rather than defaulting to `0`. 
- **services/send-service.ts**: `calculateMinBalance` uses `Number.isFinite(...)` and now throws a specific `'fee unavailable'` error, which is propagated instead of swallowed.
- **hooks/useSendFeeEstimate.ts**: Also uses `Number.isFinite(...)` and surfaces a `'fee unavailable'` error if the string is malformed instead of defaulting to `0`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test addition/improvement

## Security Impact

- [ ] This change involves cryptographic operations
- [ ] This change affects account validation logic
- [ ] This change modifies smart contracts
- [ ] This change handles user private keys
- [ ] This change affects authorization/authentication
- [x] No security impact

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests added/updated (if applicable)

### Test Coverage

- Current coverage: N/A
- New/modified code coverage: N/A

### Manual Testing Steps

N/A

## Breaking Changes

- [ ] This PR introduces breaking changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] Any flaky-test quarantine entry includes a linked follow-up issue, owner, expiry, and stable failure signature

### For High-Security Changes

- [ ] I have documented all security assumptions
- [ ] I have considered attack vectors
- [ ] I have added security-focused test cases
- [ ] I have reviewed against the threat model

## Related Issues

Closes #
Related to #

## Additional Context

N/A

## Reviewer Notes

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fee estimation now detects invalid or unavailable transaction fees instead of treating them as zero.
  - Users receive a clear “fee unavailable” error when reliable fee data cannot be obtained.
  - Invalid fee responses no longer produce misleading minimum-balance calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->