### PR TITLE
fix: storage round-trips, ingest DLQ, and overview widget boundaries

### DIFF
--- a/apps/extension-wallet/src/background/handlers/external/__tests__/handlers.test.ts
+++ b/apps/extension-wallet/src/background/handlers/external/__tests__/handlers.test.ts
@@ -107,14 +107,23 @@ describe('handleRequestAccess', () => {
     const { openApprovalWindow } = await import('../../../approval-window');
 
     vi.mocked(isAllowed).mockResolvedValueOnce(false);
-    vi.mocked(registerResponseCallbacks).mockImplementation((_requestId, resolve) => resolve({ ok: true }));
+    vi.mocked(registerResponseCallbacks).mockImplementation((_requestId, resolve) =>
+      resolve({ ok: true })
+    );
 
     const result = await handleRequestAccess(makeCtx('https://dapp.example'));
 
     expect(enqueueApproval).toHaveBeenCalled();
     expect(openApprovalWindow).toHaveBeenCalledWith('test-req-id', 'grant-access');
-    expect(addToAllowlist).toHaveBeenCalledWith('testnet', 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 'https://dapp.example');
-    expect(result).toEqual({ smartAccountId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', network: 'testnet' });
+    expect(addToAllowlist).toHaveBeenCalledWith(
+      'testnet',
+      'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      'https://dapp.example'
+    );
+    expect(result).toEqual({
+      smartAccountId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      network: 'testnet',
+    });
   });
 
   it('does not add the origin to the allowlist when the user rejects access', async () => {
@@ -122,9 +131,13 @@ describe('handleRequestAccess', () => {
     const { registerResponseCallbacks } = await import('../response-queue');
 
     vi.mocked(isAllowed).mockResolvedValueOnce(false);
-    vi.mocked(registerResponseCallbacks).mockImplementation((_requestId, _resolve, reject) => reject(new Error('User rejected')));
+    vi.mocked(registerResponseCallbacks).mockImplementation((_requestId, _resolve, reject) =>
+      reject(new Error('User rejected'))
+    );
 
-    await expect(handleRequestAccess(makeCtx('https://dapp.example'))).rejects.toThrow('User rejected');
+    await expect(handleRequestAccess(makeCtx('https://dapp.example'))).rejects.toThrow(
+      'User rejected'
+    );
     expect(addToAllowlist).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile-wallet/README.md
+++ b/apps/mobile-wallet/README.md
@@ -21,15 +21,15 @@ is its entry screen).
 
 See [`src/index.ts`](./src/index.ts) for the full surface. The main groups:
 
-| Export area                                        | Examples                                                            |
-| ---------------------------------------------------- | --------------------------------------------------------------------- |
-| Navigation                                          | `OnboardingNavigator`, `OnboardingNavigatorTestHarness`              |
-| Screens                                             | `HistoryScreen`, `WCPairingScreen`                                   |
-| Config                                              | `loadMobileWalletEnvironment`, `loadMobileWalletEnvironmentFromEnv`, `resolveServiceUrls` |
-| Security                                            | Biometric adapters, `MobileSecureVault`, lockout manager (`./src/security`) |
-| Storage                                             | Keychain-backed secure store adapter (`./src/storage`)               |
-| WalletConnect                                       | `WalletKitProvider`, `useWalletConnect`, `createStellarRpcHandlers`, `SessionApprovalSheet`, `SignAuthEntryApprovalSheet` |
-| Accounts / SDK                                      | `./src/accounts`, `./src/sdk`                                        |
+| Export area    | Examples                                                                                                                  |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Navigation     | `OnboardingNavigator`, `OnboardingNavigatorTestHarness`                                                                   |
+| Screens        | `HistoryScreen`, `WCPairingScreen`                                                                                        |
+| Config         | `loadMobileWalletEnvironment`, `loadMobileWalletEnvironmentFromEnv`, `resolveServiceUrls`                                 |
+| Security       | Biometric adapters, `MobileSecureVault`, lockout manager (`./src/security`)                                               |
+| Storage        | Keychain-backed secure store adapter (`./src/storage`)                                                                    |
+| WalletConnect  | `WalletKitProvider`, `useWalletConnect`, `createStellarRpcHandlers`, `SessionApprovalSheet`, `SignAuthEntryApprovalSheet` |
+| Accounts / SDK | `./src/accounts`, `./src/sdk`                                                                                             |
 
 Host apps (currently `apps/mobile-app`) import from `@ancore/mobile-wallet`
 and provide the React Native shell, native modules, and build config.

--- a/apps/web-dashboard/src/services/invoice-service.ts
+++ b/apps/web-dashboard/src/services/invoice-service.ts
@@ -48,7 +48,10 @@ export async function openInvoice(invoiceId: string): Promise<OpenInvoiceResult>
   return _client.open(invoiceId);
 }
 
-export async function payInvoice(invoiceId: string, paymentTxHash: string): Promise<PayInvoiceResult> {
+export async function payInvoice(
+  invoiceId: string,
+  paymentTxHash: string
+): Promise<PayInvoiceResult> {
   return _client.pay({ invoiceId, paymentTxHash });
 }
 

--- a/apps/web-dashboard/src/widgets/__tests__/AccountOverviewGrid.test.tsx
+++ b/apps/web-dashboard/src/widgets/__tests__/AccountOverviewGrid.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { AccountOverviewGrid } from '../AccountOverviewGrid';
+
+vi.mock('lucide-react', () => ({
+  AlertCircle: () => <div data-testid="alert-icon" />,
+  RefreshCw: () => <div data-testid="refresh-icon" />,
+  Wallet: () => <div data-testid="wallet-icon" />,
+  Hash: () => <div data-testid="hash-icon" />,
+  ShieldCheck: () => <div data-testid="shield-check-icon" />,
+  ShieldAlert: () => <div data-testid="shield-alert-icon" />,
+  Shield: () => <div data-testid="shield-icon" />,
+}));
+
+vi.mock('@ancore/ui-kit', () => ({
+  Card: ({ children, className, ...props }: any) => (
+    <div className={className} {...props}>
+      {children}
+    </div>
+  ),
+  CardHeader: ({ children, className, ...props }: any) => (
+    <div className={className} {...props}>
+      {children}
+    </div>
+  ),
+  CardTitle: ({ children, className, ...props }: any) => (
+    <div className={className} {...props}>
+      {children}
+    </div>
+  ),
+  CardContent: ({ children, className, ...props }: any) => (
+    <div className={className} {...props}>
+      {children}
+    </div>
+  ),
+  Skeleton: ({ className, ...props }: any) => (
+    <div className={className} aria-hidden="true" {...props} />
+  ),
+}));
+
+vi.mock('../../hooks/useAccountOverview', () => ({
+  useAccountOverview: () => ({
+    data: { balance: 100.5, nonce: 42, status: 'active' },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../OnboardingHints', () => ({
+  OnboardingHints: () => <div data-testid="onboarding-hints" />,
+}));
+
+const balanceShouldThrow = vi.fn(() => false);
+
+vi.mock('../AccountWidgets', async () => {
+  const actual = await vi.importActual<typeof import('../AccountWidgets')>('../AccountWidgets');
+  return {
+    ...actual,
+    BalanceWidget: (props: any) => {
+      if (balanceShouldThrow()) {
+        throw new Error('Unexpected balance widget crash');
+      }
+      return actual.BalanceWidget(props);
+    },
+  };
+});
+
+describe('AccountOverviewGrid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    balanceShouldThrow.mockReturnValue(false);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('renders overview widgets when healthy', () => {
+    render(
+      <AccountOverviewGrid publicKey="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" />
+    );
+
+    expect(screen.getByText('Total Balance')).toBeInTheDocument();
+    expect(screen.getByText('Account Nonce')).toBeInTheDocument();
+    expect(screen.getByText('Account Status')).toBeInTheDocument();
+    expect(screen.getByText('100.50 XLM')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('catches unhandled throw inside WidgetErrorBoundary and allows retry', () => {
+    balanceShouldThrow.mockReturnValue(true);
+
+    render(
+      <AccountOverviewGrid publicKey="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" />
+    );
+
+    expect(screen.getByText('Widget Failed')).toBeInTheDocument();
+    expect(screen.getByText('Unexpected balance widget crash')).toBeInTheDocument();
+
+    const retryBtn = screen.getByRole('button', { name: /retry/i });
+    expect(retryBtn).toBeInTheDocument();
+
+    // Sibling widgets stay mounted
+    expect(screen.getByText('Account Nonce')).toBeInTheDocument();
+    expect(screen.getByText('Account Status')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+
+    balanceShouldThrow.mockReturnValue(false);
+    fireEvent.click(retryBtn);
+
+    expect(screen.queryByText('Widget Failed')).not.toBeInTheDocument();
+    expect(screen.getByText('Total Balance')).toBeInTheDocument();
+    expect(screen.getByText('100.50 XLM')).toBeInTheDocument();
+  });
+});

--- a/packages/core-sdk/README.md
+++ b/packages/core-sdk/README.md
@@ -251,13 +251,13 @@ same derived key. Multi-account support requires #872.
 `sign()` does not catch or translate errors — callers must handle whatever
 `@ledgerhq/hw-transport-webhid` / `@ledgerhq/hw-app-str` throw:
 
-| Cause                                      | What happens                                                   |
-| ------------------------------------------ | ---------------------------------------------------------------- |
-| No Ledger device connected                 | `TransportWebHID.create()` rejects (device picker cancelled/empty) |
+| Cause                                      | What happens                                                                      |
+| ------------------------------------------ | --------------------------------------------------------------------------------- |
+| No Ledger device connected                 | `TransportWebHID.create()` rejects (device picker cancelled/empty)                |
 | Stellar app not open on the device         | `signTransaction` rejects with a `TransportStatusError` (wrong app/locked device) |
-| User rejects the signing request on-device | `signTransaction` rejects with a status-`0x6985` `TransportStatusError` |
-| Browser lacks WebHID support               | `TransportWebHID.create()` throws — see feature detection below |
-| Transaction too large / unsupported opcode | `signTransaction` rejects with a parsing error from the Stellar app |
+| User rejects the signing request on-device | `signTransaction` rejects with a status-`0x6985` `TransportStatusError`           |
+| Browser lacks WebHID support               | `TransportWebHID.create()` throws — see feature detection below                   |
+| Transaction too large / unsupported opcode | `signTransaction` rejects with a parsing error from the Stellar app               |
 
 None of these are wrapped in Ancore-specific error types today; catch and
 map them at the call site.

--- a/packages/core-sdk/src/invoice-client.ts
+++ b/packages/core-sdk/src/invoice-client.ts
@@ -1,5 +1,5 @@
 import type { Invoice, CreateInvoiceInput, InvoiceStatus } from '@ancore/types';
-import { resolveRelayerBaseUrl } from './resolve-relayer-base-url';
+import { resolveRelayerBaseUrl } from './scheduler-client';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -74,14 +74,14 @@ export class InvoiceClient {
   async listByCreator(creatorAddress: string): Promise<ListInvoicesResult> {
     return this.request<ListInvoicesResult>(
       'GET',
-      `/invoices?creator=${encodeURIComponent(creatorAddress)}`,
+      `/invoices?creator=${encodeURIComponent(creatorAddress)}`
     );
   }
 
   async listByRecipient(recipientAddress: string): Promise<ListInvoicesResult> {
     return this.request<ListInvoicesResult>(
       'GET',
-      `/invoices?recipient=${encodeURIComponent(recipientAddress)}`,
+      `/invoices?recipient=${encodeURIComponent(recipientAddress)}`
     );
   }
 
@@ -119,7 +119,8 @@ export class InvoiceClient {
    * Useful for email / messaging.
    */
   buildPaymentLink(invoiceId: string, appBaseUrl?: string): string {
-    const base = appBaseUrl ?? (typeof window !== 'undefined' ? window.location.origin : '');
+    const locationOrigin = (globalThis as { location?: { origin?: string } }).location?.origin;
+    const base = appBaseUrl ?? locationOrigin ?? '';
     return `${base}/invoices/${invoiceId}/pay`;
   }
 
@@ -128,7 +129,7 @@ export class InvoiceClient {
   private async request<T>(
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
     path: string,
-    body?: unknown,
+    body?: unknown
   ): Promise<T> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -165,7 +166,7 @@ export class InvoiceClient {
 export class InvoiceClientError extends Error {
   constructor(
     message: string,
-    public readonly statusCode: number,
+    public readonly statusCode: number
   ) {
     super(message);
     this.name = 'InvoiceClientError';

--- a/packages/core-sdk/src/storage/__tests__/normalize-storage-adapter.test.ts
+++ b/packages/core-sdk/src/storage/__tests__/normalize-storage-adapter.test.ts
@@ -1,0 +1,89 @@
+import type { StorageAdapter } from '../types';
+import { normalizeStorageAdapter, tryParseStructuredJson } from '../secure-storage-manager';
+
+class MockStorageAdapter implements StorageAdapter {
+  readonly store = new Map<string, unknown>();
+
+  async get<T>(key: string): Promise<T | null> {
+    return (this.store.get(key) as T | undefined) ?? null;
+  }
+
+  async set(key: string, value: unknown): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async remove(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+describe('tryParseStructuredJson', () => {
+  it.each(['true', 'false', 'null', '1e3', '123', '12ab', 'hello', '"quoted"'])(
+    'does not treat scalar-like string %j as structured JSON',
+    (value) => {
+      expect(tryParseStructuredJson(value)).toBeUndefined();
+    }
+  );
+
+  it('parses object and array containers', () => {
+    expect(tryParseStructuredJson('{"a":1}')).toEqual({ a: 1 });
+    expect(tryParseStructuredJson('[1,2]')).toEqual([1, 2]);
+    expect(tryParseStructuredJson('  {"nested":true}')).toEqual({ nested: true });
+  });
+
+  it('returns undefined for malformed container-shaped strings', () => {
+    expect(tryParseStructuredJson('{')).toBeUndefined();
+    expect(tryParseStructuredJson('[1,')).toBeUndefined();
+  });
+});
+
+describe('normalizeStorageAdapter round-trip', () => {
+  let legacy: MockStorageAdapter;
+  let platform: ReturnType<typeof normalizeStorageAdapter>;
+
+  beforeEach(() => {
+    legacy = new MockStorageAdapter();
+    platform = normalizeStorageAdapter(legacy);
+  });
+
+  it.each(['true', 'null', '1e3', '12ab'])(
+    'round-trips string value %j byte-identical and stores a string',
+    async (value) => {
+      await platform.set('k', value);
+
+      expect(legacy.store.get('k')).toBe(value);
+      expect(typeof legacy.store.get('k')).toBe('string');
+      expect(await platform.get('k')).toBe(value);
+    }
+  );
+
+  it('stores JSON object strings as objects in the legacy store', async () => {
+    await platform.set('obj', '{"salt":"a","iv":"b","data":"c"}');
+
+    expect(legacy.store.get('obj')).toEqual({ salt: 'a', iv: 'b', data: 'c' });
+    expect(await platform.get('obj')).toBe('{"salt":"a","iv":"b","data":"c"}');
+  });
+
+  it('stores JSON array strings as arrays in the legacy store', async () => {
+    await platform.set('arr', '[1,2,3]');
+
+    expect(legacy.store.get('arr')).toEqual([1, 2, 3]);
+    expect(await platform.get('arr')).toBe('[1,2,3]');
+  });
+
+  it('reads legacy bare objects without an envelope', async () => {
+    await legacy.set('legacy', { salt: 'x', iv: 'y', data: 'z' });
+
+    expect(await platform.get('legacy')).toBe('{"salt":"x","iv":"y","data":"z"}');
+  });
+
+  it('passes through a PlatformStorageAdapter unchanged', () => {
+    const platformOnly = {
+      get: async () => null,
+      set: async () => undefined,
+      delete: async () => undefined,
+    };
+
+    expect(normalizeStorageAdapter(platformOnly)).toBe(platformOnly);
+  });
+});

--- a/packages/core-sdk/src/storage/secure-storage-manager.ts
+++ b/packages/core-sdk/src/storage/secure-storage-manager.ts
@@ -46,7 +46,36 @@ function isLegacyStorageAdapter(
   return typeof (storage as StorageAdapter).remove === 'function';
 }
 
-function normalizeStorageAdapter(
+/**
+ * Parse only JSON object/array containers. Never coerce JSON scalars
+ * (`true`, `null`, `1e3`, …) — those must remain plain strings so
+ * round-trips stay byte-identical. Inferring JSON-ness from bare
+ * `JSON.parse` success is unsafe.
+ */
+export function tryParseStructuredJson(value: string): object | undefined {
+  const first = value.trimStart()[0];
+  if (first !== '{' && first !== '[') {
+    return undefined;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (parsed !== null && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch {
+    // Invalid JSON — keep the original string.
+  }
+
+  return undefined;
+}
+
+/**
+ * Bridge a legacy `StorageAdapter` (typed `unknown` values) to the
+ * string-only `PlatformStorageAdapter` surface used by SecureStorageManager.
+ * Structured JSON is stored as native objects; everything else as strings.
+ */
+export function normalizeStorageAdapter(
   storage: PlatformStorageAdapter | StorageAdapter
 ): PlatformStorageAdapter {
   if (!isLegacyStorageAdapter(storage)) {
@@ -62,11 +91,8 @@ function normalizeStorageAdapter(
       return typeof value === 'string' ? value : JSON.stringify(value);
     },
     set: async (key, value) => {
-      try {
-        await storage.set(key, JSON.parse(value));
-      } catch {
-        await storage.set(key, value);
-      }
+      const structured = tryParseStructuredJson(value);
+      await storage.set(key, structured !== undefined ? structured : value);
     },
     delete: (key) => storage.remove(key),
   };

--- a/services/ai-agent/src/schemas/amount.ts
+++ b/services/ai-agent/src/schemas/amount.ts
@@ -15,9 +15,12 @@ export const amountStringSchema = z
   .refine((value) => Number(value) <= MAX_AMOUNT_VALUE, {
     message: 'Amount is too large',
   })
-  .refine((value) => {
-    const [, fractionalPart = ''] = value.split('.');
-    return fractionalPart.length <= 7;
-  }, {
-    message: 'Amount must not exceed 7 decimal places',
-  });
+  .refine(
+    (value) => {
+      const [, fractionalPart = ''] = value.split('.');
+      return fractionalPart.length <= 7;
+    },
+    {
+      message: 'Amount must not exceed 7 decimal places',
+    }
+  );

--- a/services/indexer/migrations/008_create_ingest_dead_letters_table.sql
+++ b/services/indexer/migrations/008_create_ingest_dead_letters_table.sql
@@ -1,0 +1,27 @@
+-- Dead-letter queue for raw events that fail normalisation.
+--
+-- When the ingest worker cannot normalise an event it writes the raw payload
+-- here so the failure is recoverable after a fix, instead of being silently
+-- dropped while the checkpoint advances.
+CREATE TABLE IF NOT EXISTS ingest_dead_letters (
+    id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    stream          VARCHAR(64)  NOT NULL,
+    ledger_seq      BIGINT       NOT NULL,
+    tx_hash         VARCHAR(64)  NOT NULL DEFAULT '',
+    contract_id     VARCHAR(56)  NOT NULL DEFAULT '',
+    error_message   TEXT         NOT NULL,
+    raw_payload     JSONB        NOT NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    reprocessed_at  TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_dead_letters_stream_ledger
+    ON ingest_dead_letters (stream, ledger_seq DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_dead_letters_unprocessed
+    ON ingest_dead_letters (created_at)
+    WHERE reprocessed_at IS NULL;
+
+INSERT INTO schema_migrations (version, name)
+VALUES (8, 'create_ingest_dead_letters_table')
+ON CONFLICT (version) DO NOTHING;

--- a/services/indexer/scripts/check-migrations.sh
+++ b/services/indexer/scripts/check-migrations.sh
@@ -52,6 +52,7 @@ if [[ "${SKIP_DOWN:-0}" != "1" ]]; then
     DROP TABLE IF EXISTS ingest_checkpoints CASCADE;
     DROP TABLE IF EXISTS schema_migrations CASCADE;
     DROP TABLE IF EXISTS contract_events CASCADE;
+    DROP TABLE IF EXISTS ingest_dead_letters CASCADE;
   "
   echo "==> Re-applying migrations after teardown"
   for file in "$MIGRATIONS_DIR"/*.sql; do

--- a/services/indexer/src/ingest/dead_letter.rs
+++ b/services/indexer/src/ingest/dead_letter.rs
@@ -1,0 +1,156 @@
+//! Dead-letter store for events that fail normalisation.
+//!
+//! When [`crate::schema::canonical::normalise`] rejects a raw event the ingest
+//! worker persists it here so the failure is observable and reprocessable
+//! after a fix, instead of being silently dropped.
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+use crate::schema::canonical::RawEvent;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// A raw event that could not be normalised, retained for later reprocessing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeadLetterRecord {
+    /// Ingestion stream that produced the failure.
+    pub stream: String,
+    /// Ledger sequence of the failed event.
+    pub ledger_seq: u32,
+    /// Human-readable normalisation error.
+    pub error: String,
+    /// Full raw event payload (recoverable input for reprocessing).
+    pub raw: RawEvent,
+    /// When the failure was recorded.
+    pub failed_at: DateTime<Utc>,
+}
+
+// ── Trait ─────────────────────────────────────────────────────────────────────
+
+/// Trait for durable storage of normalisation failures.
+#[async_trait::async_trait]
+pub trait DeadLetterStore: Send {
+    /// Persist one or more dead-letter records.
+    async fn persist_failures(&mut self, records: &[DeadLetterRecord]) -> anyhow::Result<()>;
+}
+
+// ── Postgres implementation ───────────────────────────────────────────────────
+
+/// Durable dead-letter store backed by PostgreSQL.
+#[derive(Debug, Clone)]
+pub struct PostgresDeadLetterStore {
+    pool: PgPool,
+}
+
+impl PostgresDeadLetterStore {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl DeadLetterStore for PostgresDeadLetterStore {
+    async fn persist_failures(&mut self, records: &[DeadLetterRecord]) -> anyhow::Result<()> {
+        persist_failures(&self.pool, records).await
+    }
+}
+
+/// Insert dead-letter rows for later reprocessing.
+pub async fn persist_failures(db: &PgPool, records: &[DeadLetterRecord]) -> anyhow::Result<()> {
+    for record in records {
+        let raw_payload =
+            serde_json::to_value(&record.raw).context("serialize dead-letter raw payload")?;
+
+        sqlx::query(
+            "INSERT INTO ingest_dead_letters \
+                (stream, ledger_seq, tx_hash, contract_id, error_message, raw_payload, created_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind(&record.stream)
+        .bind(record.ledger_seq as i64)
+        .bind(&record.raw.tx_hash)
+        .bind(&record.raw.contract_id)
+        .bind(&record.error)
+        .bind(raw_payload)
+        .bind(record.failed_at)
+        .execute(db)
+        .await
+        .context("persist dead-letter record")?;
+    }
+
+    Ok(())
+}
+
+// ── In-memory stub (tests) ────────────────────────────────────────────────────
+
+/// Accumulates dead-letter records in memory for assertion in tests.
+#[derive(Debug, Default)]
+pub struct MemoryDeadLetterStore {
+    pub records: Vec<DeadLetterRecord>,
+}
+
+#[async_trait::async_trait]
+impl DeadLetterStore for MemoryDeadLetterStore {
+    async fn persist_failures(&mut self, records: &[DeadLetterRecord]) -> anyhow::Result<()> {
+        self.records.extend_from_slice(records);
+        Ok(())
+    }
+}
+
+// ── Failing stub (tests) ──────────────────────────────────────────────────────
+
+/// A dead-letter store that always returns an error.
+pub struct FailingDeadLetterStore;
+
+#[async_trait::async_trait]
+impl DeadLetterStore for FailingDeadLetterStore {
+    async fn persist_failures(&mut self, _records: &[DeadLetterRecord]) -> anyhow::Result<()> {
+        Err(anyhow::anyhow!("simulated dead-letter store failure"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn sample_record() -> DeadLetterRecord {
+        DeadLetterRecord {
+            stream: "main".into(),
+            ledger_seq: 42,
+            error: "Missing required field: tx_hash".into(),
+            raw: RawEvent {
+                ledger_seq: 42,
+                ledger_close_time: Utc::now(),
+                tx_hash: String::new(),
+                contract_id: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN".into(),
+                topics: vec!["transfer".into()],
+                data: String::new(),
+            },
+            failed_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn memory_store_accumulates_records() {
+        let mut store = MemoryDeadLetterStore::default();
+        let record = sample_record();
+        store.persist_failures(&[record.clone()]).await.unwrap();
+        assert_eq!(store.records.len(), 1);
+        assert_eq!(store.records[0].ledger_seq, 42);
+        assert_eq!(store.records[0].error, record.error);
+    }
+
+    #[tokio::test]
+    async fn failing_store_returns_error() {
+        let mut store = FailingDeadLetterStore;
+        let err = store
+            .persist_failures(&[sample_record()])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("simulated dead-letter"));
+    }
+}

--- a/services/indexer/src/ingest/mod.rs
+++ b/services/indexer/src/ingest/mod.rs
@@ -1,5 +1,6 @@
 pub mod backfill;
 pub mod checkpoint;
+pub mod dead_letter;
 pub mod postgres_sink;
 pub mod rpc_source;
 pub mod sink;
@@ -7,6 +8,9 @@ pub mod source;
 pub mod worker;
 
 pub use checkpoint::{Checkpoint, CheckpointStore, MemoryCheckpointStore, PostgresCheckpointStore};
+pub use dead_letter::{
+    DeadLetterRecord, DeadLetterStore, MemoryDeadLetterStore, PostgresDeadLetterStore,
+};
 pub use postgres_sink::PostgresEventSink;
 pub use rpc_source::{RpcEventSource, RpcSourceConfig};
 pub use sink::{EventSink, MemorySink};

--- a/services/indexer/src/ingest/worker.rs
+++ b/services/indexer/src/ingest/worker.rs
@@ -4,13 +4,20 @@
 //! them into [`CanonicalEvent`]s, persists them, and advances the checkpoint
 //! cursor.  Out-of-order events (ledger_seq ≤ last checkpoint) are silently
 //! skipped to guarantee idempotent restarts.
+//!
+//! Events that fail normalisation are written to a [`DeadLetterStore`] and
+//! counted via [`crate::metrics::record_normalise_failure`] so failures are
+//! observable and recoverable rather than silently dropped.
 
 use anyhow::Context;
-use tracing::{debug, info, warn};
+use chrono::Utc;
+use tracing::{debug, error, info, warn};
 
 use super::checkpoint::{Checkpoint, CheckpointStore, MemoryCheckpointStore};
+use super::dead_letter::{DeadLetterRecord, DeadLetterStore, MemoryDeadLetterStore};
 use super::sink::EventSink;
 use super::source::EventSource;
+use crate::metrics;
 use crate::schema::canonical::{normalise, CanonicalEvent};
 
 // ── Worker ────────────────────────────────────────────────────────────────────
@@ -41,20 +48,23 @@ pub struct BatchStats {
     pub normalised: usize,
     pub persisted: usize,
     pub errors: usize,
+    /// Events written to the dead-letter store after a normalisation failure.
+    pub dead_lettered: usize,
 }
 
 /// The ingestion worker.
 ///
 /// Designed to be testable without a real database: the checkpoint store,
-/// event source, and event sink are all injected as trait objects.
-pub struct IngestWorker<Src, Snk, Cp = MemoryCheckpointStore> {
+/// event source, event sink, and dead-letter store are all injected.
+pub struct IngestWorker<Src, Snk, Cp = MemoryCheckpointStore, Dl = MemoryDeadLetterStore> {
     config: WorkerConfig,
     checkpoint: Cp,
     source: Src,
     sink: Snk,
+    dead_letters: Dl,
 }
 
-impl<Src, Snk> IngestWorker<Src, Snk, MemoryCheckpointStore>
+impl<Src, Snk> IngestWorker<Src, Snk, MemoryCheckpointStore, MemoryDeadLetterStore>
 where
     Src: EventSource,
     Snk: EventSink,
@@ -65,6 +75,7 @@ where
             checkpoint: MemoryCheckpointStore::default(),
             source,
             sink,
+            dead_letters: MemoryDeadLetterStore::default(),
         }
     }
 
@@ -75,7 +86,7 @@ where
     }
 }
 
-impl<Src, Snk, Cp> IngestWorker<Src, Snk, Cp>
+impl<Src, Snk, Cp> IngestWorker<Src, Snk, Cp, MemoryDeadLetterStore>
 where
     Src: EventSource,
     Snk: EventSink,
@@ -92,6 +103,29 @@ where
             checkpoint,
             source,
             sink,
+            dead_letters: MemoryDeadLetterStore::default(),
+        }
+    }
+}
+
+impl<Src, Snk, Cp, Dl> IngestWorker<Src, Snk, Cp, Dl>
+where
+    Src: EventSource,
+    Snk: EventSink,
+    Cp: CheckpointStore,
+    Dl: DeadLetterStore,
+{
+    /// Replace the dead-letter store (defaults to [`MemoryDeadLetterStore`]).
+    pub fn with_dead_letter_store<D: DeadLetterStore>(
+        self,
+        dead_letters: D,
+    ) -> IngestWorker<Src, Snk, Cp, D> {
+        IngestWorker {
+            config: self.config,
+            checkpoint: self.checkpoint,
+            source: self.source,
+            sink: self.sink,
+            dead_letters,
         }
     }
 
@@ -143,6 +177,7 @@ where
         }
 
         let mut canonical: Vec<CanonicalEvent> = Vec::with_capacity(raw_events.len());
+        let mut failures: Vec<DeadLetterRecord> = Vec::new();
         let mut max_ledger = last_seq;
 
         for raw in raw_events {
@@ -156,17 +191,45 @@ where
                 continue;
             }
 
-            match normalise(raw) {
+            let ledger_seq = raw.ledger_seq;
+            match normalise(raw.clone()) {
                 Ok(ev) => {
                     max_ledger = max_ledger.max(ev.ledger_seq);
                     canonical.push(ev);
                     stats.normalised += 1;
                 }
                 Err(e) => {
-                    warn!(error = %e, "failed to normalise event, skipping");
+                    metrics::record_normalise_failure();
+                    error!(
+                        error = %e,
+                        ledger_seq,
+                        tx_hash = %raw.tx_hash,
+                        contract_id = %raw.contract_id,
+                        raw_payload = ?raw,
+                        "failed to normalise event; writing to dead-letter store"
+                    );
+                    failures.push(DeadLetterRecord {
+                        stream: self.config.stream.clone(),
+                        ledger_seq,
+                        error: e.to_string(),
+                        raw,
+                        failed_at: Utc::now(),
+                    });
+                    // Advance past the failed ledger once it is queued for DLQ —
+                    // recovery is via reprocessing dead letters, not by stalling.
+                    max_ledger = max_ledger.max(ledger_seq);
                     stats.errors += 1;
                 }
             }
+        }
+
+        if !failures.is_empty() {
+            let count = failures.len();
+            self.dead_letters
+                .persist_failures(&failures)
+                .await
+                .context("persist dead-letter records")?;
+            stats.dead_lettered = count;
         }
 
         if !canonical.is_empty() {
@@ -175,8 +238,11 @@ where
                 .await
                 .context("persist canonical events")?;
             stats.persisted = canonical.len();
+        }
 
-            // Advance checkpoint only after successful persist
+        // Advance checkpoint after successful sink + DLQ writes so we do not
+        // re-fetch events that were either persisted or dead-lettered.
+        if max_ledger > last_seq {
             self.checkpoint
                 .save(&Checkpoint {
                     stream: self.config.stream.clone(),
@@ -188,6 +254,7 @@ where
             info!(
                 stream = %self.config.stream,
                 persisted = stats.persisted,
+                dead_lettered = stats.dead_lettered,
                 max_ledger,
                 "batch committed"
             );
@@ -204,6 +271,11 @@ where
             .ok()
             .flatten()
     }
+
+    /// Borrow the dead-letter store (for inspection / testing).
+    pub fn dead_letter_store(&self) -> &Dl {
+        &self.dead_letters
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -211,6 +283,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ingest::dead_letter::FailingDeadLetterStore;
     use crate::ingest::sink::MemorySink;
     use crate::ingest::source::VecSource;
     use crate::schema::canonical::RawEvent;
@@ -239,6 +312,7 @@ mod tests {
         assert_eq!(stats.normalised, 2);
         assert_eq!(stats.persisted, 2);
         assert_eq!(stats.skipped, 0);
+        assert_eq!(stats.dead_lettered, 0);
         assert_eq!(
             worker.current_checkpoint().await.unwrap().last_ledger_seq,
             2
@@ -249,7 +323,6 @@ mod tests {
     async fn skips_out_of_order_events() {
         let source = VecSource::new(vec![raw(5, "transfer"), raw(3, "transfer")]);
         let sink = MemorySink::default();
-        // Seed checkpoint at ledger 4 — ledger 3 is behind, ledger 5 is ahead
         let mut worker = IngestWorker::new(WorkerConfig::default(), source, sink)
             .with_initial_checkpoint(Checkpoint {
                 stream: "main".into(),
@@ -259,8 +332,8 @@ mod tests {
         let stats = worker.run_once().await.unwrap();
 
         assert_eq!(stats.fetched, 2);
-        assert_eq!(stats.skipped, 1); // ledger 3 skipped
-        assert_eq!(stats.normalised, 1); // ledger 5 processed
+        assert_eq!(stats.skipped, 1);
+        assert_eq!(stats.normalised, 1);
         assert_eq!(
             worker.current_checkpoint().await.unwrap().last_ledger_seq,
             5
@@ -269,7 +342,6 @@ mod tests {
 
     #[tokio::test]
     async fn restart_recovery_resumes_from_checkpoint() {
-        // First run: process ledgers 1-3
         let source1 = VecSource::new(vec![
             raw(1, "transfer"),
             raw(2, "transfer"),
@@ -282,7 +354,6 @@ mod tests {
         let cp = worker.current_checkpoint().await.unwrap();
         assert_eq!(cp.last_ledger_seq, 3);
 
-        // Simulate restart: new worker seeded with saved checkpoint
         let source2 = VecSource::new(vec![
             raw(2, "transfer"),
             raw(3, "transfer"),
@@ -294,7 +365,6 @@ mod tests {
 
         let stats = worker2.run_once().await.unwrap();
 
-        // Ledgers 2 and 3 are behind the checkpoint — only 4 should be processed
         assert_eq!(stats.skipped, 2);
         assert_eq!(stats.normalised, 1);
         assert_eq!(
@@ -317,8 +387,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn normalisation_error_increments_error_count() {
-        // A raw event with an empty tx_hash will fail normalisation
+    async fn normalisation_failure_writes_dead_letter_and_increments_errors() {
         let mut bad = raw(10, "transfer");
         bad.tx_hash = String::new();
 
@@ -329,8 +398,16 @@ mod tests {
         let stats = worker.run_once().await.unwrap();
 
         assert_eq!(stats.errors, 1);
+        assert_eq!(stats.dead_lettered, 1);
         assert_eq!(stats.normalised, 1);
-        // Checkpoint advances to the highest successfully processed ledger
+        assert_eq!(stats.persisted, 1);
+
+        let dlq = worker.dead_letter_store();
+        assert_eq!(dlq.records.len(), 1);
+        assert_eq!(dlq.records[0].ledger_seq, 10);
+        assert_eq!(dlq.records[0].raw.tx_hash, "");
+        assert!(dlq.records[0].error.contains("tx_hash"));
+
         assert_eq!(
             worker.current_checkpoint().await.unwrap().last_ledger_seq,
             11
@@ -338,10 +415,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn normalisation_failure_only_still_advances_checkpoint_after_dlq() {
+        let mut bad = raw(7, "transfer");
+        bad.tx_hash = String::new();
+
+        let source = VecSource::new(vec![bad]);
+        let sink = MemorySink::default();
+        let mut worker = IngestWorker::new(WorkerConfig::default(), source, sink);
+
+        let stats = worker.run_once().await.unwrap();
+
+        assert_eq!(stats.errors, 1);
+        assert_eq!(stats.dead_lettered, 1);
+        assert_eq!(stats.persisted, 0);
+        assert_eq!(worker.dead_letter_store().records.len(), 1);
+        assert_eq!(
+            worker.current_checkpoint().await.unwrap().last_ledger_seq,
+            7
+        );
+    }
+
+    #[tokio::test]
+    async fn dead_letter_store_failure_aborts_batch_without_advancing_checkpoint() {
+        let mut bad = raw(10, "transfer");
+        bad.tx_hash = String::new();
+
+        let source = VecSource::new(vec![bad, raw(11, "transfer")]);
+        let sink = MemorySink::default();
+        let mut worker = IngestWorker::new(WorkerConfig::default(), source, sink)
+            .with_dead_letter_store(FailingDeadLetterStore);
+
+        let err = worker.run_once().await.unwrap_err();
+        assert!(err.to_string().contains("dead-letter"));
+        assert!(worker.current_checkpoint().await.is_none());
+    }
+
+    #[tokio::test]
     async fn checkpoint_not_advanced_when_nothing_persisted() {
         let source = VecSource::new(vec![raw(1, "transfer")]);
         let sink = MemorySink::default();
-        // Checkpoint already at 5 — ledger 1 will be skipped
         let mut worker = IngestWorker::new(WorkerConfig::default(), source, sink)
             .with_initial_checkpoint(Checkpoint {
                 stream: "main".into(),
@@ -350,7 +462,6 @@ mod tests {
 
         worker.run_once().await.unwrap();
 
-        // Checkpoint must not regress
         assert_eq!(
             worker.current_checkpoint().await.unwrap().last_ledger_seq,
             5

--- a/services/indexer/src/main.rs
+++ b/services/indexer/src/main.rs
@@ -139,6 +139,7 @@ async fn main() -> anyhow::Result<()> {
             let sink = ancore_indexer::ingest::PostgresEventSink::new(pool.clone());
             let checkpoint_store =
                 ancore_indexer::ingest::PostgresCheckpointStore::new(pool.clone());
+            let dead_letters = ancore_indexer::ingest::PostgresDeadLetterStore::new(pool.clone());
 
             let mut worker = ancore_indexer::ingest::IngestWorker::with_checkpoint_store(
                 ancore_indexer::ingest::WorkerConfig::default(),
@@ -146,6 +147,7 @@ async fn main() -> anyhow::Result<()> {
                 sink,
                 checkpoint_store,
             )
+            .with_dead_letter_store(dead_letters)
             .bootstrap_from_store()
             .await?;
 
@@ -163,6 +165,7 @@ async fn main() -> anyhow::Result<()> {
                                     normalised = stats.normalised,
                                     persisted = stats.persisted,
                                     errors = stats.errors,
+                                    dead_lettered = stats.dead_lettered,
                                     "ingest batch complete"
                                 );
                             }

--- a/services/indexer/src/metrics.rs
+++ b/services/indexer/src/metrics.rs
@@ -4,7 +4,7 @@
 //! to enable proactive monitoring and alerting.
 
 use chrono::{DateTime, Utc};
-use metrics::{describe_gauge, describe_histogram, gauge, histogram};
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 use serde::Serialize;
 use sqlx::{PgPool, Row};
 
@@ -47,6 +47,10 @@ pub fn init_prometheus_metrics() {
         "indexer_ingest_batch_duration_seconds",
         "Duration of ingest batch processing"
     );
+    describe_counter!(
+        "indexer_ingest_normalise_failures_total",
+        "Number of raw events that failed normalisation during ingest"
+    );
 }
 
 /// Record lag metrics for Prometheus export.
@@ -70,6 +74,11 @@ pub fn record_ingest_metrics(
     histogram!("indexer_ingest_records_per_second").record(records_per_second);
     gauge!("indexer_ingest_lag_ledgers").set(lag_ledgers as f64);
     histogram!("indexer_ingest_batch_duration_seconds").record(batch_duration_seconds);
+}
+
+/// Increment the normalisation-failure counter (for alerting on silent drops).
+pub fn record_normalise_failure() {
+    counter!("indexer_ingest_normalise_failures_total").increment(1);
 }
 
 /// Fetch cursor staleness metrics for all ingestion streams.
@@ -192,6 +201,12 @@ mod tests {
         record_ingest_metrics(150.0, 5, 2.5);
         record_ingest_metrics(0.0, 0, 0.0);
         record_ingest_metrics(1000.0, 100, 10.0);
+    }
+
+    #[test]
+    fn record_normalise_failure_increments_without_panic() {
+        record_normalise_failure();
+        record_normalise_failure();
     }
 
     #[test]

--- a/services/indexer/src/repositories/migrations.rs
+++ b/services/indexer/src/repositories/migrations.rs
@@ -13,7 +13,7 @@ use sqlx::{PgPool, Row};
 ///
 /// Bump this in the same commit that adds a migration file — it is the
 /// reference point `/health` compares the live ledger against.
-pub const EXPECTED_SCHEMA_VERSION: i32 = 7;
+pub const EXPECTED_SCHEMA_VERSION: i32 = 8;
 
 /// Where the database stands relative to [`EXPECTED_SCHEMA_VERSION`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/services/indexer/tests/contract_events_api_test.rs
+++ b/services/indexer/tests/contract_events_api_test.rs
@@ -256,6 +256,7 @@ async fn integration_test_cursor_pagination() {
 
     // First page
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/api/v1/contract-events?limit=2")
@@ -274,7 +275,7 @@ async fn integration_test_cursor_pagination() {
     let next_cursor = json["pagination"]["next_cursor"].as_str().unwrap();
 
     // Second page
-    let response = app
+    response = app
         .oneshot(
             Request::builder()
                 .uri(format!(

--- a/services/indexer/tests/contract_events_api_test.rs
+++ b/services/indexer/tests/contract_events_api_test.rs
@@ -275,7 +275,7 @@ async fn integration_test_cursor_pagination() {
     let next_cursor = json["pagination"]["next_cursor"].as_str().unwrap();
 
     // Second page
-    response = app
+    let response = app
         .oneshot(
             Request::builder()
                 .uri(format!(

--- a/services/relayer/src/server.test.ts
+++ b/services/relayer/src/server.test.ts
@@ -11,7 +11,11 @@ describe('relayer server startup guard', () => {
       throw new Error(`process.exit:${code ?? 'undefined'}`);
     }) as unknown as typeof process.exit;
 
-    process.env = { ...originalEnv, NODE_ENV: 'production', RELAYER_AUTH_SECRET: '' } as NodeJS.ProcessEnv;
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'production',
+      RELAYER_AUTH_SECRET: '',
+    } as NodeJS.ProcessEnv;
     process.exit = exitSpy;
 
     try {


### PR DESCRIPTION
## Summary
- **#1176**: Stop `normalizeStorageAdapter` from coercing scalar-like strings (true`, null`, 1e3`, …) via bare `JSON.parse`; only parse object/array containers, with round-trip unit tests.
- **#1178**: Persist ingest normalisation failures to a dead-letter store, emit `record_normalise_failure` metrics, and cover the failure path in worker tests.
- **#1180**: Add `AccountOverviewGrid` tests that assert per-widget `WidgetErrorBoundary` isolation (fallback + retry; siblings stay mounted). Widgets were already wrapped on `main`.

## Test plan
- [ ] `corepack pnpm --filter @ancore/core-sdk test -- normalize-storage-adapter`
- [ ] `corepack pnpm --filter @ancore/web-dashboard test -- AccountOverviewGrid.test`
- [ ] `cd services/indexer && cargo test ingest::`

Closes #1176
Closes #1178
Closes #1180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic capture of failed ingest events for later investigation and reprocessing.
  - Added monitoring for ingest normalization failures and reporting of dead-lettered events.
  - Added dashboard widget error recovery with retry support while keeping other account information available.

- **Bug Fixes**
  - Improved storage handling to preserve string values and correctly support structured JSON data.
  - Ingest checkpoints now advance safely when failed events are successfully captured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->