### PR TITLE
fix(security): resolve unguarded atob/btoa crashes with EncodingError validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Ancore
 
+
+
 > Stellar-native account abstraction stack: Soroban smart account contract, SDKs, relayer, indexer, and wallet apps.
 > Wallet engineering standards are benchmarked against SDF [Freighter](https://github.com/stellar/freighter) (extension) and [Freighter Mobile](https://github.com/stellar/freighter-mobile) — see [docs/wallets/FREIGHTER_COMPARISON.md](docs/wallets/FREIGHTER_COMPARISON.md).
 

--- a/apps/mobile-wallet/src/security/__tests__/encoding.test.ts
+++ b/apps/mobile-wallet/src/security/__tests__/encoding.test.ts
@@ -1,0 +1,31 @@
+import { bufferToBase64, base64ToBytes, EncodingError } from '../encoding';
+
+describe('Security Encoding Infrastructure Guards', () => {
+  it('should cleanly perform round-trip transformations without data loss', () => {
+    const mockBytes = new Uint8Array([83, 117, 112, 101, 114, 83, 101, 99, 114, 101, 116]);
+    const encodedBase64 = bufferToBase64(mockBytes);
+    const decodedBytes = base64ToBytes(encodedBase64);
+
+    expect(decodedBytes).toEqual(mockBytes);
+  });
+
+  it('should reject structurally broken characters by throwing a descriptive EncodingError', () => {
+    const invalidPayload = 'not*base64';
+
+    expect(() => {
+      base64ToBytes(invalidPayload);
+    }).toThrow(EncodingError);
+
+    expect(() => {
+      base64ToBytes(invalidPayload);
+    }).toThrow('invalid base64');
+  });
+
+  it('should fail on inputs that break the 4-byte padding modulus alignment constraint', () => {
+    const unpaddedMismatchedLength = 'dGVzdA'; 
+
+    expect(() => {
+      base64ToBytes(unpaddedMismatchedLength);
+    }).toThrow(EncodingError);
+  });
+});

--- a/apps/mobile-wallet/src/security/encoding.ts
+++ b/apps/mobile-wallet/src/security/encoding.ts
@@ -1,3 +1,13 @@
+export class EncodingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EncodingError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, EncodingError);
+    }
+  }
+}
+
 export function bufferToBase64(buffer: ArrayBuffer | Uint8Array): string {
   const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
   let binary = '';
@@ -6,11 +16,29 @@ export function bufferToBase64(buffer: ArrayBuffer | Uint8Array): string {
     binary += String.fromCharCode(bytes[index]);
   }
 
-  return globalThis.btoa(binary);
+  try {
+    return globalThis.btoa(binary);
+  } catch (error) {
+    throw new EncodingError('Failed to generate base64 string from source bytes.');
+  }
 }
 
 export function base64ToBytes(base64: string): Uint8Array {
-  const binary = globalThis.atob(base64);
+  const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
+  const sanitized = base64.trim();
+
+  if (!base64Regex.test(sanitized) || sanitized.length % 4 !== 0) {
+    throw new EncodingError('invalid base64');
+  }
+
+  let binary: string;
+  
+  try {
+    binary = globalThis.atob(sanitized);
+  } catch (rawError) {
+    throw new EncodingError('invalid base64');
+  }
+
   const bytes = new Uint8Array(binary.length);
 
   for (let index = 0; index < binary.length; index += 1) {


### PR DESCRIPTION
### Description
Addresses a security vulnerability where passing corrupted, unpadded, or malformed base64 cryptographic material directly to unguarded `atob` operations triggers an unhandled `InvalidCharacterError` runtime application crash. 

This solution adds defensive input boundary sanitation rules, wraps decoding operations inside a clean try/catch block, and re-throws a typed `EncodingError('invalid base64')` domain error instead of letting raw lower-level runtime exceptions escape.

### Changes
- Implemented `EncodingError` custom error class.
- Added explicit regular expression checks to validate base64 charset formatting.
- Added strict length validation matching the 4-byte padding modulus alignment constraint.
- Added comprehensive unit tests inside `__tests__/encoding.test.ts` verifying binary-to-base64 data round-trips, strict padding blocks, and unexpected character rejections.

Closes #1174
