### PR TITLE
fix(dashboard): guard parseFloat/Date in useIndexerActivity against NaN and Invalid Date

### DIFF
--- a/apps/web-dashboard/src/hooks/__tests__/useIndexerActivity.test.ts
+++ b/apps/web-dashboard/src/hooks/__tests__/useIndexerActivity.test.ts
@@ -1,0 +1,98 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useIndexerActivity } from '../useIndexerActivity';
+
+const VALID_ROW = {
+  id: 'tx-1',
+  type: 'send' as const,
+  amount: '100.50',
+  timestamp: '2026-07-30T12:00:00.000Z',
+  status: 'confirmed' as const,
+  counterparty: 'GABCDEF123',
+};
+
+const MALFORMED_ROW = {
+  id: 'tx-2',
+  type: 'receive' as const,
+  amount: 'abc',
+  timestamp: 'nope',
+  status: 'pending' as const,
+  counterparty: 'GXYZ789',
+};
+
+describe('useIndexerActivity', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('transforms valid rows correctly', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [VALID_ROW],
+        nextCursor: null,
+        hasMore: false,
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useIndexerActivity('GABC123'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].amount).toBe(100.5);
+    expect(result.current.items[0].timestamp).toEqual(new Date('2026-07-30T12:00:00.000Z'));
+  });
+
+  it('filters out rows with malformed amount and timestamp', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [VALID_ROW, MALFORMED_ROW],
+        nextCursor: null,
+        hasMore: false,
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useIndexerActivity('GABC123'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].id).toBe('tx-1');
+  });
+
+  it('handles empty result set', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [],
+        nextCursor: null,
+        hasMore: false,
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useIndexerActivity('GABC123'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.items).toHaveLength(0);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('handles fetch error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => useIndexerActivity('GABC123'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.error?.message).toBe('Network error');
+  });
+});

--- a/apps/web-dashboard/src/hooks/useIndexerActivity.ts
+++ b/apps/web-dashboard/src/hooks/useIndexerActivity.ts
@@ -67,11 +67,16 @@ export function useIndexerActivity(accountId: string): UseIndexerActivityReturn 
 
         const data: IndexerPage = await response.json();
 
-        const transformedItems: Transaction[] = data.items.map((tx) => ({
-          ...tx,
-          amount: parseFloat(tx.amount),
-          timestamp: new Date(tx.timestamp),
-        }));
+        const transformedItems: Transaction[] = data.items
+          .map((tx) => ({
+            ...tx,
+            amount: parseFloat(tx.amount),
+            timestamp: new Date(tx.timestamp),
+          }))
+          .filter(
+            (tx): tx is Transaction =>
+              !Number.isNaN(tx.amount) && !Number.isNaN(tx.timestamp.getTime())
+          );
 
         if (cursor) {
           setItems((prev) => [...prev, ...transformedItems]);


### PR DESCRIPTION
## Description

`useIndexerActivity` transforms indexer rows via `parseFloat(tx.amount)` and `new Date(tx.timestamp)` without validation. A malformed `amount` becomes `NaN` (renders as "NaN") and a malformed `timestamp` becomes `Invalid Date` (renders "Invalid Date"). A single bad row degrades the activity list silently.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Security Impact

- [x] No security impact

## Testing

- [x] Unit tests added/updated

### Test Coverage

- Current coverage: unchanged
- New/modified code coverage: covered by `useIndexerActivity.test.ts`

### Manual Testing Steps

1. Hook filters out rows with malformed `amount` (`"abc"`) or `timestamp` (`"nope"`)
2. Valid rows pass through unchanged

## Breaking Changes

- [ ] This PR introduces breaking changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues

Closes #1181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid transaction amounts and timestamps are now excluded from indexer activity results, preventing malformed entries from appearing in the dashboard.

* **Tests**
  * Added coverage for valid data parsing, malformed entries, empty results, and fetch error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->